### PR TITLE
Introducing ability to mount /var/lib/projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ An [Ansible AWX](https://github.com/ansible/awx) operator for Kubernetes built w
          * [Privileged Tasks](#privileged-tasks)
          * [Containers Resource Requirements](#containers-resource-requirements)
          * [LDAP Certificate Authority](#ldap-certificate-authority)
+         * [Persisting Projects Directory](#persisting-projects-directory)
    * [Development](#development)
       * [Testing](#testing)
          * [Testing in Docker](#testing-in-docker)
@@ -373,6 +374,29 @@ To create the secret, you can use the command below:
 
 ```sh
 # kubectl create secret generic <resourcename>-ldap-ca-cert --from-file=ldap-ca.crt=<PATH/TO/YOUR/CA/PEM/FILE>
+```
+
+#### Persisting Projects Directory
+
+In cases which you want to persist the `/var/lib/projects` directory, there are few variables that are customizable for the `awx-operator`.
+
+| Name                               | Description                                                                                          | Default        |
+| -----------------------------------| ---------------------------------------------------------------------------------------------------- | ---------------|
+| tower_projects_persistence         | Whether or not the /var/lib/projects directory will be persistent                                    |  false         |
+| tower_projects_storage_class       | Define the PersistentVolume storage class                                                            |  ''            |
+| tower_projects_storage_size        | Define the PersistentVolume size                                                                     |  8Gi           |
+| tower_projects_storage_access_mode | Define the PersistentVolume access mode                                                              |  ReadWriteMany |
+| tower_projects_existing_claim      | Define an existing PersistentVolumeClaim to use (cannot be combined with `tower_projects_storage_*`) |  ''            |
+
+Example of customization when the `awx-operator` automatically handles the persistent volume could be:
+
+```yaml
+---
+spec:
+  ...
+  tower_projects_persistence: true
+  tower_projects_storage_class: rook-ceph
+  tower_projects_storage_size: 20Gi
 ```
 
 ## Development

--- a/ansible/templates/crd.yml.j2
+++ b/ansible/templates/crd.yml.j2
@@ -258,6 +258,30 @@ spec:
                 ldap_cacert_secret:
                   description: Secret where can be found the LDAP trusted Certificate Authority Bundle
                   type: string
+                tower_projects_persistence:
+                  description: Whether or not the /var/lib/projects directory will be persistent
+                  default: false
+                  type: boolean
+                tower_projects_use_existing_claim:
+                  description: Using existing PersistentVolumeClaim
+                  type: string
+                  enum:
+                    - _Yes_
+                    - _No_
+                tower_projects_existing_claim:
+                  description: PersistentVolumeClaim to mount /var/lib/projects directory
+                  type: string
+                tower_projects_storage_class:
+                  description: Storage class for the /var/lib/projects PersistentVolumeClaim
+                  type: string
+                tower_projects_storage_size:
+                  description: Size for the /var/lib/projects PersistentVolumeClaim
+                  default: 8Gi
+                  type: string
+                tower_projects_storage_access_mode:
+                  description: AccessMode for the /var/lib/projects PersistentVolumeClaim
+                  default: ReadWriteMany
+                  type: string
               type: object
             status:
               properties:

--- a/deploy/awx-operator.yaml
+++ b/deploy/awx-operator.yaml
@@ -409,6 +409,30 @@ spec:
                 ldap_cacert_secret:
                   description: Secret where can be found the LDAP trusted Certificate Authority Bundle
                   type: string
+                tower_projects_persistence:
+                  description: Whether or not the /var/lib/projects directory will be persistent
+                  default: false
+                  type: boolean
+                tower_projects_use_existing_claim:
+                  description: Using existing PersistentVolumeClaim
+                  type: string
+                  enum:
+                    - _Yes_
+                    - _No_
+                tower_projects_existing_claim:
+                  description: PersistentVolumeClaim to mount /var/lib/projects directory
+                  type: string
+                tower_projects_storage_class:
+                  description: Storage class for the /var/lib/projects PersistentVolumeClaim
+                  type: string
+                tower_projects_storage_size:
+                  description: Size for the /var/lib/projects PersistentVolumeClaim
+                  default: 8Gi
+                  type: string
+                tower_projects_storage_access_mode:
+                  description: AccessMode for the /var/lib/projects PersistentVolumeClaim
+                  default: ReadWriteMany
+                  type: string
               type: object
             status:
               properties:

--- a/deploy/crds/awx_v1beta1_crd.yaml
+++ b/deploy/crds/awx_v1beta1_crd.yaml
@@ -258,6 +258,30 @@ spec:
                 ldap_cacert_secret:
                   description: Secret where can be found the LDAP trusted Certificate Authority Bundle
                   type: string
+                tower_projects_persistence:
+                  description: Whether or not the /var/lib/projects directory will be persistent
+                  default: false
+                  type: boolean
+                tower_projects_use_existing_claim:
+                  description: Using existing PersistentVolumeClaim
+                  type: string
+                  enum:
+                    - _Yes_
+                    - _No_
+                tower_projects_existing_claim:
+                  description: PersistentVolumeClaim to mount /var/lib/projects directory
+                  type: string
+                tower_projects_storage_class:
+                  description: Storage class for the /var/lib/projects PersistentVolumeClaim
+                  type: string
+                tower_projects_storage_size:
+                  description: Size for the /var/lib/projects PersistentVolumeClaim
+                  default: 8Gi
+                  type: string
+                tower_projects_storage_access_mode:
+                  description: AccessMode for the /var/lib/projects PersistentVolumeClaim
+                  default: ReadWriteMany
+                  type: string
               type: object
             status:
               properties:

--- a/deploy/olm-catalog/awx-operator/manifests/awx-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/awx-operator/manifests/awx-operator.clusterserviceversion.yaml
@@ -260,7 +260,7 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:fieldDependency:tower_projects_use_existing_claim:_Yes_
-        - urn:alm:descriptor:com.tectonic.ui:select:persistent-claim
+        - urn:alm:descriptor:io.kubernetes:PersistentVolumeClaim
       - displayName: Tower Projects Storage Class Name
         description: Tower Projects Storage Class Name. If not present, the default storage class will be used.
         path: tower_projects_storage_class

--- a/deploy/olm-catalog/awx-operator/manifests/awx-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/awx-operator/manifests/awx-operator.clusterserviceversion.yaml
@@ -243,6 +243,45 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:hidden
+      - displayName: Enable persistence for /var/lib/projects directory?
+        path: tower_projects_persistence
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - displayName: Use existing Persistent Claim?
+        path: tower_projects_use_existing_claim
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:select:_Yes_
+        - urn:alm:descriptor:com.tectonic.ui:select:_No_
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:tower_projects_persistence:true
+      - displayName: Tower Projects Existing Persistent Claim
+        path: tower_projects_existing_claim
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:tower_projects_use_existing_claim:_Yes_
+        - urn:alm:descriptor:com.tectonic.ui:select:persistent-claim
+      - displayName: Tower Projects Storage Class Name
+        description: Tower Projects Storage Class Name. If not present, the default storage class will be used.
+        path: tower_projects_storage_class
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:tower_projects_use_existing_claim:_No_
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - displayName: Tower Projects Storage Size
+        description: Tower Projects Storage Size
+        path: tower_projects_storage_size
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:tower_projects_use_existing_claim:_No_
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - displayName: Tower Projects Storage Access Mode
+        description: Tower Projects Storage Access Mode
+        path: tower_projects_storage_access_mode
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:tower_projects_use_existing_claim:_No_
+        - urn:alm:descriptor:com.tectonic.ui:text
       - displayName: Tower Task Command
         path: tower_task_command
         x-descriptors:

--- a/deploy/olm-catalog/awx-operator/manifests/awx.ansible.com_awxs_crd.yaml
+++ b/deploy/olm-catalog/awx-operator/manifests/awx.ansible.com_awxs_crd.yaml
@@ -32,6 +32,30 @@ spec:
                 description: Secret where can be found the LDAP trusted Certificate
                   Authority Bundle
                 type: string
+              tower_projects_persistence:
+                description: Whether or not the /var/lib/projects directory will be persistent
+                default: false
+                type: boolean
+              tower_projects_use_existing_claim:
+                description: Using existing PersistentVolumeClaim
+                type: string
+                enum:
+                  - _Yes_
+                  - _No_
+              tower_projects_existing_claim:
+                description: PersistentVolumeClaim to mount /var/lib/projects directory
+                type: string
+              tower_projects_storage_class:
+                description: Storage class for the /var/lib/projects PersistentVolumeClaim
+                type: string
+              tower_projects_storage_size:
+                description: Size for the /var/lib/projects PersistentVolumeClaim
+                default: 8Gi
+                type: string
+              tower_projects_storage_access_mode:
+                description: AccessMode for the /var/lib/projects PersistentVolumeClaim
+                default: ReadWriteMany
+                type: string
               tower_admin_email:
                 description: The admin user email
                 type: string

--- a/roles/installer/defaults/main.yml
+++ b/roles/installer/defaults/main.yml
@@ -136,6 +136,19 @@ tower_postgres_resource_requirements:
 tower_postgres_storage_class: ''
 tower_postgres_data_path: '/var/lib/postgresql/data/pgdata'
 
+# Persistence to the AWX project data folder
+# Whether or not the /var/lib/projects directory will be persistent
+tower_projects_persistence: false
+#
+# Define an existing PersistentVolumeClaim to use
+tower_projects_existing_claim: ''
+#
+# Define the storage_class, size and access_mode
+# when not using an existing claim
+tower_projects_storage_class: ''
+tower_projects_storage_size: 8Gi
+tower_projects_storage_access_mode: ReadWriteMany
+
 # Secret to lookup that provide the PostgreSQL configuration
 #
 tower_postgres_configuration_secret: ''

--- a/roles/installer/tasks/main.yml
+++ b/roles/installer/tasks/main.yml
@@ -41,6 +41,7 @@
   loop:
     - 'tower_app_credentials'
     - 'tower_service_account'
+    - 'tower_persistent'
     - 'tower_deployment'
     - 'tower_service'
     - 'tower_ingress'

--- a/roles/installer/templates/tower_deployment.yaml.j2
+++ b/roles/installer/templates/tower_deployment.yaml.j2
@@ -283,7 +283,16 @@ spec:
               - key: receptor_conf
                 path: receptor.conf
         - name: "{{ meta.name }}-projects"
+{% if tower_projects_persistence|bool %}
+          persistentVolumeClaim:
+{% if tower_projects_existing_claim %}
+            claimName: {{ tower_projects_existing_claim }}
+{% else %}
+            claimName: '{{ meta.name }}-projects-claim'
+{% endif %}
+{% else %}
           emptyDir: {}
+{% endif %}
 {% if development_mode | bool %}
         - name: awx-devel
           hostPath:

--- a/roles/installer/templates/tower_persistent.yaml.j2
+++ b/roles/installer/templates/tower_persistent.yaml.j2
@@ -1,0 +1,21 @@
+{% if tower_projects_persistence|bool and tower_projects_existing_claim == '' %}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: '{{ meta.name }}-projects-claim'
+  namespace: '{{ meta.namespace }}'
+  labels:
+   app.kubernetes.io/name: '{{ meta.name }}'
+   app.kubernetes.io/part-of: '{{ meta.name }}'
+   app.kubernetes.io/managed-by: awx-operator
+   app.kubernetes.io/component: awx
+spec:
+  accessModes:
+    - {{ tower_projects_storage_access_mode }}
+  resources:
+    requests:
+      storage: {{ tower_projects_storage_size }}
+{% if tower_projects_storage_class != '' %}
+  storageClassName: {{ tower_projects_storage_class }}
+{% endif %}
+{% endif %}

--- a/roles/installer/vars/main.yml
+++ b/roles/installer/vars/main.yml
@@ -2,3 +2,4 @@
 postgres_initdb_args: '--auth-host=scram-sha-256'
 postgres_host_auth_method: 'scram-sha-256'
 ldap_cacert_ca_crt: ''
+tower_projects_existing_claim: ''


### PR DESCRIPTION
cc: @Spredzy @shanemcd @gamuniz

Fixes: #46

This PR allows the user to specify an existing `PersistentVolumeClaim`  or dispatch the creating via the `awx-operator`. 

*Using an existing pvc*
```yaml
spec:
 ...
  tower_projects_persistence: true
  tower_projects_existing_claim: awx-projects-claim-manual
```

*Using an pvc created by the `awx-operator`*
```yaml
apiVersion: awx.ansible.com/v1beta1
kind: AWX
metadata:
  name: awx-persistent
spec:
  tower_projects_persistence: true
  tower_projects_storage_size: 20Gi
  tower_projects_storage_class: nfs-toca
```
```bash
$ kubectl get pvc -l "app.kubernetes.io/managed-by=awx-operator,app.kubernetes.io/name=awx-persistent"
NAME                                   STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
awx-persistent-projects-claim          Bound    pvc-fa0c0f2f-c5e6-4bc5-b8fe-f129f65b1d4f   20Gi       RWX            nfs-toca       53m
```

**Tested scenarios**
- [x] Without persistence :+1: 
- [x] With persistence using an existing claim :+1: 
- [x] With persistence handled by `awx-operator`

_Note_: This does not include the `pvc` garbage collector yet as we are discussing a global way to do it for all `pvc`  resources managed by the `awx-operator`. 

**WebUI**

Decided to modify the PR a little bit to enhance the selection in the UI form. 

![image](https://user-images.githubusercontent.com/809840/113739619-f81c5300-96cd-11eb-82d9-98997c969a2a.png)

Then the user will have 2 options:

![image](https://user-images.githubusercontent.com/809840/113748671-cb206e00-96d6-11eb-8a2c-c79f8c01f289.png)

When **Yes**, then a pre-existing pvc must be selected

![image](https://user-images.githubusercontent.com/809840/113803598-dbfacf00-972a-11eb-9607-11e70c5e34f9.png)

When **No**, then the PVC will be created with the information below


![image](https://user-images.githubusercontent.com/809840/113748740-db384d80-96d6-11eb-9392-b5060778a762.png)
