### PR TITLE
tower_admin_password_secret warning note @ docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,9 @@ There are three variables that are customizable for the admin user account creat
 | tower_admin_email           | Email of the admin user                      | test@example.com |
 | tower_admin_password_secret | Secret that contains the admin user password | Empty string     |
 
+
+> :warning: **tower_admin_password_secret must be a Kubernetes secret and not your text clear password**.
+
 If `tower_admin_password_secret` is not provided, the operator will look for a secret named `<resourcename>-admin-password` for the admin password. If it is not present, the operator will generate a password and create a Secret from it named `<resourcename>-admin-password`.
 
 To retrieve the admin password, run `kubectl get secret <resourcename>-admin-password -o jsonpath="{.data.password}" | base64 --decode`


### PR DESCRIPTION
Documentation is always welcome and this PR adds a small `warning`  note to emphasize the `tower_admin_password_secret` must be a k8s secret and not a `cleartext` password. 

I've seen this mistake twice already and then today when I saw issue #158, I believe we can make use of a `warning` note. 

![image](https://user-images.githubusercontent.com/809840/113082404-67fb7c80-91a8-11eb-89d4-96149a485196.png)


Related: #158 