### PR TITLE
adding fix for ansible collections path

### DIFF
--- a/roles/awx/templates/tower_config.yaml.j2
+++ b/roles/awx/templates/tower_config.yaml.j2
@@ -34,7 +34,10 @@ data:
     ALLOWED_HOSTS = ['*']
     
     INTERNAL_API_URL = 'http://127.0.0.1:8052'
-    
+
+    # Sets Ansible Collection path
+    AWX_ANSIBLE_COLLECTIONS_PATHS = '/var/lib/awx/vendor/awx_ansible_collections'
+
     # Container environments don't like chroots
     AWX_PROOT_ENABLED = False
     


### PR DESCRIPTION
As was mentioned in this issue, https://github.com/ansible/awx/issues/8144 it was found that `AWX_ANSIBLE_COLLECTIONS_PATHS` was not being correctly set based on the latest changes to the `ansible/awx` container changes, i.e. https://hub.docker.com/r/ansible/awx_task and https://hub.docker.com/r/ansible/awx_web being merged into https://hub.docker.com/r/ansible/awx . 

This is a simple fix of just adding the parameter found from https://github.com/ansible/awx/blob/devel/installer/roles/image_build/files/settings.py as this issue will likely occur in the future we might see about getting notifications setup for when AWX changes it?