### PR TITLE
Include support for nodeSelector and tolerations in AWX Postgres pod

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,15 +325,17 @@ spec:
 
 #### Assigning AWX pods to specific nodes
 
-You can constrain the AWX pods created by the operator to run on a certain subset of nodes. `tower_node_selector` constrains
-the AWX pods to run only on the nodes that match all the specified key/value pairs. `tower_tolerations` allow the AWX
+You can constrain the AWX pods created by the operator to run on a certain subset of nodes. `tower_node_selector` and `tower_postgres_selector` constrains
+the AWX pods to run only on the nodes that match all the specified key/value pairs. `tower_tolerations` and `tower_postgres_tolerations` allow the AWX
 pods to be scheduled onto nodes with matching taints.
 
 
-| Name                | Description            | Default |
-| ------------------- | ---------------------- | ------- |
-| tower_node_selector | AWX pods' nodeSelector | ''      |
-| tower_tolerations   | AWX pods' tolerations  | ''      |
+| Name                       | Description                 | Default |
+| -------------------------- | --------------------------- | ------- |
+| tower_node_selector        | AWX pods' nodeSelector      | ''      |
+| tower_tolerations          | AWX pods' tolerations       | ''      |
+| tower_postgres_selector    | Postgres pods' nodeSelector | ''      |
+| tower_postgres_tolerations | Postgres pods' tolerations  | ''      |
 
 Example of customization could be:
 
@@ -346,6 +348,15 @@ spec:
     kubernetes.io/arch: amd64
     kubernetes.io/os: linux
   tower_tolerations: |
+    - key: "dedicated"
+      operator: "Equal"
+      value: "AWX"
+      effect: "NoSchedule"
+  tower_postgres_selector: |
+    disktype: ssd
+    kubernetes.io/arch: amd64
+    kubernetes.io/os: linux
+  tower_postgres_tolerations: |
     - key: "dedicated"
       operator: "Equal"
       value: "AWX"

--- a/ansible/templates/crd.yml.j2
+++ b/ansible/templates/crd.yml.j2
@@ -224,6 +224,12 @@ spec:
                 tower_postgres_image:
                   description: Registry path to the PostgreSQL container to use
                   type: string
+                tower_postgres_selector:
+                  description: nodeSelector for the Postgres pods
+                  type: string
+                tower_postgres_tolerations:
+                  description: node tolerations for the Postgres pods
+                  type: string
                 tower_postgres_resource_requirements:
                   description: Resource requirements for the PostgreSQL container
                   properties:

--- a/deploy/awx-operator.yaml
+++ b/deploy/awx-operator.yaml
@@ -226,6 +226,12 @@ spec:
                 tower_postgres_image:
                   description: Registry path to the PostgreSQL container to use
                   type: string
+                tower_postgres_selector:
+                  description: nodeSelector for the Postgres pods
+                  type: string
+                tower_postgres_tolerations:
+                  description: node tolerations for the Postgres pods
+                  type: string
                 tower_postgres_resource_requirements:
                   description: Resource requirements for the PostgreSQL container
                   properties:

--- a/deploy/crds/awx_v1beta1_crd.yaml
+++ b/deploy/crds/awx_v1beta1_crd.yaml
@@ -224,6 +224,12 @@ spec:
                 tower_postgres_image:
                   description: Registry path to the PostgreSQL container to use
                   type: string
+                tower_postgres_selector:
+                  description: nodeSelector for the Postgres pods
+                  type: string
+                tower_postgres_tolerations:
+                  description: node tolerations for the Postgres pods
+                  type: string
                 tower_postgres_resource_requirements:
                   description: Resource requirements for the PostgreSQL container
                   properties:

--- a/deploy/olm-catalog/awx-operator/manifests/awx-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/awx-operator/manifests/awx-operator.clusterserviceversion.yaml
@@ -214,6 +214,16 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:hidden
+      - displayName: Tower Postgres Selector
+        path: tower_postgres_selector
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - displayName: Tower Postgres Tolerations
+        path: tower_postgres_tolerations
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:hidden
       - displayName: Tower Postgres Storage Class
         path: tower_postgres_storage_class
         x-descriptors:

