### PR TITLE
Patch EE receptor conf

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -3,6 +3,7 @@ extends: default
 
 ignore: |
   .cache/
+  deploy/olm-catalog
 
 rules:
   truthy: disable

--- a/ansible/instantiate-awx-deployment.yml
+++ b/ansible/instantiate-awx-deployment.yml
@@ -20,7 +20,6 @@
           spec:
             tower_admin_user: test
             tower_admin_email: test@example.com
-            tower_broadcast_websocket_secret: changeme
             tower_ingress_type: "{{ tower_ingress_type | default(omit) }}"  # Either Route or Ingress
             tower_image: "{{ tower_image | default(omit) }}"
             development_mode: "{{ development_mode | default(omit) }}"

--- a/ansible/templates/role.yml.j2
+++ b/ansible/templates/role.yml.j2
@@ -14,15 +14,19 @@ rules:
       - '*'
   - apiGroups:
       - ""
+      - "rbac.authorization.k8s.io"
     resources:
       - pods
       - services
       - services/finalizers
+      - serviceaccounts
       - endpoints
       - persistentvolumeclaims
       - events
       - configmaps
       - secrets
+      - roles
+      - rolebindings
     verbs:
       - '*'
   - apiGroups:

--- a/deploy/awx-operator.yaml
+++ b/deploy/awx-operator.yaml
@@ -16,15 +16,19 @@ rules:
       - '*'
   - apiGroups:
       - ""
+      - "rbac.authorization.k8s.io"
     resources:
       - pods
       - services
       - services/finalizers
+      - serviceaccounts
       - endpoints
       - persistentvolumeclaims
       - events
       - configmaps
       - secrets
+      - roles
+      - rolebindings
     verbs:
       - '*'
   - apiGroups:

--- a/deploy/crds/awx_v1beta1_cr.yaml
+++ b/deploy/crds/awx_v1beta1_cr.yaml
@@ -14,7 +14,7 @@ spec:
   tower_admin_user: test
   tower_admin_email: test@example.com
 
-  tower_image: ansible/awx:15.0.0
+  tower_image: quay.io/ansible/awx:execution-environments
 
   tower_create_preload_data: true
 

--- a/deploy/crds/awx_v1beta1_molecule.yaml
+++ b/deploy/crds/awx_v1beta1_molecule.yaml
@@ -13,7 +13,7 @@ spec:
 
   tower_admin_email: test@example.com
 
-  tower_image: ansible/awx:15.0.0
+  tower_image: quay.io/ansible/awx:execution-environments
 
   tower_web_resource_requirements:
     requests:

--- a/deploy/olm-catalog/awx-operator/manifests/awx-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/awx-operator/manifests/awx-operator.clusterserviceversion.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
@@ -14,22 +13,16 @@ metadata:
           },
           "spec": {
             "tower_admin_email": "test@example.com",
-            "tower_admin_password": "changeme",
             "tower_admin_user": "test",
             "tower_broadcast_websocket_secret": "changeme",
             "tower_create_preload_data": true,
             "tower_hostname": "example-awx.test",
+            "tower_image": "quay.io/ansible/awx:execution-environments",
             "tower_ingress_type": "none",
             "tower_memcached_image": "memcached:alpine",
             "tower_postgres_storage_class": "",
-            "tower_postgres_storage_request": "8Gi",
             "tower_redis_image": "redis:latest",
-            "tower_task_cpu_request": "500m",
-            "tower_image": "ansible/awx:15.0.0",
-            "tower_task_mem_request": "1Gi",
-            "tower_task_privileged": false,
-            "tower_web_cpu_request": "1000m"
-            "tower_web_mem_request": "2Gi"
+            "tower_task_privileged": false
           }
         },
         {
@@ -40,25 +33,30 @@ metadata:
             "namespace": "example-awx"
           },
           "spec": {
+            "deployment_type": "awx",
             "tower_admin_email": "test@example.com",
-            "tower_admin_password": "changeme",
-            "tower_admin_user": "test",
             "tower_broadcast_websocket_secret": "changeme",
             "tower_create_preload_data": true,
-            "tower_hostname": "example-awx.test",
+            "tower_image": "quay.io/ansible/awx:execution-environments",
             "tower_ingress_type": "ingress",
             "tower_memcached_image": "memcached:alpine",
             "tower_postgres_image": "postgres:12",
             "tower_postgres_pass": "awxpass",
             "tower_postgres_storage_class": "",
-            "tower_postgres_storage_request": "8Gi",
             "tower_redis_image": "redis:latest",
-            "tower_task_cpu_request": "500m",
-            "tower_image": "ansible/awx:15.0.0",
-            "tower_task_mem_request": "128M",
             "tower_task_privileged": false,
-            "tower_web_cpu_request": "500m",
-            "tower_web_mem_request": "128M"
+            "tower_task_resource_requirements": {
+              "requests": {
+                "cpu": "500m",
+                "memory": "128M"
+              }
+            },
+            "tower_web_resource_requirements": {
+              "requests": {
+                "cpu": "500m",
+                "memory": "128M"
+              }
+            }
           }
         }
       ]
