### PR TITLE
Inherit imagePullPolicy to redis container

### DIFF
--- a/roles/installer/templates/tower_deployment.yaml.j2
+++ b/roles/installer/templates/tower_deployment.yaml.j2
@@ -34,6 +34,7 @@ spec:
 {% endif %}
       containers:
         - image: '{{ tower_redis_image }}'
+          imagePullPolicy: '{{ tower_image_pull_policy }}'
           name: redis
           args: ["redis-server", "/etc/redis.conf"]
           volumeMounts:


### PR DESCRIPTION
cc: @shanemcd @Spredzy 

This PR allows users to modify the `imagePullPolicy` for the `redis` container as well. I don't see the need to have a different policy which the `redis`  will have a different `imagePullPolicy`  than the `tower` containers, but if you think we should have a dedicated `imagePullPolicy` for `redis`, then,  I would be happy to do it. 

Fixes: #211
Fixes: #229 