### PR TITLE
Add more configurable parameters

### DIFF
--- a/deploy/crds/awx_v1beta1_cr.yaml
+++ b/deploy/crds/awx_v1beta1_cr.yaml
@@ -16,8 +16,8 @@ spec:
   tower_admin_email: test@example.com
   tower_admin_password: changeme
 
-  tower_task_image: ansible/awx:14.0.0
-  tower_web_image: ansible/awx:14.0.0
+  tower_task_image: ansible/awx:14.1.0
+  tower_web_image: ansible/awx:14.1.0
 
   tower_task_mem_request: 1Gi
   tower_task_cpu_request: 500m

--- a/deploy/crds/awx_v1beta1_crd.yaml
+++ b/deploy/crds/awx_v1beta1_crd.yaml
@@ -30,7 +30,7 @@ spec:
               type: string
               pattern: "^(tower|awx)(-)?.*$"
             external_database:
-              type: bool
+              type: boolean
               description: |
                 If true you must supply a secret containing the location and credentials for
                 connecting to the external database by a user who has permission to create

--- a/deploy/crds/awx_v1beta1_molecule.yaml
+++ b/deploy/crds/awx_v1beta1_molecule.yaml
@@ -16,8 +16,8 @@ spec:
   tower_admin_email: test@example.com
   tower_admin_password: changeme
 
-  tower_task_image: ansible/awx:14.0.0
-  tower_web_image: ansible/awx:14.0.0
+  tower_task_image: ansible/awx:14.1.0
+  tower_web_image: ansible/awx:14.1.0
 
   tower_task_mem_request: 128M
   tower_task_cpu_request: 500m

--- a/roles/awx/defaults/main.yml
+++ b/roles/awx/defaults/main.yml
@@ -1,7 +1,16 @@
 ---
 tower_task_privileged: false
 tower_ingress_type: none
+
+# Add annotations to the ingress. Specify as literal block. E.g.:
+# tower_ingress_annotations: |
+#   kubernetes.io/ingress.class: nginx
+#   nginx.ingress.kubernetes.io/proxy-connect-timeout: 60s
 tower_ingress_annotations: ''
+# TLS secret for the ingress. The secret either has to exist before hand with
+# the corresponding cert and key or just be an indicator for where an automated
+# process like cert-manager (enabled via annotations) will store the TLS
+# certificate and key.
 tower_ingress_tls_secret: ''
 
 tower_hostname: example-awx.test
@@ -12,6 +21,10 @@ tower_admin_password: changeme
 
 tower_broadcast_websocket_secret: changeme
 
+# Add extra volumes to the AWX pod. Specify as literal block. E.g.:
+# tower_extra_volumes: |
+#   - name: my-volume
+#     emptyDir: {}
 tower_extra_volumes: ''
 
 # Use these image versions for Ansible Tower.
@@ -40,9 +53,22 @@ tower_task_cpu_request: 500m
 tower_web_mem_request: 2Gi
 tower_web_cpu_request: 1000m
 
+# Add extra environment variables to the AWX task/web containers. Specify as
+# literal block. E.g.:
+# tower_task_extra_env: |
+#   - name: FOO
+#     value: bar
+#   - name: BAZ
+#     value: bing
 tower_task_extra_env: ''
-tower_task_extra_volume_mounts: ''
 tower_web_extra_env: ''
+
+# Mount extra volumes on the AWX task/web containers. Specify as literal block.
+# E.g.:
+# tower_task_extra_volume_mounts: ''
+#   - name: my-volume
+#     mountPath: /some/path
+tower_task_extra_volume_mounts: ''
 tower_web_extra_volume_mounts: ''
 
 tower_memcached_image: memcached:alpine

--- a/roles/awx/defaults/main.yml
+++ b/roles/awx/defaults/main.yml
@@ -1,6 +1,8 @@
 ---
 tower_task_privileged: false
 tower_ingress_type: none
+tower_ingress_annotations: ''
+tower_ingress_tls_secret: ''
 
 tower_hostname: example-awx.test
 
@@ -10,23 +12,38 @@ tower_admin_password: changeme
 
 tower_broadcast_websocket_secret: changeme
 
+tower_extra_volumes: ''
+
 # Use these image versions for Ansible Tower.
 # tower_task_image: registry.redhat.io/ansible-tower-37/ansible-tower-rhel7:3.7.0
 # tower_web_image: registry.redhat.io/ansible-tower-37/ansible-tower-rhel7:3.7.0
 
 # Use these image versions for Ansible AWX.
-tower_task_image: ansible/awx:14.0.0
-tower_web_image: ansible/awx:14.0.0
+tower_task_image: ansible/awx:14.1.0
+tower_web_image: ansible/awx:14.1.0
+
+tower_image_pull_policy: IfNotPresent
 
 tower_create_preload_data: true
 
 tower_replicas: "1"