--- a/deploy/olm-catalog/awx-operator/manifests/awx.ansible.com_awxs_crd.yaml
+++ b/deploy/olm-catalog/awx-operator/manifests/awx.ansible.com_awxs_crd.yaml
@@ -134,6 +134,12 @@ spec:
               tower_postgres_image:
                 description: Registry path to the PostgreSQL container to use
                 type: string
+              tower_postgres_selector:
+                description: nodeSelector for the Postgres pods
+                type: string
+              tower_postgres_tolerations:
+                description: node tolerations for the Postgres pods
+                type: string
               tower_postgres_resource_requirements:
                 description: Resource requirements for the PostgreSQL container
                 properties:

--- a/roles/installer/defaults/main.yml
+++ b/roles/installer/defaults/main.yml
@@ -141,7 +141,7 @@ tower_postgres_image: postgres:12
 tower_postgres_selector: ''
 
 # Add node tolerations for the Postgres pods.
-#Specify as literal block. E.g.:
+# Specify as literal block. E.g.:
 # tower_postgres_tolerations: |
 #   - key: "dedicated"
 #     operator: "Equal"

--- a/roles/installer/defaults/main.yml
+++ b/roles/installer/defaults/main.yml
@@ -130,6 +130,25 @@ tower_web_extra_volume_mounts: ''
 tower_redis_image: redis:latest
 
 tower_postgres_image: postgres:12
+
+# Add a nodeSelector for the Postgres pods.
+# It must match a node's labels for the pod to be scheduled on that node.
+# Specify as literal block. E.g.:
+# tower_postgres_selector: |
+#   disktype: ssd
+#   kubernetes.io/arch: amd64
+#   kubernetes.io/os: linux
+tower_postgres_selector: ''
+
+# Add node tolerations for the Postgres pods.
+#Specify as literal block. E.g.:
+# tower_postgres_tolerations: |
+#   - key: "dedicated"
+#     operator: "Equal"
+#     value: "AWX"
+#     effect: "NoSchedule"
+tower_postgres_tolerations: ''
+
 tower_postgres_resource_requirements:
   requests:
     storage: 8Gi

--- a/roles/installer/templates/tower_postgres.yaml.j2
+++ b/roles/installer/templates/tower_postgres.yaml.j2
@@ -60,6 +60,14 @@ spec:
             - name: postgres
               mountPath: '{{ tower_postgres_data_path | dirname }}'
               subPath: '{{ tower_postgres_data_path | dirname | basename }}'
+{% if tower_node_selector %}
+      nodeSelector:
+        {{ tower_node_selector | indent(width=8) }}
+{% endif %}
+{% if tower_tolerations %}
+      tolerations:
+        {{ tower_tolerations | indent(width=8) }}
+{% endif %}  
   volumeClaimTemplates:
     - metadata:
         name: postgres

--- a/roles/installer/templates/tower_postgres.yaml.j2
+++ b/roles/installer/templates/tower_postgres.yaml.j2
@@ -66,8 +66,8 @@ spec:
 {% endif %}
 {% if tower_postgres_tolerations %}
       tolerations:
-        {{ tower_tolerations | indent(width=8) }}
-{% endif %}  
+        {{ tower_postgres_tolerations | indent(width=8) }}
+{% endif %}
   volumeClaimTemplates:
     - metadata:
         name: postgres

--- a/roles/installer/templates/tower_postgres.yaml.j2
+++ b/roles/installer/templates/tower_postgres.yaml.j2
@@ -60,11 +60,11 @@ spec:
             - name: postgres
               mountPath: '{{ tower_postgres_data_path | dirname }}'
               subPath: '{{ tower_postgres_data_path | dirname | basename }}'
-{% if tower_node_selector %}
+{% if tower_postgres_selector %}
       nodeSelector:
-        {{ tower_node_selector | indent(width=8) }}
+        {{ tower_postgres_selector | indent(width=8) }}
 {% endif %}
-{% if tower_tolerations %}
+{% if tower_postgres_tolerations %}
       tolerations:
         {{ tower_tolerations | indent(width=8) }}
 {% endif %}  


### PR DESCRIPTION
This change is based on `PR` #165 . It includes support for `nodeSelector` and `tolerations` for the `Postgres pod` that deploys awx-operator.