### PR TITLE
Handling HTTP loadbalancer

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,9 @@ The following variables are customizable to specify the TLS termination procedur
 | tower_loadbalancer_protocol    | Protocol to use for Loadbalancer ingress | http          |
 | tower_loadbalancer_port        | Port used for Loadbalancer ingress       | 80            |
 
+When setting up a Load Balancer for HTTPS you will be required to set the `tower_loadbalancer_port` to move the port away from `80`.
+
+The HTTPS Load Balancer also uses SSL termination at the Load Balancer level and will offload traffic to AWX over HTTP.
 
 ### Database Configuration
 

--- a/roles/installer/templates/tower_service.yaml.j2
+++ b/roles/installer/templates/tower_service.yaml.j2
@@ -25,10 +25,15 @@ spec:
       name: https
 {% endif %}
 {% if tower_ingress_type | lower == 'loadbalancer' and tower_loadbalancer_protocol | lower == 'https' %}
-    - port: 443
+    - port: {{ tower_loadbalancer_port }}
       protocol: TCP
       targetPort: 8052
       name: https
+{% elif tower_ingress_type | lower == 'loadbalancer' and tower_loadbalancer_protocol | lower != 'https' %}
+    - port: {{ tower_loadbalancer_port }}
+      protocol: TCP
+      targetPort: 8052
+      name: http
 {% endif %}
   selector:
     app: '{{ deployment_type }}'


### PR DESCRIPTION
fixes #151

Amended the logic for the service template around the load balancer to include a missing default HTTP setup. I have also added the tower_loadbalancer_port reference into the logic which allows users to change the port if required.

The readme has also be updated to include extra information around the capabilities of the Load Balancer.