@@ -71,289 +69,302 @@ spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
-      - kind: AWX
-        name: awxs.awx.ansible.com
-        version: v1beta1
-        description: A AWX Instance
-        specDescriptors:
-          - displayName: Hostname
-            path: tower_hostname
-            x-descriptors:
-              - urn:alm:descriptor:com.tectonic.ui:advanced
-              - urn:alm:descriptor:com.tectonic.ui:text
-          - displayName: Admin account username
-            path: tower_admin_user
-            x-descriptors:
-              - urn:alm:descriptor:com.tectonic.ui:advanced
-              - urn:alm:descriptor:com.tectonic.ui:text
-          - displayName: Admin email address
-            path: tower_admin_email
-            x-descriptors:
-              - urn:alm:descriptor:com.tectonic.ui:advanced
-              - urn:alm:descriptor:com.tectonic.ui:text
-          - displayName: Admin password secret
-            path: tower_admin_password_secret
-            x-descriptors:
-              - urn:alm:descriptor:com.tectonic.ui:advanced
-              - urn:alm:descriptor:io.kubernetes:Secret
-          - displayName: Database configuration secret
-            path: tower_postgres_configuration_secret
-            x-descriptors:
-              - urn:alm:descriptor:com.tectonic.ui:advanced
-              - urn:alm:descriptor:io.kubernetes:Secret
-          - displayName: Secret key secret
-            path: tower_secret_key_secret
-            x-descriptors:
-              - urn:alm:descriptor:com.tectonic.ui:advanced
-              - urn:alm:descriptor:io.kubernetes:Secret
-          - displayName: Ingress Type
-            path: tower_ingress_type
-            x-descriptors:
-              - urn:alm:descriptor:com.tectonic.ui:advanced
-              - urn:alm:descriptor:com.tectonic.ui:select:none
-              - urn:alm:descriptor:com.tectonic.ui:select:Ingress
-              - urn:alm:descriptor:com.tectonic.ui:select:Route
-          - displayName: Tower Ingress Annotations
-            path: tower_ingress_annotations
-            x-descriptors:
-              - urn:alm:descriptor:com.tectonic.ui:advanced
-              - urn:alm:descriptor:com.tectonic.ui:text
-              - urn:alm:descriptor:com.tectonic.ui:fieldDependency:tower_ingress_type:Ingress
-          - displayName: Tower Ingress TLS Secret
-            path: tower_ingress_tls_secret
-            x-descriptors:
-              - urn:alm:descriptor:com.tectonic.ui:advanced
-              - urn:alm:descriptor:io.kubernetes:Secret
-              - urn:alm:descriptor:com.tectonic.ui:fieldDependency:tower_ingress_type:Ingress
-          - displayName: Route DNS host
-            path: tower_route_host
-            x-descriptors:
-              - urn:alm:descriptor:com.tectonic.ui:advanced
-              - urn:alm:descriptor:com.tectonic.ui:text
-              - urn:alm:descriptor:com.tectonic.ui:fieldDependency:tower_ingress_type:Route
-          - displayName: Route TLS termination mechanism
-            path: tower_route_tls_termination_mechanism
-            x-descriptors:
-              - urn:alm:descriptor:com.tectonic.ui:advanced
-              - urn:alm:descriptor:com.tectonic.ui:select:Edge
-              - urn:alm:descriptor:com.tectonic.ui:select:Passthrough
-              - urn:alm:descriptor:com.tectonic.ui:fieldDependency:tower_ingress_type:Route
-          - displayName: Route TLS credential secret
-            path: tower_route_tls_secret
-            x-descriptors:
-              - urn:alm:descriptor:com.tectonic.ui:advanced
-              - urn:alm:descriptor:io.kubernetes:Secret
-              - urn:alm:descriptor:com.tectonic.ui:fieldDependency:tower_ingress_type:Route
-          - displayName: Image Pull Policy
-            path: tower_image_pull_policy
-            x-descriptors:
-              - urn:alm:descriptor:com.tectonic.ui:advanced
-              - urn:alm:descriptor:com.tectonic.ui:imagePullPolicy
-          - displayName: Web container resource requirements
-            path: tower_web_resource_requirements
-            x-descriptors:
-              - urn:alm:descriptor:com.tectonic.ui:advanced
-              - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
-          - displayName: Task container resource requirements
-            path: tower_task_resource_requirements
-            x-descriptors:
-              - urn:alm:descriptor:com.tectonic.ui:advanced
-              - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
-          - displayName: PostgreSQL container resource requirements (when using a managed instance)
-            path: tower_postgres_resource_requirements
-            x-descriptors:
-              - urn:alm:descriptor:com.tectonic.ui:advanced
-              - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
-          - displayName: Replicas
-            path: tower_replicas
-            x-descriptors:
-              - urn:alm:descriptor:com.tectonic.ui:advanced
-              - urn:alm:descriptor:com.tectonic.ui:number
-          - displayName: Remove used secrets on instance removal ?
-            path: tower_garbage_collect_secrets
-            x-descriptors:
-              - urn:alm:descriptor:com.tectonic.ui:advanced
-              - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
-          - displayName: Preload instance with data upon creation ?
-            path: tower_create_preload_data
-            x-descriptors:
-              - urn:alm:descriptor:com.tectonic.ui:advanced
-              - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
-          - displayName: Deployment Type
-            path: deployment_type
-            x-descriptors:
-              - urn:alm:descriptor:com.tectonic.ui:advanced
-              - urn:alm:descriptor:com.tectonic.ui:hidden
-          - displayName: Tower Image
-            path: tower_image
-            x-descriptors:
-              - urn:alm:descriptor:com.tectonic.ui:advanced
-              - urn:alm:descriptor:com.tectonic.ui:hidden
-          - displayName: Tower Postgres Storage Class
-            path: tower_postgres_storage_class
-            x-descriptors:
-              - urn:alm:descriptor:com.tectonic.ui:advanced
-              - urn:alm:descriptor:com.tectonic.ui:hidden
-          - displayName: Certificate Authorirty Trust Bundle
-            path: ca_trust_bundle
-            x-descriptors:
-              - urn:alm:descriptor:com.tectonic.ui:advanced
-              - urn:alm:descriptor:com.tectonic.ui:hidden
-        statusDescriptors:
-          - displayName: URL
-            description: Route to access the instance deployed
-            path: towerURL
-            x-descriptors:
-              - urn:alm:descriptor:org.w3:link
-          - displayName: Admin User
-            description: Admin user for the instance deployed
-            path: towerAdminUser
-            x-descriptors:
-              - urn:alm:descriptor:com.tectonic.ui:text
-          - displayName: Admin Password
-            description: Admin password for the instance deployed
-            path: towerAdminPasswordSecret
-            x-descriptors:
-              - urn:alm:descriptor:io.kubernetes:Secret
-          - displayName: Version
-            description: Version of the instance deployed
-            path: towerVersion
-            x-descriptors:
-              - urn:alm:descriptor:com.tectonic.ui:text
-          - displayName: Image
-            description: Image of the instance deployed
-            path: towerImage
-            x-descriptors:
-              - urn:alm:descriptor:com.tectonic.ui:text
+    - description: A AWX Instance
+      kind: AWX
+      name: awxs.awx.ansible.com
+      specDescriptors:
+      - displayName: Hostname
+        path: tower_hostname
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - displayName: Admin account username
+        path: tower_admin_user
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - displayName: Admin email address
+        path: tower_admin_email
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - displayName: Admin password secret
+        path: tower_admin_password_secret
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:io.kubernetes:Secret
+      - displayName: Database configuration secret
+        path: tower_postgres_configuration_secret
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:io.kubernetes:Secret
+      - displayName: Secret key secret
+        path: tower_secret_key_secret
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:io.kubernetes:Secret
+      - displayName: Ingress Type
+        path: tower_ingress_type
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:select:none
+        - urn:alm:descriptor:com.tectonic.ui:select:Ingress
+        - urn:alm:descriptor:com.tectonic.ui:select:Route
+      - displayName: Tower Ingress Annotations
+        path: tower_ingress_annotations
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:text
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:tower_ingress_type:Ingress
+      - displayName: Tower Ingress TLS Secret
+        path: tower_ingress_tls_secret
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:io.kubernetes:Secret
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:tower_ingress_type:Ingress
+      - displayName: Route DNS host
+        path: tower_route_host
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:text
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:tower_ingress_type:Route
+      - displayName: Route TLS termination mechanism
+        path: tower_route_tls_termination_mechanism
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:select:Edge
+        - urn:alm:descriptor:com.tectonic.ui:select:Passthrough
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:tower_ingress_type:Route
+      - displayName: Route TLS credential secret
+        path: tower_route_tls_secret
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:io.kubernetes:Secret
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:tower_ingress_type:Route
+      - displayName: Image Pull Policy
+        path: tower_image_pull_policy
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:imagePullPolicy
+      - displayName: Web container resource requirements
+        path: tower_web_resource_requirements
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
+      - displayName: Task container resource requirements
+        path: tower_task_resource_requirements
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
+      - displayName: PostgreSQL container resource requirements (when using a managed
+          instance)
+        path: tower_postgres_resource_requirements
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
+      - displayName: Replicas
+        path: tower_replicas
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - displayName: Remove used secrets on instance removal ?
+        path: tower_garbage_collect_secrets
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - displayName: Preload instance with data upon creation ?
+        path: tower_create_preload_data
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - displayName: Deployment Type
+        path: deployment_type
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - displayName: Tower Image
+        path: tower_image
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - displayName: Tower Postgres Storage Class
+        path: tower_postgres_storage_class
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - displayName: Certificate Authorirty Trust Bundle
+        path: ca_trust_bundle
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      statusDescriptors:
+      - description: Route to access the instance deployed
+        displayName: URL
+        path: towerURL
+        x-descriptors:
+        - urn:alm:descriptor:org.w3:link
+      - description: Admin user for the instance deployed
+        displayName: Admin User
+        path: towerAdminUser
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Admin password for the instance deployed
+        displayName: Admin Password
+        path: towerAdminPasswordSecret
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes:Secret
+      - description: Version of the instance deployed
+        displayName: Version
+        path: towerVersion
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Image of the instance deployed
+        displayName: Image
+        path: towerImage
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      version: v1beta1
   description: AWX operator
   displayName: AWX
   icon:
