### PR TITLE
Split container image and version in 2 variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ There are a few variables that are customizable for awx the image management.
 | Name                      | Description                | Default                      |
 | --------------------------| -------------------------- |------------------------------|
 | tower_image               | Path of the image to pull  | quay.io/ansible/awx          |
-| tower_image_version       | Image version to pull      | 19                           |
+| tower_image_version       | Image version to pull      | 19.0.0                       |
 | tower_image_pull_policy   | The pull policy to adopt   | IfNotPresent                 |
 | tower_image_pull_secret   | The pull secret to use     | ''                           |
 | tower_ee_images           | A list of EEs to register  | quay.io/ansible/awx-ee:0.1.1 |
@@ -279,6 +279,15 @@ spec:
     - name: my-custom-awx-ee
       image: myorg/my-custom-awx-ee
 ```
+
+**Note**: The `tower_image` and `tower_image_version` are intended for local mirroring scenarios.
+
+
+| Operator Version   | Suppported AWX version     |
+| -------------------| -------------------------- |
+| 0.0.7 and older    | >= 17.0.0                  |
+| 0.0.8 and later    | >= 18.0.0                  |
+
 
 #### Privileged Tasks
 

--- a/README.md
+++ b/README.md
@@ -255,12 +255,15 @@ spec:
 
 There are a few variables that are customizable for awx the image management.
 
-| Name                    | Description                |
-| ----------------------- | -------------------------- |
-| tower_image             | Path of the image to pull  |
-| tower_image_pull_policy | The pull policy to adopt   |
-| tower_image_pull_secret | The pull secret to use     |
-| tower_ee_images         | A list of EEs to register  |
+| Name                      | Description                | Default                      |
+| --------------------------| -------------------------- |------------------------------|
+| tower_image               | Path of the image to pull  | quay.io/ansible/awx          |
+| tower_image_version       | Image version to pull      | 19                           |
+| tower_image_pull_policy   | The pull policy to adopt   | IfNotPresent                 |
+| tower_image_pull_secret   | The pull secret to use     | ''                           |
+| tower_ee_images           | A list of EEs to register  | quay.io/ansible/awx-ee:0.1.1 |
+| tower_redis_image         | Path of the image to pull  | docker.io/redis              |
+| tower_redis_image_version | Image version to pull      | latest                       |
 
 Example of customization could be:
 
@@ -269,6 +272,7 @@ Example of customization could be:
 spec:
   ...
   tower_image: myorg/my-custom-awx
+  tower_image_version: latest
   tower_image_pull_policy: Always
   tower_image_pull_secret: pull_secret_name
   tower_ee_images:
@@ -334,12 +338,14 @@ the AWX pods to run only on the nodes that match all the specified key/value pai
 pods to be scheduled onto nodes with matching taints.
 
 
-| Name                       | Description                 | Default |
-| -------------------------- | --------------------------- | ------- |
-| tower_node_selector        | AWX pods' nodeSelector      | ''      |
-| tower_tolerations          | AWX pods' tolerations       | ''      |
-| tower_postgres_selector    | Postgres pods' nodeSelector | ''      |
-| tower_postgres_tolerations | Postgres pods' tolerations  | ''      |
+| Name                           | Description                 | Default |
+| -------------------------------| --------------------------- | ------- |
+| tower_postgres_image           | Path of the image to pull   | 12      |
+| tower_postgres_image_version   | Image version to pull       | 12      |
+| tower_node_selector            | AWX pods' nodeSelector      | ''      |
+| tower_tolerations              | AWX pods' tolerations       | ''      |
+| tower_postgres_selector        | Postgres pods' nodeSelector | ''      |
+| tower_postgres_tolerations     | Postgres pods' tolerations  | ''      |
 
 Example of customization could be:
 

--- a/README.md
+++ b/README.md
@@ -255,15 +255,15 @@ spec:
 
 There are a few variables that are customizable for awx the image management.
 
-| Name                      | Description                | Default                      |
-| --------------------------| -------------------------- |------------------------------|
-| tower_image               | Path of the image to pull  | quay.io/ansible/awx          |
-| tower_image_version       | Image version to pull      | 19.0.0                       |
-| tower_image_pull_policy   | The pull policy to adopt   | IfNotPresent                 |
-| tower_image_pull_secret   | The pull secret to use     | ''                           |
-| tower_ee_images           | A list of EEs to register  | quay.io/ansible/awx-ee:0.1.1 |
-| tower_redis_image         | Path of the image to pull  | docker.io/redis              |
-| tower_redis_image_version | Image version to pull      | latest                       |
+| Name                      | Description                |
+| --------------------------| -------------------------- |
+| tower_image               | Path of the image to pull  |
+| tower_image_version       | Image version to pull      |
+| tower_image_pull_policy   | The pull policy to adopt   |
+| tower_image_pull_secret   | The pull secret to use     |
+| tower_ee_images           | A list of EEs to register  |
+| tower_redis_image         | Path of the image to pull  |
+| tower_redis_image_version | Image version to pull      |
 
 Example of customization could be:
 
@@ -280,14 +280,7 @@ spec:
       image: myorg/my-custom-awx-ee
 ```
 
