### PR TITLE
Name pg pod in a more unique way

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ metadata:
   name: awx
 ```
 
+> The metadata.name you provide, will be the name of the resulting AWX deployment.  If you deploy more than one to the same namespace, be sure to use unique names.  
+
 Finally, use `kubectl` to create the awx instance in your cluster:
 
 ```bash

--- a/roles/installer/tasks/migrate_data.yml
+++ b/roles/installer/tasks/migrate_data.yml
@@ -13,7 +13,7 @@
     kind: Pod
     namespace: '{{ meta.namespace }}'
     label_selectors:
-      - "app={{ deployment_type }}-postgres"
+      - "app={{ meta.name }}-{{ deployment_type }}-postgres"
   register: postgres_pod
   until: "postgres_pod['resources'][0]['status']['phase'] == 'Running'"
   delay: 5

--- a/roles/installer/templates/tower_postgres.yaml.j2
+++ b/roles/installer/templates/tower_postgres.yaml.j2
@@ -6,11 +6,11 @@ metadata:
   name: '{{ meta.name }}-postgres'
   namespace: '{{ meta.namespace }}'
   labels:
-    app: '{{ deployment_type }}-postgres'
+    app: '{{ meta.name }}-{{ deployment_type }}-postgres'
 spec:
   selector:
     matchLabels:
-      app: '{{ deployment_type }}-postgres'
+      app: '{{ meta.name }}-{{ deployment_type }}-postgres'
   serviceName: '{{ meta.name }}'
   replicas: 1
   updateStrategy:
@@ -18,7 +18,7 @@ spec:
   template:
     metadata:
       labels:
-        app: '{{ deployment_type }}-postgres'
+        app: '{{ meta.name }}-{{ deployment_type }}-postgres'
     spec:
       containers:
         - image: '{{ tower_postgres_image }}'
@@ -71,10 +71,10 @@ metadata:
   name: '{{ meta.name }}-postgres'
   namespace: '{{ meta.namespace }}'
   labels:
-    app: '{{ deployment_type }}-postgres'
+    app: '{{ meta.name }}-{{ deployment_type }}-postgres'
 spec:
   ports:
     - port: 5432
   clusterIP: None
   selector:
-    app: '{{ deployment_type }}-postgres'
+    app: '{{ meta.name }}-{{ deployment_type }}-postgres'


### PR DESCRIPTION
# Summary

This is to make it possible to run data migrations with multiple deployments in the same pod.

Currently, if there are multiple awx/tower deployments in the same namespace, our data migration logic will just grab the first postgresql pod in the list:
https://github.com/ansible/awx-operator/blob/devel/roles/installer/tasks/migrate_data.yml#L16

This makes the label on the postgresql pod unique to the deployment.  



### Before

```
$ oc get pods --show-labels
NAME                      READY   STATUS    RESTARTS   AGE     LABELS
tower1-55cb79f485-4qj7b   4/4     Running   0          5m44s   app=tower,pod-template-hash=55cb79f485
tower1-postgres-0         1/1     Running   0          6m36s   app=tower-postgres,controller-revision-hash=tower1-postgres-68b445756f,statefulset.kubernetes.io/pod-name=tower1-postgres-0
tower2-546875444d-qmzk2   4/4     Running   0          69s     app=tower,pod-template-hash=546875444d
tower2-postgres-0         1/1     Running   0          112s    app=tower-postgres,controller-revision-hash=tower2-postgres-646cf657c6,statefulset.kubernetes.io/pod-name=tower2-postgres-0
```


### After

```
$ oc get pods --show-labels
NAME                      READY   STATUS    RESTARTS   AGE     LABELS
tower1-55cb79f485-nrr7m   4/4     Running   0          8m22s   app=tower,pod-template-hash=55cb79f485
tower1-postgres-0         1/1     Running   0          9m11s   app=tower1-tower-postgres,controller-revision-hash=tower1-postgres-768d9d8966,statefulset.kubernetes.io/pod-name=tower1-postgres-0
tower2-546875444d-rdkfl   4/4     Running   0          4m32s   app=tower,pod-template-hash=546875444d
tower2-postgres-0         1/1     Running   0          5m35s   app=tower2-tower-postgres,controller-revision-hash=tower2-postgres-57ddbdf4c6,statefulset.kubernetes.io/pod-name=tower2-postgres-0
```


### Why?

This allows us to grab only the postgresql pod that pertains to the intended deployment:

```
$ oc get pods --show-labels --selector app=tower1-tower-postgres
NAME                READY   STATUS    RESTARTS   AGE   LABELS
tower1-postgres-0   1/1     Running   0          14m   app=tower1-tower-postgres,controller-revision-hash=tower1-postgres-768d9d8966,statefulset.kubernetes.io/pod-name=tower1-postgres-0
```