-    - base64data: ""
-      mediatype: ""
+  - base64data: ""
+    mediatype: ""
   install:
     spec:
       clusterPermissions:
-        - rules:
-            - apiGroups:
-                - route.openshift.io
-              resources:
-                - routes
-                - routes/custom-host
-              verbs:
-                - '*'
-            - apiGroups:
-                - ""
-              resources:
-                - pods
-                - services
-                - services/finalizers
-                - endpoints
-                - persistentvolumeclaims
-                - events
-                - configmaps
-                - secrets
-              verbs:
-                - '*'
-            - apiGroups:
-                - apps
-                - extensions
-              resources:
-                - deployments
-                - daemonsets
-                - replicasets
-                - statefulsets
-                - ingresses
-              verbs:
-                - '*'
-            - apiGroups:
-                - monitoring.coreos.com
-              resources:
-                - servicemonitors
-              verbs:
-                - get
-                - create
-            - apiGroups:
-                - apps
-              resourceNames:
-                - awx-operator
-              resources:
-                - deployments/finalizers
-              verbs:
-                - update
-            - apiGroups:
-                - ""
-              resources:
-                - pods/exec
-              verbs:
-                - create
-                - get
-            - apiGroups:
-                - apps
-              resources:
-                - replicasets
-              verbs:
-                - get
-            - apiGroups:
-                - awx.ansible.com
-              resources:
-                - '*'
-              verbs:
-                - '*'
-          serviceAccountName: awx-operator
+      - rules:
+        - apiGroups:
+          - route.openshift.io
+          resources:
+          - routes
+          - routes/custom-host
+          verbs:
+          - '*'
+        - apiGroups:
+          - ""
+          - rbac.authorization.k8s.io
+          resources:
+          - pods
+          - services
+          - services/finalizers
+          - serviceaccounts
+          - endpoints
+          - persistentvolumeclaims
+          - events
+          - configmaps
+          - secrets
+          - roles
+          - rolebindings
+          verbs:
+          - '*'
+        - apiGroups:
+          - apps
+          - extensions
+          resources:
+          - deployments
+          - daemonsets
+          - replicasets
+          - statefulsets
+          - ingresses
+          verbs:
+          - '*'
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          verbs:
+          - get
+          - create
+        - apiGroups:
+          - apps
+          resourceNames:
+          - awx-operator
+          resources:
+          - deployments/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          - pods/exec
+          verbs:
+          - create
+          - get
+        - apiGroups:
+          - apps
+          resources:
+          - replicasets
+          verbs:
+          - get
+        - apiGroups:
+          - awx.ansible.com
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        serviceAccountName: awx-operator
       deployments:
