### PR TITLE
Ensure image tag is used for tower_image_version

### DIFF
--- a/roles/installer/tasks/main.yml
+++ b/roles/installer/tasks/main.yml
@@ -18,7 +18,7 @@
 
 - name: Get current version
   set_fact:
-    tower_image_version: "{{ tower_image.split(':')[1] }}"
+    tower_image_version: "{{ tower_image.split(':')[-1] }}"
 
 - name: Include secret key configuration tasks
   include_tasks: secret_key_configuration.yml


### PR DESCRIPTION
Fixes: #223 

```python
In [1]: s="registry_docker:5000/awx:19.0.0"

In [2]: s.split(":")
Out[2]: ['registry_docker', '5000/awx', '19.0.0']

In [3]: s.split(":")[1]
Out[3]: '5000/awx'

In [4]: s.split(":")[-1]
Out[4]: '19.0.0'

In [5]: s.split(":")[-1]
Out[5]: '19.0.0'

In [6]: ss = "registry_docker/awx:19.0.0"

In [7]: s.split(":")[-1]
Out[7]: '19.0.0'

In [8]: ss.split(":")[-1]
Out[8]: '19.0.0'

```