### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ should look like:
       name: <crname>-postgres-configuration
       namespace: <target namespace>
     stringData:
-      address: <external ip or url resolvable by the cluster>
+      host: <external ip or url resolvable by the cluster>
       port: <external port, this usually defaults to 5432>
       database: <desired database name>
       username: <username to connect as>

--- a/deploy/awx-operator.yaml
+++ b/deploy/awx-operator.yaml
@@ -187,7 +187,7 @@ spec:
                   name: <crname>-postgres-configuration
                   namespace: <target namespace>
                 stringData:
-                  address: <external ip or url resolvable by the cluster>
+                  host: <external ip or url resolvable by the cluster>
                   port: <external port, this usually defaults to 5432>
                   database: <desired database name>
                   username: <username to connect as>

--- a/deploy/crds/awx_v1beta1_crd.yaml
+++ b/deploy/crds/awx_v1beta1_crd.yaml
@@ -45,7 +45,7 @@ spec:
                   name: <crname>-postgres-configuration
                   namespace: <target namespace>
                 stringData:
-                  address: <external ip or url resolvable by the cluster>
+                  host: <external ip or url resolvable by the cluster>
                   port: <external port, this usually defaults to 5432>
                   database: <desired database name>
                   username: <username to connect as>


### PR DESCRIPTION
Changed example of secret for external database for helping copypasters.

Otherwise you'll get error "'dict object' has no attribute 'host'" during installation.