-        - name: awx-operator
-          spec:
-            replicas: 1
-            selector:
-              matchLabels:
+      - name: awx-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: awx-operator
+          strategy: {}
+          template:
+            metadata:
+              labels:
                 name: awx-operator
-            strategy: {}
-            template:
-              metadata:
-                labels:
-                  name: awx-operator
-              spec:
-                containers:
-                  - env:
-                      - name: WATCH_NAMESPACE
-                        valueFrom:
-                          fieldRef:
-                            fieldPath: metadata.annotations['olm.targetNamespaces']
-                      - name: POD_NAME
-                        valueFrom:
-                          fieldRef:
-                            fieldPath: metadata.name
-                      - name: OPERATOR_NAME
-                        value: awx-operator
-                    image: ansible/awx-operator:0.6.0
-                    imagePullPolicy: Always
-                    name: operator
-                    resources: {}
-                    volumeMounts:
-                      - mountPath: /tmp/ansible-operator/runner
-                        name: runner
-                serviceAccountName: awx-operator
-                volumes:
-                  - emptyDir: {}
-                    name: runner
+            spec:
+              containers:
+              - env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: OPERATOR_NAME
+                  value: awx-operator
+                - name: ANSIBLE_GATHERING
+                  value: explicit
+                image: quay.io/ansible/awx-operator:0.6.0
+                imagePullPolicy: Always
+                livenessProbe:
+                  httpGet:
+                    path: /healthz
+                    port: 6789
+                  initialDelaySeconds: 5
+                  periodSeconds: 3
+                name: awx-operator
+                resources: {}
+                volumeMounts:
+                - mountPath: /tmp/ansible-operator/runner
+                  name: runner
+              serviceAccountName: awx-operator
+              volumes:
+              - emptyDir: {}
+                name: runner
     strategy: deployment
   installModes:
-    - supported: true
-      type: OwnNamespace
-    - supported: true
-      type: SingleNamespace
-    - supported: false
-      type: MultiNamespace
-    - supported: true
-      type: AllNamespaces
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces
   keywords:
-    - awx
+  - awx
   links:
-    - name: Awx Operator
-      url: https://github.com/ansible/awx-operator
+  - name: Awx Operator
+    url: https://github.com/ansible/awx-operator
   maintainers:
-    - email: yguenane@redhat.com
-      name: Yanis Guenane
+  - email: yguenane@redhat.com
+    name: Yanis Guenane
   maturity: alpha
   provider:
     name: AWX Community

--- a/deploy/olm-catalog/awx-operator/manifests/awx.ansible.com_awxs_crd.yaml
+++ b/deploy/olm-catalog/awx-operator/manifests/awx.ansible.com_awxs_crd.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -13,199 +12,250 @@ spec:
     singular: awx
   scope: Namespaced
   versions:
-    - name: v1beta1
-      served: true
-      storage: true
-      subresources:
-        status: {}
-      schema:
-        openAPIV3Schema:
-          description: Schema validation for the AWX CRD
-          properties:
-            spec:
-              properties:
-                deployment_type:
-                  description: Name of the deployment type
-                  type: string
-                tower_admin_user:
-                  description: Username to use for the admin account
-                  type: string
-                  default: admin
-                tower_hostname:
-                  description: The hostname of the instance
-                  type: string
-                tower_admin_email:
-                  description: The admin user email
-                  type: string
-                tower_admin_password_secret:
-                  description: Secret where the admin password can be found
-                  type: string
-                tower_postgres_configuration_secret:
-                  description: Secret where the database configuration can be found
-                  type: string
-                tower_secret_key_secret:
-                  description: Secret where the secret key can be found
-                  type: string
-                tower_ingress_type:
-                  description: The ingress type to use to reach the deployed instance
-                  type: string
-                  enum:
-                    - none
-                    - Ingress
-                    - ingress
-                    - Route
-                    - route
-                tower_ingress_annotations:
-                  description: Annotations to add to the ingress
-                  type: string
-                tower_ingress_tls_secret:
-                  description: Secret where the ingress TLS secret can be found
-                  type: string
-                tower_route_host:
-                  description: The DNS to use to points to the instance
-                  type: string
-                tower_route_tls_termination_mechanism:
-                  description: The secure TLS termination mechanism to use
-                  type: string
-                  default: Edge
-                  enum:
-                    - Edge
-                    - edge
-                    - Passthrough
-                    - passthrough
-                tower_route_tls_secret:
-                  description: Secret where the TLS related credentials are stored
-                  type: string
-                tower_image:
-                  description: Registry path to the application container to use
-                  type: string
-                tower_image_pull_policy:
-                  description: The image pull policy
-                  type: string
-                  default: IfNotPresent
-                  enum:
-                    - Always
-                    - always
-                    - Never
-                    - never
-                    - IfNotPresent
-                    - ifnotpresent
-                tower_task_resource_requirements:
-                  description: Resource requirements for the task container
-                  properties:
-                    requests:
-                      properties:
-                        cpu:
-                          type: string
-                        memory:
-                          type: string
-                        storage:
-                          type: string
-                      type: object
-                    limits:
-                      properties:
-                        cpu:
-                          type: string
-                        memory:
-                          type: string
-                        storage:
-                          type: string
-                      type: object
-                  type: object
-                tower_web_resource_requirements:
-                  description: Resource requirements for the web container
-                  properties:
-                    requests:
-                      properties:
-                        cpu:
-                          type: string
-                        memory:
-                          type: string
-                        storage:
-                          type: string
-                      type: object
-                    limits:
-                      properties:
-                        cpu:
-                          type: string
-                        memory:
-                          type: string
-                        storage:
-                          type: string
-                      type: object
-                  type: object
-                tower_replicas:
-                  description: Number of instance replicas
-                  type: integer
-                  default: 1
-                  format: int32
-                tower_garbage_collect_secrets:
-                  description: Whether or not to remove secrets upon instance removal
-                  default: false
-                  type: boolean
-                tower_create_preload_data:
-                  description: Whether or not to preload data upon Tower instance creation
-                  default: true
-                  type: boolean
-                tower_postgres_resource_requirements:
-                  description: Resource requirements for the PostgreSQL container
-                  properties:
-                    requests:
-                      properties:
-                        cpu:
-                          type: string
-                        memory:
-                          type: string
-                        storage:
-                          type: string
-                      type: object
-                    limits:
-                      properties:
-                        cpu:
-                          type: string
-                        memory:
-                          type: string
-                        storage:
-                          type: string
-                      type: object
-                  type: object
-                tower_postgres_storage_class:
-                  description: Storage class to use for the PostgreSQL PVC
-                  type: string
-                ca_trust_bundle:
-                  description: Path where the trusted CA bundle is available
-                  type: string
-              type: object
-            status:
-              properties:
-                towerURL:
-                  description: URL to access the deployed instance
-                  type: string
-                towerAdminUser:
-                  description: Admin user of the deployed instance
-                  type: string
-                towerAdminPasswordSecret:
-                  description: Admin password of the deployed instance
-                  type: string
-                towerVersion:
-                  description: Version of the deployed instance
-                  type: string
-                towerImage:
-                  description: URL of the image used for the deployed instance
-                  type: string
-                conditions:
-                  description: The resulting conditions when a Service Telemetry is instantiated
-                  items:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: Schema validation for the AWX CRD
+        properties:
+          spec:
+            properties:
+              ca_trust_bundle:
+                description: Path where the trusted CA bundle is available
+                type: string
+              deployment_type:
+                description: Name of the deployment type
+                type: string
+              development_mode:
+                description: If the deployment should be done in development mode
+                type: boolean
+              tower_admin_email:
+                description: The admin user email
+                type: string
+              tower_admin_password_secret:
+                description: Secret where the admin password can be found
+                type: string
+              tower_admin_user:
+                description: Username to use for the admin account
+                type: string
+              tower_broadcast_websocket_secret:
+                description: Secret where the broadcast websocket secret can be found
+                type: string
+              tower_create_preload_data:
+                default: true
+                description: Whether or not to preload data upon Tower instance creation
+                type: boolean
+              tower_extra_volumes:
+                description: Specify extra volumes to add to the application pod
+                type: string
+              tower_garbage_collect_secrets:
+                default: false
+                description: Whether or not to remove secrets upon instance removal
+                type: boolean
+              tower_hostname:
+                description: The hostname of the instance
+                type: string
+              tower_image:
+                description: Registry path to the application container to use
+                type: string
+              tower_image_pull_policy:
+                default: IfNotPresent
+                description: The image pull policy
+                enum:
+                - Always
+                - always
+                - Never
+                - never
+                - IfNotPresent
+                - ifnotpresent
+                type: string
+              tower_ingress_annotations:
+                description: Annotations to add to the ingress
+                type: string
+              tower_ingress_tls_secret:
+                description: Secret where the ingress TLS secret can be found
+                type: string
+              tower_ingress_type:
+                description: The ingress type to use to reach the deployed instance
+                enum:
+                - none
+                - Ingress
+                - ingress
+                - Route
+                - route
+                type: string
+              tower_postgres_configuration_secret:
+                description: Secret where the database configuration can be found
+                type: string
+              tower_postgres_data_path:
+                description: Path where the PostgreSQL data are located
+                type: string
+              tower_postgres_image:
+                description: Registry path to the PostgreSQL container to use
+                type: string
+              tower_postgres_resource_requirements:
+                description: Resource requirements for the PostgreSQL container
+                properties:
+                  limits:
                     properties:
