### PR TITLE
adding service account image pull secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,34 +7,37 @@ An [Ansible AWX](https://github.com/ansible/awx) operator for Kubernetes built w
 # Table of Contents
 
 <!--ts-->
-* [AWX Operator](#awx-operator)
-* [Table of Contents](#table-of-contents)
-   * [Purpose](#purpose)
-   * [Usage](#usage)
-      * [Basic Install](#basic-install)
-      * [Admin user account configuration](#admin-user-account-configuration)
-      * [Network and TLS Configuration](#network-and-tls-configuration)
-         * [Ingress Type](#ingress-type)
-         * [TLS Termination](#tls-termination)
-      * [Database Configuration](#database-configuration)
-         * [External PostgreSQL Service](#external-postgresql-service)
-         * [Migrating data from an old AWX instance](#migrating-data-from-an-old-awx-instance)
-         * [Managed PostgreSQL Service](#managed-postgresql-service)
-      * [Advanced Configuration](#advanced-configuration)
-         * [Deploying a specific version of AWX](#deploying-a-specific-version-of-awx)
-         * [Privileged Tasks](#privileged-tasks)
-         * [Containers Resource Requirements](#containers-resource-requirements)
-         * [LDAP Certificate Authority](#ldap-certificate-authority)
-         * [Persisting Projects Directory](#persisting-projects-directory)
-   * [Development](#development)
-      * [Testing](#testing)
-         * [Testing in Docker](#testing-in-docker)
-         * [Testing in Minikube](#testing-in-minikube)
-      * [Generating a bundle](#generating-a-bundle)
-   * [Release Process](#release-process)
-      * [Build a new release](#build-a-new-release)
-      * [Build a new version of the operator yaml file](#build-a-new-version-of-the-operator-yaml-file)
-   * [Author](#author)
+- [AWX Operator](#awx-operator)
+- [Table of Contents](#table-of-contents)
+  - [Purpose](#purpose)
+  - [Usage](#usage)
+    - [Basic Install](#basic-install)
+    - [Admin user account configuration](#admin-user-account-configuration)
+    - [Network and TLS Configuration](#network-and-tls-configuration)
+      - [Ingress Type](#ingress-type)
+      - [TLS Termination](#tls-termination)
+    - [Database Configuration](#database-configuration)
+      - [External PostgreSQL Service](#external-postgresql-service)
+      - [Migrating data from an old AWX instance](#migrating-data-from-an-old-awx-instance)
+      - [Managed PostgreSQL Service](#managed-postgresql-service)
+    - [Advanced Configuration](#advanced-configuration)
+      - [Deploying a specific version of AWX](#deploying-a-specific-version-of-awx)
+    - [Adding a pull secret to the service account](#adding-a-pull-secret-to-the-service-account)
+      - [Privileged Tasks](#privileged-tasks)
+      - [Containers Resource Requirements](#containers-resource-requirements)
+      - [Assigning AWX pods to specific nodes](#assigning-awx-pods-to-specific-nodes)
+      - [LDAP Certificate Authority](#ldap-certificate-authority)
+      - [Persisting Projects Directory](#persisting-projects-directory)
+  - [Development](#development)
+    - [Testing](#testing)
+      - [Testing in Docker](#testing-in-docker)
+      - [Testing in Minikube](#testing-in-minikube)
+    - [Generating a bundle](#generating-a-bundle)
+  - [Release Process](#release-process)
+    - [Verify Functionality](#verify-functionality)
+    - [Update version](#update-version)
+    - [Commit / Create Release](#commit--create-release)
+  - [Author](#author)
 <!--te-->
 
 ## Purpose
@@ -270,6 +273,17 @@ spec:
   tower_ee_images:
     - name: my-custom-awx-ee
       image: myorg/my-custom-awx-ee
+```
+
+### Adding a pull secret to the service account
+
+In some cases it may be necessary to add a pull secret at the service account level to be used for all image pulls.  An example of this would be to avoid the daily rate limits associated with a docker registry without a registered account.  You can add a pull secret to the service account used for image pulls using the following syntax:
+
+```yaml
+---
+spec:
+  ...
+  service_account_image_pull_secret: pull_secret_name
 ```
 
 #### Privileged Tasks

--- a/ansible/templates/crd.yml.j2
+++ b/ansible/templates/crd.yml.j2
@@ -26,6 +26,9 @@ spec:
                 deployment_type:
                   description: Name of the deployment type
                   type: string
+                service_account_image_pull_secret:
+                  description: The service account image pull secret
+                  type: string
                 tower_task_privileged:
                   description: If a privileged security context should be enabled
                   type: boolean

--- a/deploy/awx-operator.yaml
+++ b/deploy/awx-operator.yaml
@@ -28,6 +28,9 @@ spec:
                 deployment_type:
                   description: Name of the deployment type
                   type: string
+                service_account_image_pull_secret:
+                  description: The service account image pull secret
+                  type: string
                 tower_task_privileged:
                   description: If a privileged security context should be enabled
                   type: boolean

--- a/deploy/crds/awx_v1beta1_crd.yaml
+++ b/deploy/crds/awx_v1beta1_crd.yaml
@@ -26,6 +26,9 @@ spec:
                 deployment_type:
                   description: Name of the deployment type
                   type: string
+                service_account_image_pull_secret:
+                  description: The service account image pull secret
+                  type: string
                 tower_task_privileged:
                   description: If a privileged security context should be enabled
                   type: boolean

--- a/deploy/olm-catalog/awx-operator/manifests/awx-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/awx-operator/manifests/awx-operator.clusterserviceversion.yaml
@@ -234,6 +234,11 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:io.kubernetes:Secret
+      - displayName: Service Account Image Pull Secret
+        path: service_account_image_pull_secret
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:serviceAccountImagePullSecret
       - displayName: Tower Task Args
         path: tower_task_args
         x-descriptors:

--- a/deploy/olm-catalog/awx-operator/manifests/awx.ansible.com_awxs_crd.yaml
+++ b/deploy/olm-catalog/awx-operator/manifests/awx.ansible.com_awxs_crd.yaml
@@ -32,6 +32,9 @@ spec:
                 description: Secret where can be found the LDAP trusted Certificate
                   Authority Bundle
                 type: string
+              service_account_image_pull_secret:
+                description: The service account image pull secret
+                type: string
               tower_admin_email:
                 description: The admin user email
                 type: string

--- a/roles/installer/defaults/main.yml
+++ b/roles/installer/defaults/main.yml
@@ -4,6 +4,9 @@ deployment_type: awx
 database_name: "{{ deployment_type }}"
 database_username: "{{ deployment_type }}"
 
+# Add to make pull secret available for all image pulls
+service_account_image_pull_secret: ''
+
 tower_task_privileged: false
 tower_ingress_type: none
 

--- a/roles/installer/templates/tower_service_account.yaml.j2
+++ b/roles/installer/templates/tower_service_account.yaml.j2
@@ -9,6 +9,10 @@ metadata:
     app.kubernetes.io/part-of: '{{ meta.name }}'
     app.kubernetes.io/managed-by: awx-operator
     app.kubernetes.io/component: awx
+{% if service_account_image_pull_secret %}
+imagePullSecrets:
+  - name: {{ service_account_image_pull_secret }}
+{% endif %}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role


### PR DESCRIPTION
This PR adds an image pull secret to the service account associated with a given AWX deployment.  This helps get around the daily pull limits of docker registries such as DockerHub by allowing a user to use their registered accounts.  The current `tower_image_pull_secret` only applies to awx images and does not apply to images such as `postgres` or `redis`