### PR TITLE
Use k8s labels to create unique matchLabels for svc and deployments

### DIFF
--- a/molecule/default/asserts.yml
+++ b/molecule/default/asserts.yml
@@ -12,7 +12,10 @@
         kind: Pod
         namespace: example-awx
         label_selectors:
-          - app=awx
+          - "app.kubernetes.io/name=example-awx"
+          - "app.kubernetes.io/part-of=example-awx"
+          - "app.kubernetes.io/managed-by=awx-operator"
+          - "app.kubernetes.io/component=awx"
       register: tower_pods
 
     - name: Verify there is one AWX pod

--- a/molecule/test-local/converge.yml
+++ b/molecule/test-local/converge.yml
@@ -110,7 +110,7 @@
               kind="Deployment",
               api_version="apps/v1",
               namespace=custom_resource.metadata.namespace,
-              label_selector="app=awx")
+              label_selector="app.kubernetes.io/name=example-awx")
             }}'
 
         - name: get operator logs

--- a/molecule/test-minikube/converge.yml
+++ b/molecule/test-minikube/converge.yml
@@ -118,7 +118,7 @@
               kind="Deployment",
               api_version="apps/v1",
               namespace=custom_resource.metadata.namespace,
-              label_selector="app=awx")
+              label_selector="app.kubernetes.io/name=example-awx")
             }}'
 
         - name: get operator logs

--- a/roles/installer/tasks/main.yml
+++ b/roles/installer/tasks/main.yml
@@ -1,4 +1,8 @@
 ---
+- name: Get current version
+  set_fact:
+    tower_image_version: "{{ tower_image.split(':')[1] }}"
+
 - name: Include secret key configuration tasks
   include_tasks: secret_key_configuration.yml
 
@@ -46,7 +50,9 @@
     kind: Pod
     namespace: '{{ meta.namespace }}'
     label_selectors:
-      - "app={{ deployment_type }}"
+      - "app.kubernetes.io/name={{ meta.name }}"
+      - "app.kubernetes.io/managed-by=awx-operator"
+      - "app.kubernetes.io/component=awx"
   register: tower_pods
   until: "tower_pods['resources'][0]['status']['phase'] == 'Running'"
   delay: 5

--- a/roles/installer/tasks/migrate_data.yml
+++ b/roles/installer/tasks/migrate_data.yml
@@ -13,7 +13,7 @@
     kind: Pod
     namespace: '{{ meta.namespace }}'
     label_selectors:
-      - "app={{ meta.name }}-{{ deployment_type }}-postgres"
+      - "app.kubernetes.io/name={{ meta.name }}-postgres"
   register: postgres_pod
   until: "postgres_pod['resources'][0]['status']['phase'] == 'Running'"
   delay: 5

--- a/roles/installer/templates/tower_admin_password_secret.yaml.j2
+++ b/roles/installer/templates/tower_admin_password_secret.yaml.j2
@@ -4,5 +4,10 @@ kind: Secret
 metadata:
   name: '{{ meta.name }}-admin-password'
   namespace: '{{ meta.namespace }}'
+  labels:
+    app.kubernetes.io/name: '{{ meta.name }}'
+    app.kubernetes.io/part-of: '{{ meta.name }}'
+    app.kubernetes.io/managed-by: awx-operator
+    app.kubernetes.io/component: awx
 stringData:
   password: '{{ lookup('password', '/dev/null length=32 chars=ascii_letters,digits') }}'

--- a/roles/installer/templates/tower_app_credentials.yaml.j2
+++ b/roles/installer/templates/tower_app_credentials.yaml.j2
@@ -5,6 +5,11 @@ kind: Secret
 metadata:
   name: '{{ meta.name }}-app-credentials'
   namespace: '{{ meta.namespace }}'
+  labels:
+    app.kubernetes.io/name: '{{ meta.name }}'
+    app.kubernetes.io/part-of: '{{ meta.name }}'
+    app.kubernetes.io/managed-by: awx-operator
+    app.kubernetes.io/component: awx
 data:
   credentials_py: "{{ lookup('template', 'credentials.py.j2') | b64encode }}"
   environment_sh: "{{ lookup('template', 'environment.sh.j2') | b64encode }}"

--- a/roles/installer/templates/tower_broadcast_websocket_secret.yaml.j2
+++ b/roles/installer/templates/tower_broadcast_websocket_secret.yaml.j2
@@ -4,5 +4,10 @@ kind: Secret
 metadata:
   name: '{{ meta.name }}-broadcast-websocket'
   namespace: '{{ meta.namespace }}'
