### PR TITLE
Improve CI troubleshooting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,4 @@ install:
   - ansible-galaxy collection install community.kubernetes operator_sdk.util
 
 script:
-  - molecule test -s test-local
+  - MOLECULE_VERBOSITY=3 molecule test -s test-local

--- a/molecule/test-local/ansible.cfg
+++ b/molecule/test-local/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+stdout_callback = yaml


### PR DESCRIPTION
This PR aims to increase both the verbosity (level debug) and the readability (callback yaml) of the CI logs.

Given CI logs are read only when failing, let's try to have the maximum information possible to help troubleshoot what's going on.