+
+tower_task_args:
+  - /usr/bin/launch_awx_task.sh
+tower_task_command: []
+tower_web_args: []
+tower_web_command: []
 
 tower_task_mem_request: 1Gi
 tower_task_cpu_request: 500m
 
 tower_web_mem_request: 2Gi
 tower_web_cpu_request: 1000m
+
+tower_task_extra_env: ''
+tower_task_extra_volume_mounts: ''
+tower_web_extra_env: ''
+tower_web_extra_volume_mounts: ''
 
 tower_memcached_image: memcached:alpine
 

--- a/roles/awx/templates/tower.yaml.j2
+++ b/roles/awx/templates/tower.yaml.j2
@@ -1,13 +1,13 @@
 # AWX Secret Configurations
 ---
-  apiVersion: v1
-  kind: Secret
-  metadata:
-    name: '{{ meta.name }}-secrets'
-    namespace: '{{ meta.namespace }}'
-  data:
-    credentials_py: "{{ lookup('template', 'credentials.py.j2') | b64encode }}"
-    environment_sh: "{{ lookup('template', 'environment.sh.j2') | b64encode }}"
+apiVersion: v1
+kind: Secret
+metadata:
+  name: '{{ meta.name }}-secrets'
+  namespace: '{{ meta.namespace }}'
+data:
+  credentials_py: "{{ lookup('template', 'credentials.py.j2') | b64encode }}"
+  environment_sh: "{{ lookup('template', 'environment.sh.j2') | b64encode }}"
 
 # AWX Deployment.
 ---
@@ -26,131 +26,156 @@ spec:
   template:
     metadata:
       labels:
-         app: awx
+        app: awx
     spec:
       containers:
-      - name: memcached
-        image: '{{ tower_memcached_image }}'
-        command:
-          - 'memcached'
-          - '-s'
-          - '/var/run/memcached/memcached.sock'
-          - '-a'
-          - '0666'
-        volumeMounts:
-          - name: {{ meta.name }}-memcached-socket
-            mountPath: "/var/run/memcached"
-      - image: '{{ tower_redis_image }}'
-        name: redis
-        args: ["redis-server", "/etc/redis.conf"]
-        volumeMounts:
-          - name: {{ meta.name }}-redis-config
-            mountPath: "/etc/redis.conf"
-            subPath: redis.conf
-            readOnly: true
-          - name: {{ meta.name }}-redis-socket
-            mountPath: "/var/run/redis"
-      - image: '{{ tower_web_image }}'
-        name: '{{ meta.name }}-web'
-        ports:
-        - containerPort: 8052
-        volumeMounts:
-          - name: "{{ meta.name }}-application-credentials"
-            mountPath: "/etc/tower/conf.d/"
-            readOnly: true
-          - name: {{ meta.name }}-secret-key
-            mountPath: /etc/tower/SECRET_KEY
-            subPath: SECRET_KEY
-            readOnly: true
-          - name: {{ meta.name }}-settings
-            mountPath: /etc/tower/settings.py
-            subPath: settings.py
-            readOnly: true
-          - name: {{ meta.name }}-nginx-conf
-            mountPath: /etc/nginx/nginx.conf
-            subPath: nginx.conf
-            readOnly: true
-          - name: {{ meta.name }}-launch-awx-web
-            mountPath: /usr/bin/launch_awx.sh
-            subPath: launch_awx.sh
-            readOnly: true
-          - name: {{ meta.name }}-supervisor-web-config
-            mountPath: /supervisor.conf
-            subPath: supervisor.conf
-            readOnly: true
-          - name: {{ meta.name }}-redis-socket
-            mountPath: "/var/run/redis"
-          - name: {{ meta.name }}-memcached-socket
-            mountPath: "/var/run/memcached"
-          - name: supervisor-socket
-            mountPath: "/var/run/supervisor"
-          - name: rsyslog-socket
-            mountPath: "/var/run/awx-rsyslog"
-          - name: rsyslog-dir
-            mountPath: "/var/lib/awx/rsyslog"
-        resources:
-          requests:
-            memory: '{{ tower_web_mem_request }}'
-            cpu: '{{ tower_web_cpu_request }}'
-      - image: '{{ tower_task_image }}'
-        name: '{{ meta.name }}-task'
-{% if tower_task_privileged == true %}
-        securityContext:
-          privileged: true
+        - name: memcached
+          image: '{{ tower_memcached_image }}'
+          command:
+            - 'memcached'
+            - '-s'
+            - '/var/run/memcached/memcached.sock'
+            - '-a'
+            - '0666'
+          volumeMounts:
+            - name: {{ meta.name }}-memcached-socket
+              mountPath: "/var/run/memcached"
+        - image: '{{ tower_redis_image }}'
+          name: redis
+          args: ["redis-server", "/etc/redis.conf"]
+          volumeMounts:
+            - name: {{ meta.name }}-redis-config
+              mountPath: "/etc/redis.conf"
+              subPath: redis.conf
+              readOnly: true
+            - name: {{ meta.name }}-redis-socket
+              mountPath: "/var/run/redis"
+        - image: '{{ tower_web_image }}'
+          name: '{{ meta.name }}-web'
+{% if tower_web_command %}
+          command: {{ tower_web_command }}
 {% endif %}