+  labels:
+    app.kubernetes.io/name: '{{ meta.name }}'
+    app.kubernetes.io/part-of: '{{ meta.name }}'
+    app.kubernetes.io/managed-by: awx-operator
+    app.kubernetes.io/component: awx
 stringData:
   secret: '{{ lookup('password', '/dev/null length=32 chars=ascii_letters,digits') }}'

--- a/roles/installer/templates/tower_config.yaml.j2
+++ b/roles/installer/templates/tower_config.yaml.j2
@@ -6,7 +6,10 @@ metadata:
   name: '{{ meta.name }}-{{ deployment_type }}-configmap'
   namespace: '{{ meta.namespace }}'
   labels:
-    app: '{{ deployment_type }}'
+    app.kubernetes.io/name: '{{ meta.name }}'
+    app.kubernetes.io/part-of: '{{ meta.name }}'
+    app.kubernetes.io/managed-by: awx-operator
+    app.kubernetes.io/component: awx
 data:
   environment: |
     AWX_SKIP_MIGRATIONS=true

--- a/roles/installer/templates/tower_deployment.yaml.j2
+++ b/roles/installer/templates/tower_deployment.yaml.j2
@@ -6,16 +6,26 @@ metadata:
   name: '{{ meta.name }}'
   namespace: '{{ meta.namespace }}'
   labels:
-    app: '{{ deployment_type }}'
+    app.kubernetes.io/name: '{{ meta.name }}'
+    app.kubernetes.io/version: '{{ tower_image_version }}'
+    app.kubernetes.io/part-of: '{{ meta.name }}'
+    app.kubernetes.io/managed-by: awx-operator
+    app.kubernetes.io/component: awx
 spec:
   replicas: {{ tower_replicas }}
   selector:
     matchLabels:
-      app: '{{ deployment_type }}'
+      app.kubernetes.io/name: '{{ meta.name }}'
+      app.kubernetes.io/managed-by: awx-operator
+      app.kubernetes.io/component: awx
   template:
     metadata:
       labels:
-        app: '{{ deployment_type }}'
+        app.kubernetes.io/name: '{{ meta.name }}'
+        app.kubernetes.io/version: '{{ tower_image_version }}'
+        app.kubernetes.io/part-of: '{{ meta.name }}'
+        app.kubernetes.io/managed-by: awx-operator
+        app.kubernetes.io/component: awx
     spec:
       serviceAccountName: '{{ meta.name }}'
 {% if tower_image_pull_secret %}

--- a/roles/installer/templates/tower_ingress.yaml.j2
+++ b/roles/installer/templates/tower_ingress.yaml.j2
@@ -5,6 +5,11 @@ kind: Ingress
 metadata:
   name: '{{ meta.name }}-ingress'
   namespace: '{{ meta.namespace }}'
+  labels:
+    app.kubernetes.io/name: '{{ meta.name }}'
+    app.kubernetes.io/part-of: '{{ meta.name }}'
+    app.kubernetes.io/managed-by: awx-operator
+    app.kubernetes.io/component: awx
 {% if tower_ingress_annotations %}
   annotations:
     {{ tower_ingress_annotations | indent(width=4) }}
@@ -33,6 +38,11 @@ kind: Route
 metadata:
   name: '{{ meta.name }}'
   namespace: '{{ meta.namespace }}'
+  labels:
+    app.kubernetes.io/name: '{{ meta.name }}'
+    app.kubernetes.io/part-of: '{{ meta.name }}'
+    app.kubernetes.io/managed-by: awx-operator
+    app.kubernetes.io/component: awx
 spec:
 {% if tower_route_host != '' %}
   host: {{ tower_route_host }}

--- a/roles/installer/templates/tower_postgres.yaml.j2
+++ b/roles/installer/templates/tower_postgres.yaml.j2
@@ -6,11 +6,16 @@ metadata:
   name: '{{ meta.name }}-postgres'
   namespace: '{{ meta.namespace }}'
   labels:
-    app: '{{ meta.name }}-{{ deployment_type }}-postgres'
+    app.kubernetes.io/name: '{{ meta.name }}-postgres'
+    app.kubernetes.io/part-of: '{{ meta.name }}'
+    app.kubernetes.io/managed-by: awx-operator
+    app.kubernetes.io/component: database
 spec:
   selector:
     matchLabels:
-      app: '{{ meta.name }}-{{ deployment_type }}-postgres'
+      app.kubernetes.io/name: '{{ meta.name }}-postgres'
+      app.kubernetes.io/managed-by: awx-operator
+      app.kubernetes.io/component: database
   serviceName: '{{ meta.name }}'
   replicas: 1
   updateStrategy:
@@ -18,7 +23,10 @@ spec:
   template:
     metadata:
       labels:
-        app: '{{ meta.name }}-{{ deployment_type }}-postgres'
+        app.kubernetes.io/name: '{{ meta.name }}-postgres'
+        app.kubernetes.io/part-of: '{{ meta.name }}'
+        app.kubernetes.io/managed-by: awx-operator
+        app.kubernetes.io/component: database
     spec:
       containers:
         - image: '{{ tower_postgres_image }}'
@@ -71,10 +79,15 @@ metadata:
   name: '{{ meta.name }}-postgres'
   namespace: '{{ meta.namespace }}'
   labels:
-    app: '{{ meta.name }}-{{ deployment_type }}-postgres'
+    app.kubernetes.io/name: '{{ meta.name }}-postgres'
+    app.kubernetes.io/part-of: '{{ meta.name }}'
+    app.kubernetes.io/managed-by: awx-operator
+    app.kubernetes.io/component: database
 spec:
   ports:
     - port: 5432
   clusterIP: None
   selector:
-    app: '{{ meta.name }}-{{ deployment_type }}-postgres'
+    app.kubernetes.io/name: '{{ meta.name }}-postgres'
+    app.kubernetes.io/managed-by: awx-operator
+    app.kubernetes.io/component: database

--- a/roles/installer/templates/tower_postgres_secret.yaml.j2
+++ b/roles/installer/templates/tower_postgres_secret.yaml.j2
@@ -5,6 +5,11 @@ kind: Secret
 metadata:
   name: '{{ meta.name }}-postgres-configuration'
   namespace: '{{ meta.namespace }}'
+  labels:
+    app.kubernetes.io/name: '{{ meta.name }}'
+    app.kubernetes.io/part-of: '{{ meta.name }}'
+    app.kubernetes.io/managed-by: awx-operator
+    app.kubernetes.io/component: awx
 stringData:
   password: '{{ lookup('password', '/dev/null length=32 chars=ascii_letters,digits') }}'
   username: '{{ database_username }}'

--- a/roles/installer/templates/tower_secret_key.yaml.j2
+++ b/roles/installer/templates/tower_secret_key.yaml.j2
@@ -4,5 +4,10 @@ kind: Secret
 metadata:
   name: '{{ meta.name }}-secret-key'
   namespace: '{{ meta.namespace }}'
+  labels:
+    app.kubernetes.io/name: '{{ meta.name }}'
+    app.kubernetes.io/part-of: '{{ meta.name }}'
+    app.kubernetes.io/managed-by: awx-operator
+    app.kubernetes.io/component: awx
 stringData:
   secret_key: '{{ lookup('password', '/dev/null length=32 chars=ascii_letters,digits') }}'

--- a/roles/installer/templates/tower_service.yaml.j2
+++ b/roles/installer/templates/tower_service.yaml.j2
@@ -5,7 +5,10 @@ metadata:
   name: '{{ meta.name }}-service'
   namespace: '{{ meta.namespace }}'
   labels:
-    app: '{{ deployment_type }}'
+    app.kubernetes.io/name: '{{ meta.name }}'
+    app.kubernetes.io/part-of: '{{ meta.name }}'
+    app.kubernetes.io/managed-by: awx-operator
+    app.kubernetes.io/component: awx
 {% if tower_ingress_type | lower == 'loadbalancer' %}
   annotations:
     {{ tower_loadbalancer_annotations | indent(width=4) }}
@@ -36,7 +39,9 @@ spec:
       name: http
 {% endif %}
   selector:
-    app: '{{ deployment_type }}'
+    app.kubernetes.io/name: '{{ meta.name }}'
+    app.kubernetes.io/managed-by: awx-operator
+    app.kubernetes.io/component: awx
 {% if tower_ingress_type | lower == "loadbalancer" %}
   type: LoadBalancer
 {% elif tower_ingress_type != "none" %}

--- a/roles/installer/templates/tower_service_account.yaml.j2
+++ b/roles/installer/templates/tower_service_account.yaml.j2
@@ -4,7 +4,11 @@ kind: ServiceAccount
 metadata:
   name: '{{ meta.name }}'
   namespace: '{{ meta.namespace }}'
