### PR TITLE
Intial GH Actions - Publish latest build and CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,41 @@
+---
+
+name: CI
+
+on:
+  pull_request:
+    branches: [devel]
+
+jobs:
+  pull_request:
+    runs-on: ubuntu-18.04
+    name: pull_request
+    env:
+      DOCKER_API_VERSION: "1.38"
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: "3.8"
+
+      - name: Install Dependencies
+        run: |
+          pip install \
+            molecule \
+            molecule-docker \
+            yamllint \
+            ansible-lint \
+            openshift \
+            jmespath \
+            ansible
+
+      - name: Install Collections
+        run: |
+         ansible-galaxy collection install community.kubernetes operator_sdk.util
+
+      - name: Run Molecule
+        env:
+          MOLECULE_VERBOSITY: 3
+        run: |
+          molecule test -s test-local

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,34 @@
+---
+
+name: Release
+
+on:
+  push:
+    branches: [devel]
+
+jobs:
+  release:
+    runs-on: ubuntu-18.04
+    name: release
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install Operator-SDK
+        run: |
+          mkdir -p $GITHUB_WORKSPACE/bin
+          wget -O $GITHUB_WORKSPACE/bin/operator-sdk https://github.com/operator-framework/operator-sdk/releases/download/v0.19.4/operator-sdk-v0.19.4-x86_64-linux-gnu
+          chmod +x $GITHUB_WORKSPACE/bin/operator-sdk
+          echo "$GITHUB_WORKSPACE/bin" >> $GITHUB_PATH
+
+      - name: Build Image
+        run: |
+          operator-sdk build awx-operator:devel
+
+      - name: Push To Quay
+        uses: redhat-actions/push-to-registry@v2.1.1
+        with:
+          image: awx-operator
+          tags: devel
+          registry: quay.io/ansible/
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_TOKEN }}

--- a/.yamllint
+++ b/.yamllint
@@ -8,5 +8,5 @@ ignore: |
 rules:
   truthy: disable
   line-length:
-    max: 160
+    max: 170
     level: warning


### PR DESCRIPTION
resolves #124

This PR adds GH Actions for CI and image publishing anytime something is pushed to the `devel` branch. This cuts off about ~5 minutes from the current CI time in travis without making any changes (so there's definitely some room for even more improvement).

This is just some of the initial possibilities to cover issue #124. If this is something the group is interested in moving forward with -- we can add a bit more in follow up for things like publishing a tagged version (i.e. vX.Y.Z) and updating the appropriate docs when a release is cut, testing against different versions of python/collections/k8s, etc.

For reference, you can see successful output of the actions here:

CI: https://github.com/tylerauerbeck/awx-operator/runs/2162012057?check_suite_focus=true
Release: https://github.com/tylerauerbeck/awx-operator/runs/2162099663?check_suite_focus=true
Quay: https://quay.io/repository/tauerbec/awx-operator?tag=latest&tab=tags

The only thing required before a merge would be to create appropriate secrets in order to publish to quay (reference in `release.yaml`