### PR TITLE
Use k8s-exec instead of shell

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,8 +1,5 @@
 FROM quay.io/operator-framework/ansible-operator:v0.17.0
 
-# Install kubectl.
-COPY --from=lachlanevenson/k8s-kubectl:v1.18.3 /usr/local/bin/kubectl /usr/local/bin/kubectl
-
 # Install Ansible requirements.
 COPY requirements.yml ${HOME}/requirements.yml
 RUN ansible-galaxy collection install -r ${HOME}/requirements.yml \

--- a/roles/tower/meta/main.yml
+++ b/roles/tower/meta/main.yml
@@ -26,3 +26,6 @@ galaxy_info:
     - deployment
 
 dependencies: []
+
+collections:
+  - community.kubernetes

--- a/roles/tower/tasks/initialize.yml
+++ b/roles/tower/tasks/initialize.yml
@@ -25,7 +25,7 @@
     when: users_result.rc > 0
     no_log: true
 
-- name: Create preload data if necessary. # noqa 305
+- name: Create preload data if necessary.  # noqa 305
   k8s_exec:
     namespace: "{{ meta.namespace }}"
     pod: "{{ tower_pod_name }}"

--- a/roles/tower/tasks/initialize.yml
+++ b/roles/tower/tasks/initialize.yml
@@ -25,7 +25,7 @@
     when: users_result.rc > 0
     no_log: true
 
-- name: Create preload data if necessary. #noqa 305
+- name: Create preload data if necessary. # noqa 305
   k8s_exec:
     namespace: "{{ meta.namespace }}"
     pod: "{{ tower_pod_name }}"

--- a/roles/tower/tasks/initialize.yml
+++ b/roles/tower/tasks/initialize.yml
@@ -1,28 +1,37 @@
 ---
 - name: Check if there are any Tower super users defined.
-  shell: >-
-    kubectl exec -n {{ meta.namespace }} -c {{ meta.name }}-task {{ tower_pod_name }} -- bash -c
-    "echo 'from django.contrib.auth.models import User;
-    nsu = User.objects.filter(is_superuser=True).count();
-    exit(0 if nsu > 0 else 1)'
-    | awx-manage shell"
+  k8s_exec:
+    namespace: "{{ meta.namespace }}"
+    pod: "{{ tower_pod_name }}"
+    container: "{{ meta.name }}-task"
+    command: >-
+      bash -c "echo 'from django.contrib.auth.models import User;
+      nsu = User.objects.filter(is_superuser=True).count();
+      exit(0 if nsu > 0 else 1)'
+      | awk-manage shell"
   ignore_errors: true
   register: users_result
   changed_when: users_result.rc > 0
 
 - name: Create Tower super user via Django if it doesn't exist.
-  shell: >-
-    kubectl exec -n {{ meta.namespace }} -c {{ meta.name }}-task {{ tower_pod_name }} -- bash -c
-    "echo \"from django.contrib.auth.models import User;
-    User.objects.create_superuser('{{ tower_admin_user }}', '{{ tower_admin_email }}', '{{ tower_admin_password }}')\"
-    | awx-manage shell"
-  when: users_result.rc > 0
-  no_log: true
+  k8s_exec:
+    namespace: "{{ meta.namespace }}"
+    pod: "{{ tower_pod_name }}"
+    container: "{{ meta.name }}-task"
+    command: >-
+      bash -c "echo \"from django.contrib.auth.models import User;
+      User.objects.create_superuser('{{ tower_admin_user }}', '{{ tower_admin_email }}', '{{ tower_admin_password }}')\"
+      | awx-manage shell"
+    when: users_result.rc > 0
+    no_log: true
 
-- name: Create preload data if necessary.  # noqa 305
-  shell: >-
-    kubectl exec -n {{ meta.namespace }} -c {{ meta.name }}-task {{ tower_pod_name }} -- bash -c
-    "awx-manage create_preload_data"
+- name: Create preload data if necessary. #noqa 305
+  k8s_exec:
+    namespace: "{{ meta.namespace }}"
+    pod: "{{ tower_pod_name }}"
+    container: "{{ meta.name }}-task"
+    command: >-
+      bash -c "awx-manage create_preload_data"
   register: cdo
   changed_when: "'added' in cdo.stdout"
   when: tower_create_preload_data | bool

--- a/roles/tower/tasks/initialize.yml
+++ b/roles/tower/tasks/initialize.yml
@@ -8,7 +8,7 @@
       bash -c "echo 'from django.contrib.auth.models import User;
       nsu = User.objects.filter(is_superuser=True).count();
       exit(0 if nsu > 0 else 1)'
-      | awk-manage shell"
+      | awx-manage shell"
   ignore_errors: true
   register: users_result
   changed_when: users_result.rc > 0

--- a/roles/tower/tasks/main.yml
+++ b/roles/tower/tasks/main.yml
@@ -35,21 +35,27 @@
     fail_msg: "Could not find the tower pod's name."
 
 - name: Check if database is populated (auth_user table exists).
-  shell: >-
-    kubectl exec -n {{ meta.namespace }} -c {{ meta.name }}-task {{ tower_pod_name }} -- bash -c
-    "echo 'from django.db import connection;
-    tbl = \"auth_user\" in connection.introspection.table_names();
-    exit(0 if tbl else 1)'
-    | awx-manage shell"
+  k8s_exec:
+    namespace: "{{ meta.namespace }}"
+    pod: "{{ tower_pod_name }}"
+    container: "{{ meta.name }}-task"
+    command: >-
+      bash -c "echo 'from django.db import connection;
+      tbl = \"auth_user\" in connection.introspection.table_names();
+      exit(0 if tbl else 1)'
+      | awx-manage shell"
   ignore_errors: true
   changed_when: false
   register: database_check
   when: k8s_defs_result is not changed
 
-- name: Migrate the database if the K8s resources were updated.  # noqa 305
-  shell: >-
-    kubectl exec -n {{ meta.namespace }} -c {{ meta.name }}-task {{ tower_pod_name }} -- bash -c
-    "awx-manage migrate --noinput"
+- name: Migrate the database if the K8s resources were updated. #noqa 305
+  k8s_exec:
+    namespace: "{{ meta.namespace }}"
+    pod: "{{ tower_pod_name }}"
+    container: "{{ meta.name }}-task"
+    command: >-
+      bash -c "awx-manage migrate --noinput"
   register: migrate_result
   when: (k8s_defs_result is changed) or (database_check is defined and database_check.rc != 0)
 

--- a/roles/tower/tasks/main.yml
+++ b/roles/tower/tasks/main.yml
@@ -49,7 +49,7 @@
   register: database_check
   when: k8s_defs_result is not changed
 
-- name: Migrate the database if the K8s resources were updated. # noqa 305
+- name: Migrate the database if the K8s resources were updated.  # noqa 305
   k8s_exec:
     namespace: "{{ meta.namespace }}"
     pod: "{{ tower_pod_name }}"

--- a/roles/tower/tasks/main.yml
+++ b/roles/tower/tasks/main.yml
@@ -49,7 +49,7 @@
   register: database_check
   when: k8s_defs_result is not changed
 
-- name: Migrate the database if the K8s resources were updated. #noqa 305
+- name: Migrate the database if the K8s resources were updated. # noqa 305
   k8s_exec:
     namespace: "{{ meta.namespace }}"
     pod: "{{ tower_pod_name }}"


### PR DESCRIPTION
This updates the `tower` role to use the `k8s_exec` module instead of shelling out to use the `kubectl` command. Had to explicitly add the kubernetes collection to the role so that it would pick things up and know how to find the appropriate module, which I believe is a known issue.

resolves #3 