### PR TITLE
PostgreSQL: Allow one to provide her own db configuration secret

### DIFF
--- a/ansible/templates/crd.yml.j2
+++ b/ansible/templates/crd.yml.j2
@@ -26,25 +26,3 @@ spec:
         spec:
           type: object
           properties:
-            external_database:
-              type: boolean
-              description: |
-                If true you must supply a secret containing the location and credentials for
-                connecting to the external database by a user who has permission to create
-                and apply a schema.
-
-                The secret should have the name: <custom resource name>-postgres-configuration and
-                should look like:
-
-                apiVersion: v1
-                kind: Secret
-                metadata:
-                  name: <crname>-postgres-configuration
-                  namespace: <target namespace>
-                stringData:
-                  host: <external ip or url resolvable by the cluster>
-                  port: <external port, this usually defaults to 5432>
-                  database: <desired database name>
-                  username: <username to connect as>
-                  password: <password to connect with>
-                type: Opaque

--- a/deploy/awx-operator.yaml
+++ b/deploy/awx-operator.yaml
@@ -166,25 +166,3 @@ spec:
         spec:
           type: object
           properties:
-            external_database:
-              type: boolean
-              description: |
-                If true you must supply a secret containing the location and credentials for
-                connecting to the external database by a user who has permission to create
-                and apply a schema.
-
-                The secret should have the name: <custom resource name>-postgres-configuration and
-                should look like:
-
-                apiVersion: v1
-                kind: Secret
-                metadata:
-                  name: <crname>-postgres-configuration
-                  namespace: <target namespace>
-                stringData:
-                  host: <external ip or url resolvable by the cluster>
-                  port: <external port, this usually defaults to 5432>
-                  database: <desired database name>
-                  username: <username to connect as>
-                  password: <password to connect with>
-                type: Opaque

--- a/deploy/crds/awx_v1beta1_crd.yaml
+++ b/deploy/crds/awx_v1beta1_crd.yaml
@@ -26,25 +26,3 @@ spec:
         spec:
           type: object
           properties:
-            external_database:
-              type: boolean
-              description: |
-                If true you must supply a secret containing the location and credentials for
-                connecting to the external database by a user who has permission to create
-                and apply a schema.
-
-                The secret should have the name: <custom resource name>-postgres-configuration and
-                should look like:
-
-                apiVersion: v1
-                kind: Secret
-                metadata:
-                  name: <crname>-postgres-configuration
-                  namespace: <target namespace>
-                stringData:
-                  host: <external ip or url resolvable by the cluster>
-                  port: <external port, this usually defaults to 5432>
-                  database: <desired database name>
-                  username: <username to connect as>
-                  password: <password to connect with>
-                type: Opaque

--- a/deploy/olm-catalog/awx-operator/manifests/awx.ansible.com_awxs_crd.yaml
+++ b/deploy/olm-catalog/awx-operator/manifests/awx.ansible.com_awxs_crd.yaml
@@ -20,28 +20,6 @@ spec:
       properties:
         spec:
           properties:
-            external_database:
-              description: |
-                If true you must supply a secret containing the location and credentials for
-                connecting to the external database by a user who has permission to create
-                and apply a schema.
-
-                The secret should have the name: <custom resource name>-postgres-configuration and
-                should look like:
-
-                apiVersion: v1
-                kind: Secret
-                metadata:
-                  name: <crname>-postgres-configuration
-                  namespace: <target namespace>
-                stringData:
-                  host: <external ip or url resolvable by the cluster>
-                  port: <external port, this usually defaults to 5432>
-                  database: <desired database name>
-                  username: <username to connect as>
-                  password: <password to connect with>
-                type: Opaque
-              type: boolean
           type: object
       type: object
   version: v1beta1

--- a/roles/installer/defaults/main.yml
+++ b/roles/installer/defaults/main.yml
@@ -75,6 +75,10 @@ tower_postgres_storage_request: 8Gi
 tower_postgres_storage_class: ''
 tower_postgres_data_path: '/var/lib/postgresql/data/pgdata'
 
+# Secret to lookup that provide the PostgreSQL configuration
+#
+tower_postgres_configuration_secret: ''
+
 ca_trust_bundle: "/etc/pki/tls/certs/ca-bundle.crt"
 
 development_mode: false

