### PR TITLE
fix wrong conf file for SUPERVISOR_WEB_CONFIG_PATH in kubernetes deployment file

### DIFF
--- a/roles/installer/templates/tower_deployment.yaml.j2
+++ b/roles/installer/templates/tower_deployment.yaml.j2
@@ -150,7 +150,7 @@ spec:
 {% endif %}
           env:
             - name: SUPERVISOR_WEB_CONFIG_PATH
-              value: "/supervisor.conf"
+              value: "/etc/supervisord_task.conf"
             - name: AWX_SKIP_MIGRATIONS
               value: "1"
             - name: MY_POD_UID

--- a/roles/installer/templates/tower_deployment.yaml.j2
+++ b/roles/installer/templates/tower_deployment.yaml.j2
@@ -150,7 +150,7 @@ spec:
 {% endif %}
           env:
             - name: SUPERVISOR_WEB_CONFIG_PATH
-              value: "/etc/supervisord_task.conf"
+              value: "/etc/supervisord.conf"
             - name: AWX_SKIP_MIGRATIONS
               value: "1"
             - name: MY_POD_UID


### PR DESCRIPTION
When a reload is issued it looks in the wrong configuration file, this is only referenced in the task container should it also be referenced in the web container maybe? 

AWX: https://github.com/ansible/awx/blob/9a61c4368784c421e47551e4175020ced116f56e/awx/main/utils/reload.py#L20

Operator: https://github.com/ansible/awx-operator/blob/210ac2c41955f96a4fa3f748b54879483d1bae62/roles/installer/templates/tower_deployment.yaml.j2#L152-L153

```
2021-04-03 11:17:54,377 DEBUG    [-] awx.main.utils.reload Issuing command to restart services, args=['supervisorctl', '-c', '/supervisor.conf', 'restart', 'tower-processes:awx-rsyslogd']
2021-04-03 11:17:54,513 ERROR    [-] awx.main.utils.reload supervisorctl restart awx-rsyslogd errored with exit code `2`, stdout:
```