-                      status:
+                      cpu:
                         type: string
-                      type:
+                      memory:
                         type: string
-                      reason:
-                        type: string
-                      lastTransitionTime:
+                      storage:
                         type: string
                     type: object
-                  type: array
-              type: object
-          type: object
+                  requests:
+                    properties:
+                      cpu:
+                        type: string
+                      memory:
+                        type: string
+                      storage:
+                        type: string
+                    type: object
+                type: object
+              tower_postgres_storage_class:
+                description: Storage class to use for the PostgreSQL PVC
+                type: string
+              tower_redis_image:
+                description: Registry path to the redis container to use
+                type: string
+              tower_replicas:
+                default: 1
+                description: Number of instance replicas
+                format: int32
+                type: integer
+              tower_route_host:
+                description: The DNS to use to points to the instance
+                type: string
+              tower_route_tls_secret:
+                description: Secret where the TLS related credentials are stored
+                type: string
+              tower_route_tls_termination_mechanism:
+                default: Edge
+                description: The secure TLS termination mechanism to use
+                enum:
+                - Edge
+                - edge
+                - Passthrough
+                - passthrough
+                type: string
+              tower_secret_key_secret:
+                description: Secret where the secret key can be found
+                type: string
+              tower_task_args:
+                items:
+                  type: string
+                type: array
+              tower_task_command:
+                items:
+                  type: string
+                type: array
+              tower_task_extra_env:
+                type: string
+              tower_task_extra_volume_mounts:
+                type: string
+              tower_task_privileged:
+                description: If a privileged security context should be enabled
+                type: boolean
+              tower_task_resource_requirements:
+                description: Resource requirements for the task container
+                properties:
+                  limits:
+                    properties:
+                      cpu:
+                        type: string
+                      memory:
+                        type: string
+                      storage:
+                        type: string
+                    type: object
+                  requests:
+                    properties:
+                      cpu:
+                        type: string
+                      memory:
+                        type: string
+                      storage:
+                        type: string
+                    type: object
+                type: object
+              tower_web_args:
+                items:
+                  type: string
+                type: array
+              tower_web_command:
+                items:
+                  type: string
+                type: array
+              tower_web_extra_env:
+                type: string
+              tower_web_extra_volume_mounts:
+                type: string
+              tower_web_resource_requirements:
+                description: Resource requirements for the web container
+                properties:
+                  limits:
+                    properties:
+                      cpu:
+                        type: string
+                      memory:
+                        type: string
+                      storage:
+                        type: string
+                    type: object
+                  requests:
+                    properties:
+                      cpu:
+                        type: string
+                      memory:
+                        type: string
+                      storage:
+                        type: string
+                    type: object
+                type: object
+            type: object
+          status:
+            properties:
+              conditions:
+                description: The resulting conditions when a Service Telemetry is
+                  instantiated
+                items:
+                  properties:
+                    lastTransitionTime:
+                      type: string
+                    reason:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      type: string
+                  type: object
+                type: array
+              towerAdminPasswordSecret:
+                description: Admin password of the deployed instance
+                type: string
+              towerAdminUser:
+                description: Admin user of the deployed instance
+                type: string
+              towerImage:
+                description: URL of the image used for the deployed instance
+                type: string
+              towerURL:
+                description: URL to access the deployed instance
+                type: string
+              towerVersion:
+                description: Version of the deployed instance
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/deploy/olm-catalog/awx-operator/metadata/annotations.yaml
+++ b/deploy/olm-catalog/awx-operator/metadata/annotations.yaml
@@ -1,4 +1,3 @@
----
 annotations:
   operators.operatorframework.io.bundle.channel.default.v1: alpha
   operators.operatorframework.io.bundle.channels.v1: alpha

