### PR TITLE
Port 930b468 from https://github.com/ansible/awx

### DIFF
--- a/roles/awx/templates/tower_config.yaml.j2
+++ b/roles/awx/templates/tower_config.yaml.j2
@@ -198,6 +198,7 @@ data:
                 include {{ extra_nginx_include }};
                 {%- endif %}
                 proxy_set_header X-Forwarded-Port 443;
+                uwsgi_param HTTP_X_FORWARDED_PORT 443;
             }
         }
     }


### PR DESCRIPTION
Add the uwsgi_param 'HTTP_X_FORWARDED_PORT' to nginx configuration,
This prevents the python-saml "invalid_response" error