### PR TITLE
Set Service to use type ClusterIP instead of NodePort when tower_ingress_type is Ingress

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ stringData:
 
 By default, the AWX operator is not opinionated and won't force a specific ingress type on you. So, if `tower_ingress_type` is not specified as part of the Custom Resource specification, it will default to `none` and nothing ingress-wise will be created.
 
-The AWX operator provides support for three kinds of `Ingress` to access AWX: `Ingress`, `Route` and `LoadBalancer`, To toggle between these options, you can add the following to your AWX CR:
+The AWX operator provides support for four kinds of `Ingress` to access AWX: `Ingress`, `Route`,  `LoadBalancer` and `NodePort`, To toggle between these options, you can add the following to your AWX CR:
 
   * Route
 
@@ -150,13 +150,22 @@ spec:
   tower_loadbalancer_protocol: http
 ```
 
+  * NodePort
+
+```yaml
+---
+spec:
+  ...
+  tower_ingress_type: NodePort
+```
+
 The AWX `Service` that gets created will have a `type` set based on the `tower_ingress_type` being used:
 
-If `tower_ingress_type: LoadBalancer` is used the `Service` will be set as `type: LoadBalancer`.
-
-If `tower_ingress_type: Ingress` is used the `Service` will be set as `type: ClusterIP`.
-
-If `tower_ingress_type: Route`, or no `tower_ingress_type` is specified in the Custom Resource Definition, the `Service` will be set as `type: NodePort`.
+| Ingress Type `tower_ingress_type`     | Service Type   |
+| ------------------------------------- | -------------- |
+| `LoadBalancer`                        | `LoadBalancer` |
+| `NodePort`                            | `NodePort`     |
+| `Ingress` or `Route` or not specified | `ClusterIP`    |
 
 #### TLS Termination
 

--- a/README.md
+++ b/README.md
@@ -150,6 +150,14 @@ spec:
   tower_loadbalancer_protocol: http
 ```
 
+The AWX `Service` that gets created will have a `type` set based on the `tower_ingress_type` being used:
+
+If `tower_ingress_type: LoadBalancer` is used the `Service` will be set as `type: LoadBalancer`.
+
+If `tower_ingress_type: Ingress` is used the `Service` will be set as `type: ClusterIP`.
+
+If `tower_ingress_type: Route`, or no `tower_ingress_type` is specified in the Custom Resource Definition, the `Service` will be set as `type: NodePort`.
+
 #### TLS Termination
 
   * Route

--- a/ansible/templates/crd.yml.j2
+++ b/ansible/templates/crd.yml.j2
@@ -69,6 +69,8 @@ spec:
                     - route
                     - LoadBalancer
                     - loadbalancer
+                    - NodePort
+                    - nodeport
                 tower_ingress_annotations:
                   description: Annotations to add to the ingress
                   type: string

--- a/deploy/awx-operator.yaml
+++ b/deploy/awx-operator.yaml
@@ -71,6 +71,8 @@ spec:
                     - route
                     - LoadBalancer
                     - loadbalancer
+                    - NodePort
+                    - nodeport
                 tower_ingress_annotations:
                   description: Annotations to add to the ingress
                   type: string

--- a/deploy/crds/awx_v1beta1_crd.yaml
+++ b/deploy/crds/awx_v1beta1_crd.yaml
@@ -69,6 +69,8 @@ spec:
                     - route
                     - LoadBalancer
                     - loadbalancer
+                    - NodePort
+                    - nodeport
                 tower_ingress_annotations:
                   description: Annotations to add to the ingress
                   type: string

--- a/deploy/olm-catalog/awx-operator/manifests/awx-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/awx-operator/manifests/awx-operator.clusterserviceversion.yaml
@@ -91,6 +91,7 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:select:Ingress
         - urn:alm:descriptor:com.tectonic.ui:select:Route
         - urn:alm:descriptor:com.tectonic.ui:select:LoadBalancer
+        - urn:alm:descriptor:com.tectonic.ui:select:NodePort
       - displayName: Tower Ingress Annotations
         path: tower_ingress_annotations
         x-descriptors:

--- a/deploy/olm-catalog/awx-operator/manifests/awx.ansible.com_awxs_crd.yaml
+++ b/deploy/olm-catalog/awx-operator/manifests/awx.ansible.com_awxs_crd.yaml
@@ -103,6 +103,8 @@ spec:
                 - route
                 - LoadBalancer
                 - loadbalancer
+                - NodePort
+                - nodeport
                 type: string
               tower_loadbalancer_annotations:
                 description: Annotations to add to the loadbalancer

--- a/roles/installer/templates/tower_service.yaml.j2
+++ b/roles/installer/templates/tower_service.yaml.j2
@@ -44,8 +44,8 @@ spec:
     app.kubernetes.io/component: awx
 {% if tower_ingress_type | lower == "loadbalancer" %}
   type: LoadBalancer
-{% elif tower_ingress_type | lower == "ingress" %}
-  type: ClusterIP
-{% elif tower_ingress_type != "none" %}
+{% elif tower_ingress_type | lower == "nodeport" %}
   type: NodePort
+{% elif  %}
+  type: ClusterIP
 {% endif %}

--- a/roles/installer/templates/tower_service.yaml.j2
+++ b/roles/installer/templates/tower_service.yaml.j2
@@ -46,6 +46,6 @@ spec:
   type: LoadBalancer
 {% elif tower_ingress_type | lower == "nodeport" %}
   type: NodePort
-{% elif  %}
+{% else %}
   type: ClusterIP
 {% endif %}

--- a/roles/installer/templates/tower_service.yaml.j2
+++ b/roles/installer/templates/tower_service.yaml.j2
@@ -44,6 +44,8 @@ spec:
     app.kubernetes.io/component: awx
 {% if tower_ingress_type | lower == "loadbalancer" %}
   type: LoadBalancer
+{% elif tower_ingress_type | lower == "ingress" %}
+  type: ClusterIP
 {% elif tower_ingress_type != "none" %}
   type: NodePort
 {% endif %}


### PR DESCRIPTION
Fixes: #202 #25

Simple tweak to `tower_service_yaml.j2` template to set the service type to `ClusterIP` when `tower_ingress_type` has been specified as `Ingress`.

Currently when using an Ingress the AWX service is created using `type: NodePort` which then exposes AWX directly outside the cluster unnecessarily.