--- a/roles/installer/defaults/main.yml
+++ b/roles/installer/defaults/main.yml
@@ -53,8 +53,9 @@ tower_extra_volumes: ''
 
 # Use these image versions for Ansible AWX.
 
-tower_image: ansible/awx:15.0.0
+tower_image: quay.io/ansible/awx:execution-environments
 tower_image_pull_policy: IfNotPresent
+default_ee: quay.io/ansible/awx-ee
 
 tower_create_preload_data: true
 

--- a/roles/installer/tasks/main.yml
+++ b/roles/installer/tasks/main.yml
@@ -29,6 +29,7 @@
   register: tower_deployment_result
   loop:
     - 'tower_app_credentials'
+    - 'tower_service_account'
     - 'tower_deployment'
     - 'tower_service'
     - 'tower_ingress'

--- a/roles/installer/templates/tower_config.yaml.j2
+++ b/roles/installer/templates/tower_config.yaml.j2
@@ -23,7 +23,9 @@ data:
     STATIC_ROOT = '/var/lib/awx/public/static'
     PROJECTS_ROOT = '/var/lib/awx/projects'
     JOBOUTPUT_ROOT = '/var/lib/awx/job_status'
-    
+
+    IS_K8S = True
+
     SECRET_KEY = get_secret()
     
     ALLOWED_HOSTS = ['*']
@@ -59,6 +61,7 @@ data:
         '()': 'logging.StreamHandler',
         'level': 'DEBUG',
         'formatter': 'simple',
+        'filters': ['guid'],
     }
     
     LOGGING['loggers']['django.request']['handlers'] = ['console']
@@ -208,3 +211,32 @@ data:
     unixsocketperm 777
     port 0
     bind 127.0.0.1
+  receptor_conf: |
+    ---
+    - log-level: debug
+
+    - control-service:
+        service: control
+        filename: /var/run/receptor/receptor.sock
+
+    - local-only:
+
+    - work-command:
+        worktype: local
+        command: ansible-runner
+        params: worker
+        allowruntimeparams: true
+
+    - work-kubernetes:
+        worktype: kubernetes-runtime-auth
+        authmethod: runtime
+        allowruntimeauth: true
+        allowruntimepod: true
+        allowruntimeparams: true
+
+    - work-kubernetes:
+        worktype: kubernetes-incluster-auth
+        authmethod: incluster
+        allowruntimeauth: true
+        allowruntimepod: true
+        allowruntimeparams: true

--- a/roles/installer/templates/tower_deployment.yaml.j2
+++ b/roles/installer/templates/tower_deployment.yaml.j2
@@ -17,6 +17,7 @@ spec:
       labels:
         app: '{{ deployment_type }}'
     spec:
