### PR TITLE
Use postgres config values

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ stringData:
 type: Opaque
 ```
 
-> It is possible to set a specific username, password, port, or database, but still have the database managed by the operator. In this case, when creating the postgres-configuration secret, the `type: managed` field should be added.  
+> It is possible to set a specific username, password, or database, but still have the database managed by the operator. In this case, when creating the postgres-configuration secret, the `type: managed` field should be added.  
 
 **Note**: The variable `sslmode` is valid for `external` databases only. The allowed values are: `prefer`, `disable`, `allow`, `require`, `verify-ca`, `verify-full`.
 


### PR DESCRIPTION
This adds the ability for users to specify custom postgres config values for managed database deployments.  With this PR, these config values will be honored:
* database
* username
* password
* port

Previously, the tower_postgres.yml.j2 only looked in the default location for the tower postgres configuration secret.  