### PR TITLE
Fix data migrations when the database names do not match

### DIFF
--- a/roles/installer/tasks/migrate_data.yml
+++ b/roles/installer/tasks/migrate_data.yml
@@ -52,7 +52,7 @@
 - name: Set pg_restore command
   set_fact:
     psql_restore: >-
-      psql -U {{ awx_postgres_user }}
+      psql -U {{ database_username }}
       -d template1
       -p {{ awx_postgres_port }}
 


### PR DESCRIPTION
This is a follow-up to this: https://github.com/ansible/awx-operator/commit/0cc1190e3e9caa5396d50fa039bfada96ade4643

That broke data migrations in some cases, specifically when migrating from a db with user `tower` to one with user `awx`.  