+      serviceAccountName: '{{ meta.name }}'
       containers:
         - image: '{{ tower_redis_image }}'
           name: redis
@@ -28,6 +29,8 @@ spec:
               readOnly: true
             - name: {{ meta.name }}-redis-socket
               mountPath: "/var/run/redis"
+            - name: "{{ meta.name }}-redis-data"
+              mountPath: "/data"
         - image: '{{ tower_image }}'
           name: '{{ meta.name }}-web'
 {% if tower_web_command %}
@@ -78,9 +81,11 @@ spec:
 {% if tower_web_extra_volume_mounts -%}
             {{ tower_web_extra_volume_mounts | indent(width=12, indentfirst=True) }}
 {% endif %}
-{% if (development_mode | bool) or (tower_task_extra_env | bool) %}
           env:
-{% endif %}
+            - name: MY_POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
 {% if development_mode | bool %}
             - name: AWX_KUBE_DEVEL
               value: "1"
@@ -122,6 +127,10 @@ spec:
               mountPath: "/var/run/awx-rsyslog"
             - name: rsyslog-dir
               mountPath: "/var/lib/awx/rsyslog"
+            - name: receptor-socket
+              mountPath: "/var/run/receptor"
+            - name: "{{ meta.name }}-projects"
+              mountPath: "/var/lib/awx/projects"
 {% if development_mode | bool %}
             - name: awx-devel
               mountPath: "/awx_devel"
@@ -142,6 +151,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
+            - name: MY_POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
 {% if development_mode | bool %}
             - name: AWX_KUBE_DEVEL
               value: "1"
@@ -150,6 +163,26 @@ spec:
             {{ tower_task_extra_env | indent(width=12, indentfirst=True) }}
 {% endif %}
           resources: {{ tower_task_resource_requirements }}
+        - image: '{{ default_ee }}'
+          name: '{{ meta.name }}-ee'
+          imagePullPolicy: '{{ tower_image_pull_policy }}'
+          args: ['receptor', '--config', '/etc/receptor.conf']
+          volumeMounts:
+            - name: "{{ meta.name }}-receptor-config"
+              mountPath: "/etc/receptor.conf"
+              subPath: receptor.conf
+              readOnly: true
+            - name: receptor-socket
+              mountPath: "/var/run/receptor"
+            - name: "{{ meta.name }}-projects"
+              mountPath: "/var/lib/awx/projects"
+{% if development_mode | bool %}
+          env:
+            - name: SDB_NOTIFY_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+{% endif %}
       volumes:
 {% if tower_ingress_type | lower == 'route' and tower_route_tls_termination_mechanism | lower == 'passthrough' %}
         - name: "{{ meta.name }}-nginx-certs"
@@ -195,11 +228,23 @@ spec:
                 path: redis.conf
         - name: {{ meta.name }}-redis-socket
           emptyDir: {}
+        - name: {{ meta.name }}-redis-data
+          emptyDir: {}
         - name: supervisor-socket
           emptyDir: {}
         - name: rsyslog-socket
           emptyDir: {}
+        - name: receptor-socket
+          emptyDir: {}
         - name: rsyslog-dir
+          emptyDir: {}
+        - name: {{ meta.name }}-receptor-config
+          configMap:
+            name: {{ meta.name }}-awx-configmap
+            items:
+              - key: receptor_conf
+                path: receptor.conf
+        - name: "{{ meta.name }}-projects"
           emptyDir: {}
 {% if development_mode | bool %}
         - name: awx-devel

--- a/roles/installer/templates/tower_deployment.yaml.j2
+++ b/roles/installer/templates/tower_deployment.yaml.j2
@@ -240,7 +240,7 @@ spec:
           emptyDir: {}
         - name: {{ meta.name }}-receptor-config
           configMap:
-            name: {{ meta.name }}-awx-configmap
+            name: '{{ meta.name }}-{{ deployment_type }}-configmap'
             items:
               - key: receptor_conf
                 path: receptor.conf

--- a/roles/installer/templates/tower_service_account.yaml.j2
+++ b/roles/installer/templates/tower_service_account.yaml.j2
@@ -1,0 +1,37 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: '{{ meta.name }}'
+  namespace: '{{ meta.namespace }}'
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: '{{ meta.name }}'
+  namespace: '{{ meta.namespace }}'
+rules:
+- apiGroups: [""] # "" indicates the core API group
+  resources: ["pods"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups: [""]
+  resources: ["pods/log"]
+  verbs: ["get"]
+- apiGroups: [""]
+  resources: ["pods/attach"]
+  verbs: ["create"]
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: '{{ meta.name }}'
+  namespace: '{{ meta.namespace }}'
+subjects:
+- kind: ServiceAccount
+  name: '{{ meta.name }}'
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: '{{ meta.name }}'


### PR DESCRIPTION
For Tower deployments, the configmap name is currently set incorrectly to tower-awx-configmap.  As a result, the receptor config is unable to mount.  