### PR TITLE
add tower_image_pull_secret as property of AWX resource

### DIFF
--- a/ansible/templates/crd.yml.j2
+++ b/ansible/templates/crd.yml.j2
@@ -134,6 +134,9 @@ spec:
                     - never
                     - IfNotPresent
                     - ifnotpresent
+                tower_image_pull_secret:
+                  description: The image pull secret
+                  type: string
                 tower_task_resource_requirements:
                   description: Resource requirements for the task container
                   properties:

--- a/deploy/awx-operator.yaml
+++ b/deploy/awx-operator.yaml
@@ -285,6 +285,9 @@ spec:
                     - never
                     - IfNotPresent
                     - ifnotpresent
+                tower_image_pull_secret:
+                  description: The image pull secret
+                  type: string
                 tower_task_resource_requirements:
                   description: Resource requirements for the task container
                   properties:

--- a/deploy/crds/awx_v1beta1_crd.yaml
+++ b/deploy/crds/awx_v1beta1_crd.yaml
@@ -134,6 +134,9 @@ spec:
                     - never
                     - IfNotPresent
                     - ifnotpresent
+                tower_image_pull_secret:
+                  description: The image pull secret
+                  type: string
                 tower_task_resource_requirements:
                   description: Resource requirements for the task container
                   properties:

--- a/deploy/olm-catalog/awx-operator/manifests/awx-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/awx-operator/manifests/awx-operator.clusterserviceversion.yaml
@@ -155,6 +155,11 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:imagePullPolicy
+      - displayName: Image Pull Secret
+        path: tower_image_pull_secret
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:imagePullSecret
       - displayName: Web container resource requirements
         path: tower_web_resource_requirements
         x-descriptors:

--- a/deploy/olm-catalog/awx-operator/manifests/awx.ansible.com_awxs_crd.yaml
+++ b/deploy/olm-catalog/awx-operator/manifests/awx.ansible.com_awxs_crd.yaml
@@ -108,6 +108,9 @@ spec:
                 - IfNotPresent
                 - ifnotpresent
                 type: string
+              tower_image_pull_secret:
+                description: The image pull secret
+                type: string
               tower_ingress_annotations:
                 description: Annotations to add to the ingress
                 type: string


### PR DESCRIPTION
fixes #183 
Tested with manually applying a awx resource with the new property "tower_image_pull_secret" set.
The secret of Type kubernetes.io/dockerconfigjson was correctly listed in the resulting deployment.
And pulling an AWX image from a private Registry was possible.