-
+  labels:
+    app.kubernetes.io/name: '{{ meta.name }}'
+    app.kubernetes.io/part-of: '{{ meta.name }}'
+    app.kubernetes.io/managed-by: awx-operator
+    app.kubernetes.io/component: awx
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role


### PR DESCRIPTION
cc: @Spredzy  @shanemcd  @gamuniz - guys I think this is ready to roll. Let me know what you think! :+1: 

This PR introduces the ability to use `k8s` labels to create unique entries that identify `services`, `deployments`, `ingress`, and `statefulsets`. 

Using labels in this format also provides an extra advantage as some UI tools can map those labels on functional graphs or reports.

Fixes: #161 

## TODO
- [x]  Fix Molecule `unit-tests`
- External database
  - [x] Fresh install
  - [x] Operator idempotency after `rollout restart  deploy/awx-operator` 
- Managed database
  - [x] Fresh install
  - [x] Operator idempotency after `rollout restart  deploy/awx-operator` 
- [x]  Upgrade
- [x] Scaling

```sh
$ kubectl get awx 
NAME          AGE
awx-labels    74m
awx-testing   139m
```
Showing labels
```yaml
$ kubectl describe pod awx-labels-6d56b7c9dc-s8twd | grep 'Labels:' -A6
Labels:       app.kubernetes.io/component=awx
              app.kubernetes.io/managed-by=awx-operator
              app.kubernetes.io/name=awx-labels
              app.kubernetes.io/part-of=awx-labels
              app.kubernetes.io/version=18.0.0
              pod-template-hash=6d56b7c9dc
Annotations:  <none>

$ kubectl describe pod awx-testing-c7c95b484-qgm98  | grep 'Labels:' -A6
Labels:       app.kubernetes.io/component=awx
              app.kubernetes.io/managed-by=awx-operator
              app.kubernetes.io/name=awx-testing
              app.kubernetes.io/part-of=awx-testing
              app.kubernetes.io/version=18.0.0
              pod-template-hash=c7c95b484
```
Grabbing all service entries managed by the `awx-operator`

```yaml
$  kubectl get svc  -l "app.kubernetes.io/managed-by=awx-operator"
NAME                  TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)   AGE
awx-labels-service    ClusterIP   10.233.14.169   <none>        80/TCP    79m
awx-testing-service   ClusterIP   10.233.61.195   <none>        80/TCP    144m
```

So now the `svc` looks unique. 
```yaml
kubectl get svc  -l "app.kubernetes.io/managed-by=awx-operator,app.kubernetes.io/name=awx-labels" -o yaml | kubectl neat 
apiVersion: v1
items:
- apiVersion: v1
  kind: Service
  metadata:
    labels:
      app.kubernetes.io/component: awx
      app.kubernetes.io/managed-by: awx-operator
      app.kubernetes.io/name: awx-labels
      app.kubernetes.io/part-of: awx-labels
    name: awx-labels-service
    namespace: default
  spec:
    clusterIP: 10.233.14.169
    ports:
    - name: http
      port: 80
      targetPort: 8052
    selector:
      app.kubernetes.io/component: awx
      app.kubernetes.io/managed-by: awx-operator
      app.kubernetes.io/name: awx-labels
kind: List
metadata:
  resourceVersion: ""
  selfLink: ""
```

And if we look at the `selector` used in the `svc` entry, we get the expected pod. 

```yaml
$ kubectl get pods -l "app.kubernetes.io/component=awx,app.kubernetes.io/managed-by=awx-operator,app.kubernetes.io/name=awx-labels"
NAME                          READY   STATUS    RESTARTS   AGE
awx-labels-6d56b7c9dc-s8twd   4/4     Running   0          83m
```

Another cool feature is that we can select any resource managed by the `awx-operator` just apply the `labels` 

```yaml
$ kubectl get all -l  'app.kubernetes.io/managed-by=awx-operator' 
NAME                              READY   STATUS    RESTARTS   AGE
pod/awx-labels-6d56b7c9dc-s8twd   4/4     Running   0          88m
pod/awx-testing-c7c95b484-qgm98   4/4     Running   0          152m

NAME                          TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)   AGE
service/awx-labels-service    ClusterIP   10.233.14.169   <none>        80/TCP    88m
service/awx-testing-service   ClusterIP   10.233.61.195   <none>        80/TCP    152m

NAME                          READY   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/awx-labels    1/1     1            1           88m
deployment.apps/awx-testing   1/1     1            1           152m

NAME                                    DESIRED   CURRENT   READY   AGE
replicaset.apps/awx-labels-6d56b7c9dc   1         1         1       88m
replicaset.apps/awx-testing-c7c95b484   1         1         1       152m
```