-        command:
-          - /usr/bin/launch_awx_task.sh
-        volumeMounts:
-          - name: "{{ meta.name }}-application-credentials"
-            mountPath: "/etc/tower/conf.d/"
-            readOnly: true
-          - name: {{ meta.name }}-secret-key
-            mountPath: /etc/tower/SECRET_KEY
-            subPath: SECRET_KEY
-            readOnly: true
-          - name: {{ meta.name }}-settings
-            mountPath: /etc/tower/settings.py
-            subPath: settings.py
-            readOnly: true
-          - name: {{ meta.name }}-launch-awx-task
-            mountPath: /usr/bin/launch_awx_task.sh
-            subPath: launch_awx_task.sh
-            readOnly: true
-          - name: {{ meta.name }}-supervisor-web-config
-            mountPath: "/supervisor.conf"
-            subPath: supervisor.conf
-            readOnly: true
-          - name: {{ meta.name }}-supervisor-task-config
-            mountPath: /supervisor_task.conf
-            subPath: supervisor_task.conf
-            readOnly: true
-          - name: {{ meta.name }}-redis-socket
-            mountPath: "/var/run/redis"
-          - name: {{ meta.name }}-memcached-socket
-            mountPath: "/var/run/memcached"
-          - name: supervisor-socket
-            mountPath: "/var/run/supervisor"
-          - name: rsyslog-socket
-            mountPath: "/var/run/awx-rsyslog"
-          - name: rsyslog-dir
-            mountPath: "/var/lib/awx/rsyslog"
-        env:
-          - name: SUPERVISOR_WEB_CONFIG_PATH
-            value: "/supervisor.conf"
-          - name: AWX_SKIP_MIGRATIONS
-            value: "1"
-          - name: MY_POD_UID
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.uid
-          - name: MY_POD_IP
-            valueFrom:
-              fieldRef:
-                fieldPath: status.podIP
-        resources:
-          requests:
-            memory: '{{ tower_task_mem_request }}'
-            cpu: '{{ tower_task_cpu_request }}'
+{% if tower_web_args %}
+          args: {{ tower_web_args }}
+{% endif %}
+          imagePullPolicy: '{{ tower_image_pull_policy }}'
+          ports:
+            - containerPort: 8052
+          volumeMounts:
+            - name: "{{ meta.name }}-application-credentials"
+              mountPath: "/etc/tower/conf.d/"
+              readOnly: true
+            - name: {{ meta.name }}-secret-key
+              mountPath: /etc/tower/SECRET_KEY
+              subPath: SECRET_KEY
+              readOnly: true
+            - name: {{ meta.name }}-settings
+              mountPath: /etc/tower/settings.py
+              subPath: settings.py
+              readOnly: true
+            - name: {{ meta.name }}-nginx-conf
+              mountPath: /etc/nginx/nginx.conf
+              subPath: nginx.conf
+              readOnly: true
+            - name: {{ meta.name }}-launch-awx-web
+              mountPath: /usr/bin/launch_awx.sh
+              subPath: launch_awx.sh
+              readOnly: true
+            - name: {{ meta.name }}-supervisor-web-config
+              mountPath: /supervisor.conf
+              subPath: supervisor.conf
+              readOnly: true
+            - name: {{ meta.name }}-redis-socket
+              mountPath: "/var/run/redis"
+            - name: {{ meta.name }}-memcached-socket
+              mountPath: "/var/run/memcached"
+            - name: supervisor-socket
+              mountPath: "/var/run/supervisor"
+            - name: rsyslog-socket
+              mountPath: "/var/run/awx-rsyslog"
+            - name: rsyslog-dir
+              mountPath: "/var/lib/awx/rsyslog"
+{% if tower_web_extra_volume_mounts -%}
+            {{ tower_web_extra_volume_mounts | indent(width=12, indentfirst=True) }}
+{% endif %}
+{% if tower_task_extra_env %}
+          env:
+            {{ tower_web_extra_env | indent(width=12, indentfirst=True) }}
+{% endif %}
+          resources:
+            requests:
+              memory: '{{ tower_web_mem_request }}'
+              cpu: '{{ tower_web_cpu_request }}'
+        - image: '{{ tower_task_image }}'
+          name: '{{ meta.name }}-task'
+          imagePullPolicy: '{{ tower_image_pull_policy }}'
+{% if tower_task_privileged == true %}
+          securityContext:
+            privileged: true
+{% endif %}
+{% if tower_task_command %}
+          command: {{ tower_task_command }}
+{% endif %}
+{% if tower_task_args %}
+          args: {{ tower_task_args }}
+{% endif %}
+          volumeMounts:
+            - name: "{{ meta.name }}-application-credentials"
+              mountPath: "/etc/tower/conf.d/"
+              readOnly: true
+            - name: {{ meta.name }}-secret-key
+              mountPath: /etc/tower/SECRET_KEY
+              subPath: SECRET_KEY
+              readOnly: true
+            - name: {{ meta.name }}-settings
+              mountPath: /etc/tower/settings.py
+              subPath: settings.py
+              readOnly: true
+            - name: {{ meta.name }}-launch-awx-task
+              mountPath: /usr/bin/launch_awx_task.sh
+              subPath: launch_awx_task.sh
+              readOnly: true
+            - name: {{ meta.name }}-supervisor-web-config
+              mountPath: "/supervisor.conf"
+              subPath: supervisor.conf
+              readOnly: true
+            - name: {{ meta.name }}-supervisor-task-config
+              mountPath: /supervisor_task.conf
+              subPath: supervisor_task.conf
+              readOnly: true
+            - name: {{ meta.name }}-redis-socket
+              mountPath: "/var/run/redis"
+            - name: {{ meta.name }}-memcached-socket
+              mountPath: "/var/run/memcached"
+            - name: supervisor-socket
+              mountPath: "/var/run/supervisor"
+            - name: rsyslog-socket
+              mountPath: "/var/run/awx-rsyslog"
+            - name: rsyslog-dir
+              mountPath: "/var/lib/awx/rsyslog"
+{% if tower_task_extra_volume_mounts -%}
+            {{ tower_task_extra_volume_mounts | indent(width=12, indentfirst=True) }}
+{% endif %}
+          env:
+            - name: SUPERVISOR_WEB_CONFIG_PATH
+              value: "/supervisor.conf"
+            - name: AWX_SKIP_MIGRATIONS
+              value: "1"
+            - name: MY_POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+{% if tower_task_extra_env -%}
+            {{ tower_task_extra_env | indent(width=12, indentfirst=True) }}
+{% endif %}
+          resources:
+            requests:
+              memory: '{{ tower_task_mem_request }}'
+              cpu: '{{ tower_task_cpu_request }}'
       volumes:
         - name: "{{ meta.name }}-application-credentials"
           secret:
