### PR TITLE
Removed jinja2 filter 'quote' for db password

### DIFF
--- a/roles/installer/templates/credentials.py.j2
+++ b/roles/installer/templates/credentials.py.j2
@@ -4,7 +4,7 @@ DATABASES = {
         'ENGINE': 'awx.main.db.profiled_pg',
         'NAME': "{{ awx_postgres_database }}",
         'USER': "{{ awx_postgres_user }}",
-        'PASSWORD': "{{ awx_postgres_pass | quote }}",
+        'PASSWORD': "{{ awx_postgres_pass }}",
         'HOST': '{{ awx_postgres_host }}',
         'PORT': "{{ awx_postgres_port }}",
         'OPTIONS': { 'sslmode': '{{ pg_sslmode|default("prefer") }}',


### PR DESCRIPTION
cc: @shanemcd 

Fixes: #187

See issue #187 for further explanation.

Furthermore, this change aligns with the downstream installer as well. 