### PR TITLE
Update GH Actions to run on push to devel

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [devel]
 
+  push:
+    branches: [devel]
+
 jobs:
   pull_request:
     runs-on: ubuntu-18.04

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AWX Operator
 
-[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) [![Build Status](https://travis-ci.org/ansible/awx-operator.svg?branch=devel)](https://travis-ci.org/ansible/awx-operator)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) [![Build Status](https://github.com/ansible/awx-operator/workflows/CI/badge.svg?event=push)](https://github.com/ansible/awx-operator/actions)
 
 An [Ansible AWX](https://github.com/ansible/awx) operator for Kubernetes built with [Operator SDK](https://github.com/operator-framework/operator-sdk) and Ansible.
 


### PR DESCRIPTION
Just realized that CI is only running on PR's to devel. This ensures that it also runs when something is pushed to devel (in cases where something is pushed directly). This also adds a badge to show the current status of the devel branch.