### PR TITLE
Added ability to specify LDAP CA cert

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ An [Ansible AWX](https://github.com/ansible/awx) operator for Kubernetes built w
          * [Deploying a specific version of AWX](#deploying-a-specific-version-of-awx)
          * [Privileged Tasks](#privileged-tasks)
          * [Containers Resource Requirements](#containers-resource-requirements)
+         * [LDAP Certificate Authority](#ldap-certificate-authority)
    * [Development](#development)
       * [Testing](#testing)
          * [Testing in Docker](#testing-in-docker)
@@ -312,6 +313,30 @@ spec:
     limits:
       cpu: 1000m
       memory: 2Gi
+```
+
+#### LDAP Certificate Authority
+
+If the variable `ldap_cacert_secret` is provided, the operator will look for a the data field `ldap-ca.crt` in the specified secret.
+
+| Name                             | Description                             | Default |
+| -------------------------------- | --------------------------------------- | --------|
+| ldap_cacert_secret               | LDAP Certificate Authority secret name  |  ''     |
+
+
+Example of customization could be:
+
+```yaml
+---
+spec:
+  ...
+  ldap_cacert_secret: <resourcename>-ldap-ca-cert
+```
+
+To create the secret, you can use the command below:
+
+```sh
+# kubectl create secret generic <resourcename>-ldap-ca-cert --from-file=ldap-ca.crt=<PATH/TO/YOUR/CA/PEM/FILE>
 ```
 
 ## Development

--- a/ansible/templates/crd.yml.j2
+++ b/ansible/templates/crd.yml.j2
@@ -242,6 +242,9 @@ spec:
                 development_mode:
                   description: If the deployment should be done in development mode
                   type: boolean
+                ldap_cacert_secret:
+                  description: Secret where can be found the LDAP trusted Certificate Authority Bundle
+                  type: string
               type: object
             status:
               properties:

--- a/deploy/awx-operator.yaml
+++ b/deploy/awx-operator.yaml
@@ -393,6 +393,9 @@ spec:
                 development_mode:
                   description: If the deployment should be done in development mode
                   type: boolean
+                ldap_cacert_secret:
+                  description: Secret where can be found the LDAP trusted Certificate Authority Bundle
+                  type: string
               type: object
             status:
               properties:

--- a/deploy/crds/awx_v1beta1_crd.yaml
+++ b/deploy/crds/awx_v1beta1_crd.yaml
@@ -242,6 +242,9 @@ spec:
                 development_mode:
                   description: If the deployment should be done in development mode
                   type: boolean
+                ldap_cacert_secret:
+                  description: Secret where can be found the LDAP trusted Certificate Authority Bundle
+                  type: string
               type: object
             status:
               properties:

--- a/deploy/olm-catalog/awx-operator/manifests/awx-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/awx-operator/manifests/awx-operator.clusterserviceversion.yaml
@@ -261,6 +261,11 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:hidden
+      - displayName: LDAP Certificate Authority Trust Bundle
+        path: ldap_cacert_secret
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:io.kubernetes:Secret
       - displayName: Tower Task Args
         path: tower_task_args
         x-descriptors:

--- a/deploy/olm-catalog/awx-operator/manifests/awx.ansible.com_awxs_crd.yaml
+++ b/deploy/olm-catalog/awx-operator/manifests/awx.ansible.com_awxs_crd.yaml
@@ -22,6 +22,9 @@ spec:
               ca_trust_bundle:
                 description: Path where the trusted CA bundle is available
                 type: string
+              ldap_cacert_secret:
+                 description: Secret where can be found the LDAP trusted Certificate Authority Bundle
+                 type: string
               deployment_type:
                 description: Name of the deployment type
                 type: string

--- a/roles/installer/defaults/main.yml
+++ b/roles/installer/defaults/main.yml
@@ -123,4 +123,8 @@ tower_postgres_configuration_secret: ''
 
 ca_trust_bundle: "/etc/pki/tls/certs/ca-bundle.crt"
 
+# Secret to lookup that provides the LDAP CACert trusted bundle
+#
+ldap_cacert_secret: ''
+
 development_mode: false

--- a/roles/installer/tasks/load_ldap_cacert_secret.yml
+++ b/roles/installer/tasks/load_ldap_cacert_secret.yml
@@ -1,0 +1,12 @@
+---
+- name: Retrieve LDAP CA Certificate Secret
+  community.kubernetes.k8s_info:
+    kind: Secret
+    namespace: '{{ meta.namespace }}'
+    name: '{{ ldap_cacert_secret }}'
+  register: ldap_cacert
+
+- name: Load LDAP CA Certificate Secret content
+  set_fact:
+    ldap_cacert_ca_crt: '{{ ldap_cacert["resources"][0]["data"]["ldap-ca.crt"] | b64decode }}'
+  when: '"ldap-ca.crt" in ldap_cacert["resources"][0]["data"]'

--- a/roles/installer/tasks/main.yml
+++ b/roles/installer/tasks/main.yml
@@ -2,6 +2,11 @@
 - name: Include secret key configuration tasks
   include_tasks: secret_key_configuration.yml
 
+- name: Load LDAP CAcert certificate
+  include_tasks: load_ldap_cacert_secret.yml
+  when:
+    - ldap_cacert_secret != ''
+
 - name: Include admin password configuration tasks
   include_tasks: admin_password_configuration.yml
 

--- a/roles/installer/templates/ldap.py.j2
+++ b/roles/installer/templates/ldap.py.j2
@@ -1,0 +1,6 @@
+AUTH_LDAP_GLOBAL_OPTIONS = {
+{% if ldap_cacert_secret %}
+    ldap.OPT_X_TLS_REQUIRE_CERT: True,
+    ldap.OPT_X_TLS_CACERTFILE: "/etc/openldap/certs/ldap-ca.crt"
+{% endif %}
+}

--- a/roles/installer/templates/ldap.py.j2
+++ b/roles/installer/templates/ldap.py.j2
@@ -1,5 +1,5 @@
 AUTH_LDAP_GLOBAL_OPTIONS = {
-{% if ldap_cacert_secret %}
+{% if ldap_cacert_ca_crt %}
     ldap.OPT_X_TLS_REQUIRE_CERT: True,
     ldap.OPT_X_TLS_CACERTFILE: "/etc/openldap/certs/ldap-ca.crt"
 {% endif %}

--- a/roles/installer/templates/tower_app_credentials.yaml.j2
+++ b/roles/installer/templates/tower_app_credentials.yaml.j2
@@ -8,3 +8,4 @@ metadata:
 data:
   credentials_py: "{{ lookup('template', 'credentials.py.j2') | b64encode }}"
   environment_sh: "{{ lookup('template', 'environment.sh.j2') | b64encode }}"
+  ldap_py: "{{ lookup('template', 'ldap.py.j2') | b64encode }}"

--- a/roles/installer/templates/tower_deployment.yaml.j2
+++ b/roles/installer/templates/tower_deployment.yaml.j2
@@ -58,6 +58,12 @@ spec:
               mountPath: "/etc/nginx/pki"
               readOnly: true
 {% endif %}
+{% if ldap_cacert_secret %}
+            - name: "{{ meta.name }}-ldap-cacert"
+              mountPath: /etc/openldap/certs/ldap-ca.crt
+              subPath: ldap-ca.crt
+              readOnly: true
+{% endif %}
             - name: "{{ secret_key_secret_name }}"
               mountPath: /etc/tower/SECRET_KEY
               subPath: SECRET_KEY
@@ -198,6 +204,14 @@ spec:
               - key: tls.crt
                 path: 'web.crt'
 {% endif %}
+{% if ldap_cacert_secret %}
+        - name: "{{ meta.name }}-ldap-cacert"
+          secret:
+            secretName: "{{ ldap_cacert_secret }}"
+            items:
+              - key: ldap-ca.crt
+                path: 'ldap-ca.crt'
+{% endif %}
         - name: "{{ meta.name }}-application-credentials"
           secret:
             secretName: "{{ meta.name }}-app-credentials"
@@ -206,6 +220,8 @@ spec:
                 path: 'credentials.py'
               - key: environment_sh
                 path: 'environment.sh'
+              - key: ldap_py
+                path: 'ldap.py'
         - name: "{{ secret_key_secret_name }}"
           secret:
             secretName: '{{ secret_key_secret_name }}'

--- a/roles/installer/templates/tower_deployment.yaml.j2
+++ b/roles/installer/templates/tower_deployment.yaml.j2
@@ -58,7 +58,7 @@ spec:
               mountPath: "/etc/nginx/pki"
               readOnly: true
 {% endif %}
-{% if ldap_cacert_secret %}
+{% if ldap_cacert_ca_crt %}
             - name: "{{ meta.name }}-ldap-cacert"
               mountPath: /etc/openldap/certs/ldap-ca.crt
               subPath: ldap-ca.crt
@@ -204,7 +204,7 @@ spec:
               - key: tls.crt
                 path: 'web.crt'
 {% endif %}
-{% if ldap_cacert_secret %}
+{% if ldap_cacert_ca_crt %}
         - name: "{{ meta.name }}-ldap-cacert"
           secret:
             secretName: "{{ ldap_cacert_secret }}"

--- a/roles/installer/vars/main.yml
+++ b/roles/installer/vars/main.yml
@@ -1,3 +1,4 @@
 ---
 postgres_initdb_args: '--auth-host=scram-sha-256'
 postgres_host_auth_method: 'scram-sha-256'
+ldap_cacert_ca_crt: ''


### PR DESCRIPTION
Fixes: #117

Introduces the ability to specify an LDAP Certificate Authority

- [x] - Tested deployment manually deployed
- [ ] - Testing via OLM manifest (UI)
- [x] - Documentation
Should we create a dedicated link on how to create the secret with ldap.cert contents?

```
kubectl create secret generic awx-ldap-ca-cert \
  --from-file=ldap-ca.crt=/etc/pki/ca-trust/source/anchors/Toca_Intermediate_CA.crt  --dry-run -o yaml
```

**Testing**

1. Updating operator
```diff
diff --git a/ansible/group_vars/all b/ansible/group_vars/all
index 0334822..0f9cf2a 100644
--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -1,3 +1,3 @@
-operator_image: quay.io/ansible/awx-operator
-operator_version: 0.7.0
+operator_image: registry.tatu.home/ansible/awx-operator
+operator_version: ldaps
 pull_policy: Always
diff --git a/deploy/awx-operator.yaml b/deploy/awx-operator.yaml
index 457793c..d56bcf3 100644
--- a/deploy/awx-operator.yaml
+++ b/deploy/awx-operator.yaml
@@ -122,7 +122,7 @@ spec:
       serviceAccountName: awx-operator
       containers:
         - name: awx-operator
-          image: "quay.io/ansible/awx-operator:0.7.0"
+         image: "registry.tatu.home/ansible/awx-operator:ldaps"
           imagePullPolicy: "Always"
           volumeMounts:
             - mountPath: /tmp/ansible-operator/runner
@@ -390,12 +390,12 @@ spec:
                 ca_trust_bundle:
                   description: Path where the trusted CA bundle is available
                   type: string
-                ldap_cacert_secret:
-                  description: Secret where can be found the LDAP trusted Certificate Authority Bundle
-                  type: string
                 development_mode:
                   description: If the deployment should be done in development mode
                   type: boolean
+                ldap_cacert_secret:
+                  description: Secret where can be found the LDAP trusted Certificate Authority Bundle
+                  type: string
               type: object
             status:
               properties:
```
* Image updated
```sh
kubectl get deployment awx-operator -o yaml | grep 'image: re'  
        image: registry.tatu.home/ansible/awx-operator:ldaps
```

2. Creating Secret
```sh
kubectl create secret generic awx-ldaps-ldap-ca-cert --from-file=ldap-ca.crt=/etc/pki/ca-trust/source/anchors/Toca_Intermediate_CA.crt 
secret/awx-ldaps-ldap-ca-cert created

kubectl describe secret awx-ldaps-ldap-ca-cert 
Name:         awx-ldaps-ldap-ca-cert
Namespace:    default
Labels:       <none>
Annotations:  <none>

Type:  Opaque

Data
====
ldap-ca.crt:  1899 bytes
```

3. Creating the `awx` kind
```yaml
---
apiVersion: awx.ansible.com/v1beta1
kind: AWX
metadata:
  name: awx-ldaps
spec:
  tower_admin_user: admin
  tower_admin_email: tchello.mello@gmail.com
  ldap_cacert_secret: awx-ldaps-ldap-ca-cert
```

4. Applying YAML
```sh
$ kubectl apply -f 04_awx-ldaps.yaml 
awx.awx.ansible.com/awx-ldaps created

$ kubectl get awx awx-ldaps -o yaml | kubectl neat 
apiVersion: awx.ansible.com/v1beta1
kind: AWX
metadata:
  name: awx-ldaps
  namespace: default
spec:
  ldap_cacert_secret: awx-ldaps-ldap-ca-cert
  tower_admin_email: tchello.mello@gmail.com
  tower_admin_user: admin
  tower_create_preload_data: true
  tower_garbage_collect_secrets: false
  tower_image_pull_policy: IfNotPresent
  tower_loadbalancer_port: 80
  tower_loadbalancer_protocol: http
  tower_replicas: 1
  tower_route_tls_termination_mechanism: Edge
  tower_task_privileged: false
```

5. Checking deployment
```sh
kubectl get  deploy/awx-ldaps
NAME        READY   UP-TO-DATE   AVAILABLE   AGE
awx-ldaps   1/1     1            1           10m

kubectl describe deploy/awx-ldaps  
Name:                   awx-ldaps
[....SNIP....]
    Mounts:
      /etc/nginx/nginx.conf from awx-ldaps-nginx-conf (ro,path="nginx.conf")
      /etc/openldap/certs/ldap-ca.crt from awx-ldaps-ldap-cacert (ro,path="ldap-ca.crt")
[....SNIP....]
  Volumes:
   awx-ldaps-ldap-cacert:
    Type:        Secret (a volume populated by a Secret)
    SecretName:  awx-ldaps-ldap-ca-cert
    Optional:    false
```

6. Checking mounted certificate and configuration
```sh
$ kubectl iexec awx-ldaps /bin/bash
Namespace: default | Pod: ✔ awx-ldaps-747645f9c-8w9qf
Container: ✔ awx-ldaps-web
bash-4.4$ ls -la /etc/openldap/certs/ldap-ca.crt 
-rw-r--r--. 1 root root 1899 Mar 30 01:45 /etc/openldap/certs/ldap-ca.crt

bash-4.4$ cat /etc/tower/conf.d/ldap.py 
AUTH_LDAP_GLOBAL_OPTIONS = {
    ldap.OPT_X_TLS_REQUIRE_CERT: True,
    ldap.OPT_X_TLS_CACERTFILE: "/etc/openldap/certs/ldap-ca.crt"
}

bash-4.4$ awx-manage shell_plus --quiet
Python 3.6.8 (default, Aug 24 2020, 17:57:11) 
[GCC 8.3.1 20191121 (Red Hat 8.3.1-5)] on linux
Type "help", "copyright", "credits" or "license" for more information.
(InteractiveConsole)
>>> settings.AUTH_LDAP_GLOBAL_OPTIONS
{24582: True, 24578: '/etc/openldap/certs/ldap-ca.crt'}

$ openssl  x509 -in /etc/openldap/certs/ldap-ca.crt -noout -text | head -n 5
Certificate:
    Data:
        Version: 3 (0x2)
        Serial Number: 1 (0x1)
        Signature Algorithm: sha256WithRSAEncryption
```