@@ -220,6 +245,9 @@ spec:
           emptyDir: {}
         - name: rsyslog-dir
           emptyDir: {}
+{% if tower_extra_volumes -%}
+        {{ tower_extra_volumes | indent(width=8, indentfirst=True) }}
+{% endif %}
 
 # AWX Service.
 ---
@@ -232,12 +260,15 @@ metadata:
     app: awx
 spec:
   ports:
-  - port: 80
-    protocol: TCP
-    targetPort: 8052
-    name: http
+    - port: 80
+      protocol: TCP
+      targetPort: 8052
+      name: http
   selector:
     app: awx
+{% if tower_ingress_type != "none" %}
+  type: NodePort
+{% endif %}
 
 # AWX Ingress.
 {% if 'ingress' == tower_ingress_type|lower %}
@@ -247,15 +278,25 @@ kind: Ingress
 metadata:
   name: '{{ meta.name }}-ingress'
   namespace: '{{ meta.namespace }}'
+{% if tower_ingress_annotations %}
+  annotations:
+    {{ tower_ingress_annotations | indent(width=4) }}
+{% endif %}
 spec:
   rules:
-  - host: '{{ tower_hostname }}'
-    http:
-      paths:
-      - path: /
-        backend:
-          serviceName: '{{ meta.name }}-service'
-          servicePort: 80
+    - host: '{{ tower_hostname }}'
+      http:
+        paths:
+          - path: /
+            backend:
+              serviceName: '{{ meta.name }}-service'
+              servicePort: 80
+{% if tower_ingress_tls_secret %}
+  tls:
+    - hosts:
+        - {{ tower_hostname }}
+      secretName: {{ tower_ingress_tls_secret }}
+{% endif %}
 {% endif %}
 
 {% if 'route' == tower_ingress_type|lower %}


### PR DESCRIPTION
This adds extra parameters to allow the configuration of:
- Additional volumes
- Task and web containers' additional env vars, and volume mounts
- Task and web containers' entrypoint, command, and image pull policy
- Ingress annotations and TLS secret

Additionally it performs a few cleanup tasks:
- Fixes the alignment in the main tower template for consistency
- Changes the specification of command to args for the task container in order to not override the entrypoint but the command
- Bumps the default image from 14.0.0 to 14.1.0
- Fixes the type for `external_database` in the CRD from `bool` to `boolean`
