### PR TITLE
Added build.sh to facilitate local tests

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+## This script will be build 3 images awx-{operator,bundle,catalog}
+## and push to the $REGISTRY specified.
+##
+## The goal is provide an quick way to build a test image.
+##
+## Example:
+##
+## git clone https://github.com/ansible/awx-operator.git
+## cd awx-operator
+## REGISTRY=registry.example.com/ansible TAG=mytag scripts/build.sh
+##
+## As a result, the $REGISTRY will be populated with 2 images
+## registry.example.com/ansible/awx-operator:mytag
+## registry.example.com/ansible/awx-operator-bundle:mytag
+## registry.example.com/ansible/awx-operator-catalog:mytag
+
+OPERATOR_IMAGE=${OPERATOR_IMAGE:-awx-operator}
+BUNDLE_IMAGE=${BUNDLE_IMAGE:-awx-operator-bundle}
+CATALOG_IMAGE=${CATALOG_IMAGE:-awx-operator-catalog}
+
+verify_podman_binary() {
+  if hash podman 2>/dev/null; then
+      POD_MANAGER="podman"
+  else
+      POD_MANAGER="docker"
+  fi
+}
+
+verify_operator_sdk_binary() {
+  if hash operator-sdk 2>/dev/null; then
+      OPERATOR_SDK="$(which operator-sdk)"
+  else
+      echo "operator-sdk binary not found."
+      echo "Please visit https://sdk.operatorframework.io/docs/building-operators/ansible/installation"
+      exit 1
+  fi
+}
+
+verify_opm_binary() {
+  if hash opm 2>/dev/null; then
+      OPM_BINARY="$(which opm)"
+  else
+      echo "opm binary not found."
+      echo "Please visit https://github.com/operator-framework/operator-registry/releases"
+      exit 1
+  fi
+}
+
+prepare_local_deploy() {
+    echo "operator_image: $REGISTRY/$OPERATOR_IMAGE" > ansible/group_vars/all
+    echo "operator_version: $TAG" >> ansible/group_vars/all
+    echo "pull_policy: Always" >> ansible/group_vars/all
+    ansible-playbook ansible/chain-operator-files.yml
+}
+
+
+REGISTRY=${REGISTRY:-''}
+if [[ -z "$REGISTRY" ]]; then
+    echo "Set your \$REGISTRY variable to your registry server."
+    echo "export REGISTRY=quay.io/ansible"
+    exit 1
+fi
+
+TAG=${TAG:-''}
+if [[ -z "$TAG" ]]; then
+    echo "Set your \$TAG variable to your registry server."
+    echo "export TAG=mytag"
+    exit 1
+fi
+
+build_operator_image() {
+  echo "Building and pushing $OPERATOR_IMAGE image"
+  $POD_MANAGER build . -f build/Dockerfile -t $REGISTRY/$OPERATOR_IMAGE:$TAG
+  $POD_MANAGER push $REGISTRY/$OPERATOR_IMAGE:$TAG
+}
+
+build_bundle_image() {
+  echo "Building and pushing $BUNDLE_IMAGE image"
+  $POD_MANAGER build . -f bundle.Dockerfile -t $REGISTRY/$BUNDLE_IMAGE:$TAG
+  $POD_MANAGER push $REGISTRY/$BUNDLE_IMAGE:$TAG
+}
+
+build_catalog_image() {
+  echo "Building and pushing $CATALOG_IMAGE image"
+  $OPM_BINARY index add --bundles $REGISTRY/$BUNDLE_IMAGE:$TAG --tag $REGISTRY/$CATALOG_IMAGE:$TAG
+  $POD_MANAGER push $REGISTRY/$CATALOG_IMAGE:$TAG
+}
+
+generate_catalogsource_yaml() {
+  echo "Creating CatalogSource YAML"
+  cat > catalogsource.yaml << EOF
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: awx-operator
+  namespace: operators
+spec:
+  displayName: 'Ansible AWX Operator'
+  image: "$REGISTRY/$CATALOG_IMAGE:$TAG"
+  publisher: 'Ansible AWX Operator'
+  sourceType: grpc
+EOF
+
+  echo "Now run: 'kubectl apply -f catalogsource.yaml' to update the operator"
+  echo "Happy testing!"
+}
+
+verify_podman_binary
+verify_operator_sdk_binary
+verify_opm_binary
+prepare_local_deploy
+build_operator_image
+build_bundle_image
+build_catalog_image
+generate_catalogsource_yaml


### PR DESCRIPTION
I think I built the so many times the image to test lately, that this script will be handy for local tests. 

It will basically create the 3 images and the `CatalogSource` to play with it. 

I hope this becomes helpful to others as well.


