### PR TITLE
removing incorrect namespace field from spec

### DIFF
--- a/deploy/awx-operator.yaml
+++ b/deploy/awx-operator.yaml
@@ -103,7 +103,6 @@ spec:
   selector:
     matchLabels:
       name: awx-operator
-      namespace: default
   template:
     metadata:
       labels:


### PR DESCRIPTION
A recent edit to the awx-operator.yaml added spec.selector.matchLabels.namespace, this is invalid and prevents deployment.