### PR TITLE
Added expected labels to AWX kind

### DIFF
--- a/molecule/default/asserts.yml
+++ b/molecule/default/asserts.yml
@@ -7,6 +7,22 @@
     ansible_python_interpreter: '{{ ansible_playbook_python }}'
 
   tasks:
+    - name: Get AWX Kind data
+      k8s_info:
+        api_version: awx.ansible.com/v1beta1
+        kind: AWX
+        namespace: example-awx
+        label_selectors:
+          - "app.kubernetes.io/name=example-awx"
+          - "app.kubernetes.io/part-of=example-awx"
+          - "app.kubernetes.io/managed-by=awx-operator"
+          - "app.kubernetes.io/component=awx"
+      register: awx_kind
+
+    - name: Verify there is one AWX kind
+      assert:
+        that: '{{ (awx_kind.resources | length) == 1 }}'
+
     - name: Get AWX Pod data
       k8s_info:
         kind: Pod

--- a/roles/installer/tasks/main.yml
+++ b/roles/installer/tasks/main.yml
@@ -1,4 +1,21 @@
 ---
+- name: Patching labels to AWX kind
+  k8s:
+    state: present
+    definition:
+      apiVersion: awx.ansible.com/v1beta1
+      kind: AWX
+      name: '{{ meta.name }}'
+      namespace: '{{ meta.namespace }}'
+      metadata:
+        name: '{{ meta.name }}'
+        namespace: '{{ meta.namespace }}'
+        labels:
+          app.kubernetes.io/name: '{{ meta.name }}'
+          app.kubernetes.io/part-of: '{{ meta.name }}'
+          app.kubernetes.io/managed-by: awx-operator
+          app.kubernetes.io/component: awx
+
 - name: Get current version
   set_fact:
     tower_image_version: "{{ tower_image.split(':')[1] }}"


### PR DESCRIPTION
cc: @gamuniz  @shanemcd @Spredzy 

This is a follow-up PR from https://github.com/ansible/awx-operator/commit/185238c199ee3319796970c0f0121a23b9812963  so the `AWX` kind can also use the labels used elsewhere. 

![image](https://user-images.githubusercontent.com/809840/113811061-84179480-9739-11eb-8f6f-98a3bf76a5c6.png)

**Sweet**
![image](https://user-images.githubusercontent.com/809840/113916156-a64afa00-97ad-11eb-8910-443f6e59659a.png)



```yaml
kubectl get awx -l "app.kubernetes.io/name=awx-toca"  
NAME       AGE
awx-toca   71m
```

```yaml
kubectl describe awx awx-toca
Name:         awx-toca
Namespace:    default
Labels:       app.kubernetes.io/component=awx
              app.kubernetes.io/managed-by=awx-operator
              app.kubernetes.io/name=awx-toca
              app.kubernetes.io/part-of=awx-toca
Annotations:  <none>
API Version:  awx.ansible.com/v1beta1
Kind:         AWX
Metadata:
  Creation Timestamp:  2021-04-07T03:30:59Z
  Finalizers:
    finalizer.awx.ansible.com
  Generation:  1
  [.....]
  Resource Version:  160128722
  Self Link:         /apis/awx.ansible.com/v1beta1/namespaces/default/awxs/awx-toca
  UID:               e0d5fa85-6b28-40c6-a5a0-f45c828bbe77
Spec:
  ldap_cacert_secret:                     awx-toca-ldap-ca-cert
  tower_admin_email:                      tchello.mello@gmail.com
  tower_admin_password_secret:            awx-toca-admin-password
  tower_admin_user:                       admin
  tower_create_preload_data:              true
  tower_garbage_collect_secrets:          true
  tower_hostname:                         tower.tatu.home
  tower_image_pull_policy:                IfNotPresent
  tower_loadbalancer_port:                80
  tower_loadbalancer_protocol:            http
  tower_projects_persistence:             true
  tower_projects_storage_access_mode:     ReadWriteMany
  tower_projects_storage_class:           toca-rook-ceph-filesystem
  tower_projects_storage_size:            12Gi
  tower_replicas:                         1
  tower_route_tls_termination_mechanism:  Edge
  tower_task_privileged:                  false
  tower_task_resource_requirements:
    Limits:
      Cpu:     1000m
      Memory:  2Gi
    Requests:
      Cpu:     500m
      Memory:  1Gi
  tower_web_resource_requirements:
    Limits:
      Cpu:     2000m
      Memory:  4Gi
    Requests:
      Cpu:     1000m
      Memory:  2Gi
Status:
  Conditions:
    Last Transition Time:       2021-04-07T03:30:59Z
    Reason:                     Successful
    Status:                     True
    Type:                       Running
  Tower Admin Password Secret:  awx-toca-admin-password
  Tower Admin User:             admin
  Tower Image:                  quay.io/ansible/awx:18.0.0
  Tower Version:                18.0.0
Events:                         <none>
```