#### Upgrading test notes
1. Specifying version
```yaml
apiVersion: awx.ansible.com/v1beta1
kind: AWX
metadata:
  name: awx-localdb2
  namespace: default
spec:
  tower_admin_user: admin
  tower_create_preload_data: true
  tower_garbage_collect_secrets: true
  tower_image: docker.io/ansible/awx:17.1.0
  tower_image_pull_policy: IfNotPresent
  tower_loadbalancer_port: 80
  tower_loadbalancer_protocol: http
  tower_replicas: 1
  tower_route_tls_termination_mechanism: Edge
  tower_task_privileged: false
```

2.  Checking deployment and pod status
```yaml
kubectl get pods  -l "app.kubernetes.io/component=awx" -w
NAME                           READY   STATUS    RESTARTS   AGE
awx-localdb2-7c5b9d8dc-bwh6b   4/4     Running   0          46s
awx-localdb2-postgres-0        1/1     Running   0          55s
```
3. Upgrading
```diff
 spec:
   tower_admin_user: admin
   tower_garbage_collect_secrets: true
-  tower_image: docker.io/ansible/awx:17.1.0
+  tower_image: quay.io/ansible/awx:18.0.0
 ---
 apiVersion: traefik.containo.us/v1alpha1
 kind: IngressRoute
```
4. Checking status
* Verifying DB service
```yaml
kubectl get svc awx-localdb2-postgres -o yaml | kubectl neat
apiVersion: v1
kind: Service
metadata:
  labels:
    app.kubernetes.io/component: database
    app.kubernetes.io/managed-by: awx-operator
    app.kubernetes.io/name: awx-localdb2-postgres
    app.kubernetes.io/part-of: awx-localdb2
  name: awx-localdb2-postgres
  namespace: default
spec:
  clusterIP: None
  ports:
  - port: 5432
  selector:
    app.kubernetes.io/component: database
    app.kubernetes.io/managed-by: awx-operator
    app.kubernetes.io/name: awx-localdb2-postgres
```
* Checking POD
```yaml
kubectl get pods -l "app.kubernetes.io/component=database,app.kubernetes.io/managed-by=awx-operator,app.kubernetes.io/name=awx-localdb2-postgres"
NAME                      READY   STATUS    RESTARTS   AGE
awx-localdb2-postgres-0   1/1     Running   0          53s
```
* Verifying AWX service
```yaml
kubectl get svc awx-localdb2-service -o yaml | kubectl neat 
apiVersion: v1
kind: Service
metadata:
  labels:
    app.kubernetes.io/component: awx
    app.kubernetes.io/managed-by: awx-operator
    app.kubernetes.io/name: awx-localdb2
    app.kubernetes.io/part-of: awx-localdb2
  name: awx-localdb2-service
  namespace: default
spec:
  clusterIP: 10.233.19.174
  ports:
  - name: http
    port: 80
    targetPort: 8052
  selector:
    app.kubernetes.io/component: awx
    app.kubernetes.io/managed-by: awx-operator
    app.kubernetes.io/name: awx-localdb2
```
* Checking POD
```yaml
kubectl get pods -l "app.kubernetes.io/component=awx,app.kubernetes.io/managed-by=awx-operator,app.kubernetes.io/name=awx-localdb2"
NAME                           READY   STATUS    RESTARTS   AGE
awx-localdb2-7ccdc5cbc-xf8p5   4/4     Running   0          3m16s
```

** Checking after scaling up 3 replicas
```yaml
kubectl -o wide get pods -l "app.kubernetes.io/component=awx,app.kubernetes.io/managed-by=awx-operator,app.kubernetes.io/name=awx-localdb2"
NAME                           READY   STATUS    RESTARTS   AGE     IP              NODE     NOMINATED NODE   READINESS GATES
awx-localdb2-7ccdc5cbc-52r44   4/4     Running   0          6s      10.233.65.214   t470n2   <none>           <none>
awx-localdb2-7ccdc5cbc-m85n5   4/4     Running   0          6s      10.233.69.199   p50      <none>           <none>
awx-localdb2-7ccdc5cbc-xf8p5   4/4     Running   0          5m57s   10.233.64.181   p70      <none>           <none>
```