--- a/roles/installer/tasks/database_configuration.yml
+++ b/roles/installer/tasks/database_configuration.yml
@@ -1,0 +1,53 @@
+---
+- name: Check for specified PostgreSQL configuration
+  k8s_info:
+    kind: Secret
+    namespace: '{{ meta.namespace }}'
+    name: '{{ tower_postgres_configuration_secret }}'
+  register: _custom_pg_config_resources
+  when: tower_postgres_configuration_secret | length
+
+- name: Check for default PostgreSQL configuration
+  k8s_info:
+    kind: Secret
+    namespace: '{{ meta.namespace }}'
+    name: '{{ meta.name }}-postgres-configuration'
+  register: _default_pg_config_resources
+
+- name: Set PostgreSQL configuration
+  set_fact:
+    _pg_config: '{{ _custom_pg_config_resources["resources"] | default([]) | length | ternary(_custom_pg_config_resources, _default_pg_config_resources) }}'
+
+- block:
+    - name: Create Database configuration
+      k8s:
+        apply: true
+        definition: "{{ lookup('template', 'tower_postgres_secret.yaml.j2') }}"
+
+    - name: Read Database Configuration
+      k8s_info:
+        kind: Secret
+        namespace: '{{ meta.namespace }}'
+        name: '{{ meta.name }}-postgres-configuration'
+      register: _generated_pg_config_resources
+
+  when: not _pg_config['resources'] | default([]) | length
+
+- name: Set PostgreSQL Configuration
+  set_fact:
+    pg_config: '{{ _generated_pg_config_resources["resources"] | default([]) | length | ternary(_generated_pg_config_resources, _pg_config) }}'
+
+- name: Create Database if no database is specified
+  k8s:
+    apply: true
+    definition: "{{ lookup('template', 'tower_postgres.yaml.j2') }}"
+  when:
+    - pg_config['resources'][0]['data']['type'] | default('') | b64decode == 'managed'
+
+- name: Store Database Configuration
+  set_fact:
+    awx_postgres_user: "{{ pg_config['resources'][0]['data']['username'] | b64decode }}"
+    awx_postgres_pass: "{{ pg_config['resources'][0]['data']['password'] | b64decode }}"
+    awx_postgres_database: "{{ pg_config['resources'][0]['data']['database'] | b64decode }}"
+    awx_postgres_port: "{{ pg_config['resources'][0]['data']['port'] | b64decode }}"
+    awx_postgres_host: "{{ pg_config['resources'][0]['data']['host'] | b64decode }}"

--- a/roles/installer/tasks/main.yml
+++ b/roles/installer/tasks/main.yml
@@ -6,48 +6,15 @@
     name: '{{ meta.name }}-secret-key'
   register: secret_key_resources
 
-- name: Check for existing postgres configuration
-  k8s_info:
-    kind: Secret
-    namespace: '{{ meta.namespace }}'
-    name: '{{ meta.name }}-postgres-configuration'
-  register: postgres_config_resources
-
-- name: Create Database configuration if it doesn't already exist
-  k8s:
-    apply: yes
-    definition: "{{ lookup('template', 'tower_postgres_secret.yaml.j2') }}"
-  register: k8s_postgres_config_result
-  when: postgres_config_resources['resources'] | length < 1 and not external_database | default(False) | bool
-
-- name: Create Database if External Database not selected
-  k8s:
-    apply: yes
-    definition: "{{ lookup('template', 'tower_postgres.yaml.j2') }}"
-  register: k8s_postgres_result
-  when: not external_database | default(False) | bool
-
-- name: Read Database Configuration
-  k8s_info:
-    kind: Secret
-    namespace: '{{ meta.namespace }}'
-    name: '{{ meta.name }}-postgres-configuration'
-  register: postgres_configuration
-
-- name: Store Database Configuration
-  set_fact:
-    awx_postgres_user: "{{ postgres_configuration['resources'][0]['data']['username'] | b64decode }}"
-    awx_postgres_pass: "{{ postgres_configuration['resources'][0]['data']['password'] | b64decode }}"
-    awx_postgres_database: "{{ postgres_configuration['resources'][0]['data']['database'] | b64decode }}"
-    awx_postgres_port: "{{ postgres_configuration['resources'][0]['data']['port'] | b64decode }}"
-    awx_postgres_host: "{{ postgres_configuration['resources'][0]['data']['host'] | b64decode }}"
-
 - name: Deploy Tower Secret Key if needed
   k8s:
     apply: yes
     definition: "{{ lookup('template', 'tower_secret.yaml.j2') }}"
   register: k8s_tower_secret_result
   when: secret_key_resources['resources'] | length < 1
+
+- name: Include database configuration tasks
+  include_tasks: database_configuration.yml
 
 - name: Ensure configured instance resources exist in the cluster.
   k8s:

--- a/roles/installer/templates/tower_postgres_secret.yaml.j2
+++ b/roles/installer/templates/tower_postgres_secret.yaml.j2
@@ -11,3 +11,4 @@ stringData:
   database: '{{ deployment_type }}'
   port: '5432'
   host: {{ meta.name }}-postgres
+  type: 'managed'


### PR DESCRIPTION
If a user provide its own secret by using the
`tower_postgres_configuration_secret` use this variable, else try to use
`<instance>-postgres-configuration` secret. Else create one and use a
local database.