### PR TITLE
Update liveness probe defaults

### DIFF
--- a/ansible/templates/operator.yml.j2
+++ b/ansible/templates/operator.yml.j2
@@ -37,8 +37,8 @@ spec:
             httpGet:
               path: /healthz
               port: 6789
-            initialDelaySeconds: 5
-            periodSeconds: 3
+            initialDelaySeconds: 15
+            periodSeconds: 20
       volumes:
         - name: runner
           emptyDir: {}

--- a/deploy/awx-operator.yaml
+++ b/deploy/awx-operator.yaml
@@ -143,8 +143,8 @@ spec:
             httpGet:
               path: /healthz
               port: 6789
-            initialDelaySeconds: 5
-            periodSeconds: 3
+            initialDelaySeconds: 15
+            periodSeconds: 20
       volumes:
         - name: runner
           emptyDir: {}
@@ -349,9 +349,6 @@ spec:
                 tower_task_extra_volume_mounts:
                   type: string
                 tower_web_extra_volume_mounts:
-                  type: string
-                tower_ee_image:
-                  description: Registry path to the Execution Environment container to use
                   type: string
                 tower_redis_image:
                   description: Registry path to the redis container to use

--- a/deploy/crds/awx_v1beta1_crd.yaml
+++ b/deploy/crds/awx_v1beta1_crd.yaml
@@ -199,9 +199,6 @@ spec:
                   type: string
                 tower_web_extra_volume_mounts:
                   type: string
-                tower_ee_image:
-                  description: Registry path to the Execution Environment container to use
-                  type: string
                 tower_redis_image:
                   description: Registry path to the redis container to use
                   type: string

--- a/deploy/olm-catalog/awx-operator/manifests/awx-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/awx-operator/manifests/awx-operator.clusterserviceversion.yaml
@@ -440,8 +440,8 @@ spec:
                   httpGet:
                     path: /healthz
                     port: 6789
-                  initialDelaySeconds: 5
-                  periodSeconds: 3
+                  initialDelaySeconds: 15
+                  periodSeconds: 20
                 name: awx-operator
                 resources: {}
                 volumeMounts:


### PR DESCRIPTION
The liveness probes default are too agressive and can lead to
undeployable operators[1][2] - We are bumping them as per the
operator-sdk default in 1.0[3]

[1] https://github.com/operator-framework/operator-sdk/issues/3216
[2] https://github.com/operator-framework/operator-sdk/issues/3267
[3]
https://github.com/operator-framework/operator-sdk/commit/ea43495073a543ede5f10ea5790660004cf750be

Fixes: https://github.com/ansible/awx-operator/issues/131