```sh
REGISTRY=registry.tatu.home/ansible TAG=add_labels_to_awx_kind scripts/build.sh

PLAY [Chain operator files together for easy deployment.] *************************************************
Wednesday 07 April 2021  16:39:34 -0400 (0:00:00.015)       0:00:00.015 ******* 

TASK [Template CRD] ***************************************************************************************
[DEPRECATION WARNING]: Distribution fedora 34 on host localhost should use /usr/bin/python3, but is using 
/usr/bin/python for backward compatibility with prior Ansible releases. A future Ansible release will 
default to using the discovered platform python for this host. See 
https://docs.ansible.com/ansible/2.9/reference_appendices/interpreter_discovery.html for more information.
 This feature will be removed in version 2.12. Deprecation warnings can be disabled by setting 
deprecation_warnings=False in ansible.cfg.
ok: [localhost]
Wednesday 07 April 2021  16:39:34 -0400 (0:00:00.708)       0:00:00.723 ******* 

TASK [Template awx-operator.yaml] *************************************************************************
changed: [localhost]

PLAY RECAP ************************************************************************************************
localhost                  : ok=2    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   

Wednesday 07 April 2021  16:39:35 -0400 (0:00:00.519)       0:00:01.243 ******* 
=============================================================================== 
Template CRD --------------------------------------------------------------------------------------- 0.71s
Template awx-operator.yaml ------------------------------------------------------------------------- 0.52s
Building and pushing awx-operator image
STEP 1: FROM quay.io/operator-framework/ansible-operator:v0.19.4
STEP 2: COPY requirements.yml ${HOME}/requirements.yml
--> Using cache 1944b8b80c25f49a6f6241449fce03c5f7e1296cd1e039a3f7b7c8f8257a39a8
--> 1944b8b80c2
STEP 3: RUN ansible-galaxy collection install -r ${HOME}/requirements.yml  && chmod -R ug+rwx ${HOME}/.ansible
--> Using cache 15cd67655ebfad80d9fa9fa99f6d92cadd0adc2672dde3f21611125d5c94387a
--> 15cd67655eb
STEP 4: COPY watches.yaml ${HOME}/watches.yaml
--> Using cache 3cbd1c2a245d58da0d0e0043a6d00640c29b344304b01cd043fb6a0d7f37eb33
--> 3cbd1c2a245
STEP 5: COPY main.yml ${HOME}/main.yml
--> Using cache 2cdaee08fbf8a071c25c422253791eea3d92a6696ee4841d051653a6414c1d71
--> 2cdaee08fbf
STEP 6: COPY roles/ ${HOME}/roles/
--> Using cache 3ad460d5bed5457fa79f7a69cd4f1c583f7e34f0acc21c1c9641604dc2700d74
STEP 7: COMMIT registry.tatu.home/ansible/awx-operator:add_labels_to_awx_kind
--> 3ad460d5bed
3ad460d5bed5457fa79f7a69cd4f1c583f7e34f0acc21c1c9641604dc2700d74
Getting image source signatures
Copying blob b7b591e3443f skipped: already exists  
Copying blob 230bd8545fdb skipped: already exists  
Copying blob 4c6b9a282251 skipped: already exists  
Copying blob ccf04fbd6e19 skipped: already exists  
Copying blob ac2e73452624 skipped: already exists  
Copying blob 99cf45bcfc1b skipped: already exists  
Copying blob 23add9b2776b skipped: already exists  
Copying blob d07ef24f0163 skipped: already exists  
Copying blob 4f8355a93c34 skipped: already exists  
Copying blob d03ca2fb81a3 skipped: already exists  
Copying blob 95583591e541 skipped: already exists  
Copying blob 2871b8555d37 skipped: already exists  
Copying blob 587f8c95b8c7 skipped: already exists  
Copying blob 77a3aee29bd5 [--------------------------------------] 0.0b / 0.0b
Copying config 3ad460d5be [======================================] 6.3KiB / 6.3KiB
Writing manifest to image destination
Storing signatures
Building and pushing awx-operator-bundle image
STEP 1: FROM scratch
STEP 2: LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
--> Using cache 394f04916db4b8e581781d77eb6daf0efba20f9d8a732a6515d70a60a2132666
--> 394f04916db
STEP 3: LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
--> Using cache bf06b8c6b6271fc047e9b0ab98fc53da6f025c798d54255ba2d6d9eb843ace87
--> bf06b8c6b62
STEP 4: LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
--> Using cache f7a109f7eb6816c7b0873b480d1f0dd819195902e5304c922544f9dfdad21dde
--> f7a109f7eb6
STEP 5: LABEL operators.operatorframework.io.bundle.package.v1=awx-operator
--> Using cache 2a72d051dcb37eb562d1b9a7025154e6e9e73adf2e54e565d13bea5811d95acd
--> 2a72d051dcb
STEP 6: LABEL operators.operatorframework.io.bundle.channels.v1=alpha
--> Using cache 4ae20882c2447d68ce87e1b121474291d401aaee9b922319386c8fe5ef480bca
--> 4ae20882c24
STEP 7: LABEL operators.operatorframework.io.bundle.channel.default.v1=alpha
--> Using cache 4be5bbb9a6ec5a5e51c688243e6cd9c4117988f5b67701c6f7196191e0b0a298
--> 4be5bbb9a6e
STEP 8: LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
--> Using cache d5bf8d5d9d997b08f33e4f402609a165ce262a70ac185eeb96ac44beb3e6928e
--> d5bf8d5d9d9
STEP 9: LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v0.19.4
--> Using cache 5bafd646a9b145bc882a2d9d1316cc6294b5976736e11dae7168f9d67c10c400
--> 5bafd646a9b
STEP 10: LABEL operators.operatorframework.io.metrics.project_layout=ansible
--> Using cache 16b9857e3104327e5304221b835a645ea80cab6780cea30daaa4897d9ebb1fc2
--> 16b9857e310
STEP 11: COPY deploy/olm-catalog/awx-operator/manifests /manifests/
--> Using cache 90c16ab260046ce7d96b864b223361ddb18e173fabb4d35be6724aec366df2ef
--> 90c16ab2600
STEP 12: COPY deploy/olm-catalog/awx-operator/metadata /metadata/
--> Using cache 545b252638176ee814cc70a968e64dfbfc67a957784664c4a34837d5e5a57ef2
STEP 13: COMMIT registry.tatu.home/ansible/awx-operator-bundle:add_labels_to_awx_kind
--> 545b2526381
545b252638176ee814cc70a968e64dfbfc67a957784664c4a34837d5e5a57ef2
Getting image source signatures
Copying blob a9be50e43021 skipped: already exists  
Copying blob f6e582813203 [--------------------------------------] 0.0b / 0.0b
Copying config 545b252638 [======================================] 2.8KiB / 2.8KiB
Writing manifest to image destination
Storing signatures
Building and pushing awx-operator-catalog image
INFO[0000] building the index                            bundles="[registry.tatu.home/ansible/awx-operator-bundle:add_labels_to_awx_kind]"
INFO[0000] resolved name: registry.tatu.home/ansible/awx-operator-bundle:add_labels_to_awx_kind 
INFO[0000] fetched                                       digest="sha256:67adc4370345cf606fb1f2f10b3a83aabd5564a8ec88a3ddaaef9f5d603fdf21"
INFO[0000] fetched                                       digest="sha256:ac07d80195c9d7cb074a2e332b726ea96de8e357a188df6fe56046415dca7c5e"
INFO[0000] fetched                                       digest="sha256:58bd7670a40934e6dbbd64d0c8edb6d078631f46aa46a4efefe1dd267c6543e3"
INFO[0000] fetched                                       digest="sha256:545b252638176ee814cc70a968e64dfbfc67a957784664c4a34837d5e5a57ef2"
INFO[0000] unpacking layer: {application/vnd.oci.image.layer.v1.tar+gzip sha256:58bd7670a40934e6dbbd64d0c8edb6d078631f46aa46a4efefe1dd267c6543e3 5126 [] map[] <nil>} 
INFO[0000] unpacking layer: {application/vnd.oci.image.layer.v1.tar+gzip sha256:ac07d80195c9d7cb074a2e332b726ea96de8e357a188df6fe56046415dca7c5e 337 [] map[] <nil>} 
INFO[0000] Could not find optional dependencies file     dir=bundle_tmp376554983 file=bundle_tmp376554983/metadata load=annotations
INFO[0000] found csv, loading bundle                     dir=bundle_tmp376554983 file=bundle_tmp376554983/manifests load=bundle
INFO[0000] loading bundle file                           dir=bundle_tmp376554983/manifests file=awx-operator.clusterserviceversion.yaml load=bundle
INFO[0000] loading bundle file                           dir=bundle_tmp376554983/manifests file=awx.ansible.com_awxs_crd.yaml load=bundle
INFO[0000] Generating dockerfile                         bundles="[registry.tatu.home/ansible/awx-operator-bundle:add_labels_to_awx_kind]"
INFO[0000] writing dockerfile: index.Dockerfile990314285  bundles="[registry.tatu.home/ansible/awx-operator-bundle:add_labels_to_awx_kind]"
INFO[0000] running podman build                          bundles="[registry.tatu.home/ansible/awx-operator-bundle:add_labels_to_awx_kind]"
INFO[0000] [podman build --format docker -f index.Dockerfile990314285 -t registry.tatu.home/ansible/awx-operator-catalog:add_labels_to_awx_kind .]  bundles="[registry.tatu.home/ansible/awx-operator-bundle:add_labels_to_awx_kind]"
Getting image source signatures
Copying blob f980e95921f1 done  
Copying blob 203be4006c3c skipped: already exists  
Copying blob 161273f53988 skipped: already exists  
Copying blob f3c4a25ff8f1 skipped: already exists  
Copying blob d3c853b30bb8 skipped: already exists  
Copying blob 8ea3b23f387b skipped: already exists  
Copying config 06904fb12c done  
Writing manifest to image destination
Storing signatures
Creating CatalogSource YAML
Now run: 'kubectl apply -f catalogsource.yaml' to update the operator
Happy testing!
```