-**Note**: The `tower_image` and `tower_image_version` are intended for local mirroring scenarios.
-
-
-| Operator Version   | Suppported AWX version     |
-| -------------------| -------------------------- |
-| 0.0.7 and older    | >= 17.0.0                  |
-| 0.0.8 and later    | >= 18.0.0                  |
-
+**Note**: The `tower_image` and `tower_image_version` are intended for local mirroring scenarios. Please note that using a version of AWX other than the one bundled with the `awx-operator` is **not** supported. For the default values, check the [main.yml](https://github.com/ansible/awx-operator/blob/devel/roles/installer/defaults/main.yml) file.
 
 #### Privileged Tasks
 

--- a/ansible/templates/crd.yml.j2
+++ b/ansible/templates/crd.yml.j2
@@ -113,6 +113,9 @@ spec:
                 tower_image:
                   description: Registry path to the application container to use
                   type: string
+                tower_image_version:
+                  description: Application container image version to use
+                  type: string
                 tower_ee_images:
                   description: Registry path to the Execution Environment container to use
                   type: array
@@ -226,8 +229,14 @@ spec:
                 tower_redis_image:
                   description: Registry path to the redis container to use
                   type: string
+                tower_redis_image_version:
+                  description: Redis container image version to use
+                  type: string
                 tower_postgres_image:
                   description: Registry path to the PostgreSQL container to use
+                  type: string
+                tower_postgres_image_version:
+                  description: PostgreSQL container image version to use
                   type: string
                 tower_postgres_selector:
                   description: nodeSelector for the Postgres pods

--- a/deploy/awx-operator.yaml
+++ b/deploy/awx-operator.yaml
@@ -115,6 +115,9 @@ spec:
                 tower_image:
                   description: Registry path to the application container to use
                   type: string
+                tower_image_version:
+                  description: Application container image version to use
+                  type: string
                 tower_ee_images:
                   description: Registry path to the Execution Environment container to use
                   type: array
@@ -223,8 +226,14 @@ spec:
                 tower_redis_image:
                   description: Registry path to the redis container to use
                   type: string
+                tower_redis_image_version:
+                  description: Redis container image version to use
+                  type: string
                 tower_postgres_image:
                   description: Registry path to the PostgreSQL container to use
+                  type: string
+                tower_postgres_image_version:
+                  description: PostgreSQL container image version to use
                   type: string
                 tower_postgres_selector:
                   description: nodeSelector for the Postgres pods

--- a/deploy/crds/awx_v1beta1_crd.yaml
+++ b/deploy/crds/awx_v1beta1_crd.yaml
@@ -113,6 +113,9 @@ spec:
                 tower_image:
                   description: Registry path to the application container to use
                   type: string
+                tower_image_version:
+                  description: Application container image version to use
+                  type: string
                 tower_ee_images:
                   description: Registry path to the Execution Environment container to use
                   type: array
@@ -221,8 +224,14 @@ spec:
                 tower_redis_image:
                   description: Registry path to the redis container to use
                   type: string
+                tower_redis_image_version:
+                  description: Redis container image version to use
+                  type: string
                 tower_postgres_image:
                   description: Registry path to the PostgreSQL container to use
+                  type: string
+                tower_postgres_image_version:
+                  description: PostgreSQL container image version to use
                   type: string
                 tower_postgres_selector:
                   description: nodeSelector for the Postgres pods

--- a/deploy/olm-catalog/awx-operator/manifests/awx-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/awx-operator/manifests/awx-operator.clusterserviceversion.yaml
@@ -204,13 +204,28 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:hidden
+      - displayName: Tower Image Version
+        path: tower_image_version
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:hidden
       - displayName: Redis Image
         path: tower_redis_image
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:hidden
+      - displayName: Redis Image Version
+        path: tower_redis_image_version
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:hidden
       - displayName: PostgreSQL Image
         path: tower_postgres_image
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - displayName: PostgreSQL Image Version
+        path: tower_postgres_image_version
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:hidden

--- a/deploy/olm-catalog/awx-operator/manifests/awx.ansible.com_awxs_crd.yaml
+++ b/deploy/olm-catalog/awx-operator/manifests/awx.ansible.com_awxs_crd.yaml
@@ -73,6 +73,9 @@ spec:
               tower_image:
                 description: Registry path to the application container to use
                 type: string
+              tower_image_version:
+                description: Application container image version to use
+                type: string
               tower_image_pull_policy:
                 default: IfNotPresent
                 description: The image pull policy
@@ -134,6 +137,9 @@ spec:
               tower_postgres_image:
                 description: Registry path to the PostgreSQL container to use
                 type: string
+              tower_postgres_image_version:
+                description: PostgreSQL container image version to use
+                type: string
               tower_postgres_selector:
                 description: nodeSelector for the Postgres pods
                 type: string
@@ -192,6 +198,9 @@ spec:
                 type: string
               tower_redis_image:
                 description: Registry path to the redis container to use
+                type: string
+              tower_redis_image_version:
+                description: Redis container image version to use
                 type: string
               tower_replicas:
                 default: 1

--- a/roles/installer/defaults/main.yml
+++ b/roles/installer/defaults/main.yml
@@ -81,7 +81,12 @@ tower_extra_volumes: ''
 
 # Use these image versions for Ansible AWX.
 
-tower_image: quay.io/ansible/awx:19.0.0
+tower_image: quay.io/ansible/awx
+tower_image_version: 19.0.0
+tower_redis_image: docker.io/redis
+tower_redis_image_version: latest
+tower_postgres_image: postgres
+tower_postgres_image_version: 12
 tower_image_pull_policy: IfNotPresent
 tower_image_pull_secret: ''
 
@@ -127,9 +132,6 @@ tower_web_extra_env: ''
 tower_task_extra_volume_mounts: ''
 tower_web_extra_volume_mounts: ''
 tower_ee_extra_volume_mounts: ''
-tower_redis_image: redis:latest
-
-tower_postgres_image: postgres:12
 
 # Add a nodeSelector for the Postgres pods.
 # It must match a node's labels for the pod to be scheduled on that node.

--- a/roles/installer/tasks/main.yml
+++ b/roles/installer/tasks/main.yml
@@ -16,10 +16,6 @@
           app.kubernetes.io/managed-by: awx-operator
           app.kubernetes.io/component: awx
 
-- name: Get current version
-  set_fact:
-    tower_image_version: "{{ tower_image.split(':')[1] }}"
-
 - name: Include secret key configuration tasks
   include_tasks: secret_key_configuration.yml
 

--- a/roles/installer/templates/tower_deployment.yaml.j2
+++ b/roles/installer/templates/tower_deployment.yaml.j2
@@ -33,7 +33,7 @@ spec:
         - name: {{ tower_image_pull_secret }}
 {% endif %}
       containers:
-        - image: '{{ tower_redis_image }}'
+        - image: '{{ tower_redis_image }}:{{ tower_redis_image_version }}'
           name: redis
           args: ["redis-server", "/etc/redis.conf"]
           volumeMounts:
@@ -45,7 +45,7 @@ spec:
               mountPath: "/var/run/redis"
             - name: "{{ meta.name }}-redis-data"
               mountPath: "/data"
-        - image: '{{ tower_image }}'
+        - image: '{{ tower_image }}:{{ tower_image_version }}'
           name: '{{ meta.name }}-web'
 {% if tower_web_command %}
           command: {{ tower_web_command }}
@@ -123,7 +123,7 @@ spec:
             {{ tower_web_extra_env | indent(width=12, indentfirst=True) }}
 {% endif %}
           resources: {{ tower_web_resource_requirements }}
-        - image: '{{ tower_image }}'
+        - image: '{{ tower_image }}:{{ tower_image_version }}'
           name: '{{ meta.name }}-task'
           imagePullPolicy: '{{ tower_image_pull_policy }}'
 {% if tower_task_privileged == true %}

--- a/roles/installer/templates/tower_postgres.yaml.j2
+++ b/roles/installer/templates/tower_postgres.yaml.j2
@@ -29,7 +29,7 @@ spec:
         app.kubernetes.io/component: database
     spec:
       containers:
-        - image: '{{ tower_postgres_image }}'
+        - image: '{{ tower_postgres_image }}:{{ tower_postgres_image_version }}'
           name: postgres
           env:
             - name: POSTGRES_DB


### PR DESCRIPTION
This PR splits the containers `image` and `version` into 2 different variables. 


Fixes: #232
Fixes: #223
Fixes: #182

**Breaking Change Warning**
For users with the `tower_image` set to the `spec`, an update will be required. 

**old format**
```yaml 
spec: 
   tower_image: quay.io/ansible/awx:19.0.0
```

**new format**
```yaml
spec: 
   tower_image: quay.io/ansible/awx
   tower_image_version: 19.0.0
```