### PR TITLE
Allow the user to set the ingress apiVersion

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ spec:
 spec:
   ...
   ingress_type: Ingress
+  ingress_apiversion: networking.k8s.io/v1
   hostname: awx.mycompany.com
 ```
 
@@ -184,10 +185,13 @@ The following variables are customizable to specify the TLS termination procedur
 
 The following variables are customizable to specify the TLS termination procedure when `Ingress` is picked as an Ingress
 
-| Name                       | Description                              | Default       |
-| -------------------------- | ---------------------------------------- | ------------- |
-| ingress_annotations        | Ingress annotations                      | Empty string  |
-| ingress_tls_secret         | Secret that contains the TLS information | Empty string  |
+| Name                       | Description                              | Default             |
+| -------------------------- | ---------------------------------------- | ------------------- |
+| ingress_annotations        | Ingress annotations                      | Empty string        |
+| ingress_apiversion         | API Version for the Ingress              | extensions/v1beta1  |
+| ingress_tls_secret         | Secret that contains the TLS information | Empty string        |
+
+The default ingress_apiversion is `extensions/v1beta1`, but if you have a newer nginx-ingress deployment in k8s, you may need to change this to `networking.k8s.io/v1beta1`.
 
   * LoadBalancer
 

--- a/ansible/templates/crd.yml.j2
+++ b/ansible/templates/crd.yml.j2
@@ -86,6 +86,9 @@ spec:
                 ingress_annotations:
                   description: Annotations to add to the ingress
                   type: string
+                ingress_apiversion:
+                  description: apiVersion to use for the ingress
+                  type: string
                 ingress_tls_secret:
                   description: Secret where the ingress TLS secret can be found
                   type: string

--- a/deploy/awx-operator.yaml
+++ b/deploy/awx-operator.yaml
@@ -88,6 +88,9 @@ spec:
                 ingress_annotations:
                   description: Annotations to add to the ingress
                   type: string
+                ingress_apiversion:
+                  description: apiVersion to use for the ingress
+                  type: string
                 ingress_tls_secret:
                   description: Secret where the ingress TLS secret can be found
                   type: string

--- a/deploy/crds/awx_v1beta1_crd.yaml
+++ b/deploy/crds/awx_v1beta1_crd.yaml
@@ -86,6 +86,9 @@ spec:
                 ingress_annotations:
                   description: Annotations to add to the ingress
                   type: string
+                ingress_apiversion:
+                  description: apiVersion to use for the ingress
+                  type: string
                 ingress_tls_secret:
                   description: Secret where the ingress TLS secret can be found
                   type: string

--- a/deploy/olm-catalog/awx-operator/manifests/awx-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/awx-operator/manifests/awx-operator.clusterserviceversion.yaml
@@ -194,6 +194,11 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:io.kubernetes:Secret
         - urn:alm:descriptor:com.tectonic.ui:fieldDependency:ingress_type:Ingress
+      - displayName: Ingress apiVersion
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:text
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:ingress_type:Ingress
       - displayName: LoadBalancer Annotations
         path: loadbalancer_annotations
         x-descriptors:

--- a/deploy/olm-catalog/awx-operator/manifests/awx.ansible.com_awxs_crd.yaml
+++ b/deploy/olm-catalog/awx-operator/manifests/awx.ansible.com_awxs_crd.yaml
@@ -102,6 +102,9 @@ spec:
               ingress_annotations:
                 description: Annotations to add to the ingress
                 type: string
+              ingress_apiversion:
+                description: apiVersion to use for the ingress
+                type: string
               ingress_tls_secret:
                 description: Secret where the ingress TLS secret can be found
                 type: string

--- a/roles/installer/defaults/main.yml
+++ b/roles/installer/defaults/main.yml
@@ -20,7 +20,10 @@ service_labels: ''
 #   kubernetes.io/ingress.class: nginx
 #   nginx.ingress.kubernetes.io/proxy-connect-timeout: 60s
 ingress_annotations: ''
-
+# The default ingress_apiversion is extensions/v1beta1, but if you have
+# a newer nginx-ingress deployment in k8s, you may need to change this to
+# networking.k8s.io/v1beta1.
+ingress_apiversion: 'extensions/v1beta1'
 # TLS secret for the ingress. The secret either has to exist before hand with
 # the corresponding cert and key or just be an indicator for where an automated
 # process like cert-manager (enabled via annotations) will store the TLS

--- a/roles/installer/templates/ingress.yaml.j2
+++ b/roles/installer/templates/ingress.yaml.j2
@@ -1,6 +1,6 @@
 {% if 'ingress' == ingress_type|lower %}
 ---
-apiVersion: extensions/v1beta1
+apiVersion: '{{ ingress_apiversion }}'
 kind: Ingress
 metadata:
   name: '{{ meta.name }}-ingress'
@@ -20,6 +20,14 @@ spec:
     - host: '{{ hostname }}'
       http:
         paths:
+{% if ingress_apiversion == 'networking.k8s.io/v1' %}
+          - path: /
+            backend:
+              service:
+                name: '{{ meta.name }}-service'
+                port:
+                  number: 80
+{% else %}
           - path: /
             backend:
               serviceName: '{{ meta.name }}-service'


### PR DESCRIPTION
In #205, newer ingress is broken by not using networking.k8s.io/v1,
but this may not be the case for all users.

Allow apiVersion to be set by the user.

Default to networking.k8s.io/v1, but add a note in the README.md about
older k8s or ingress-nginx to use networking.k8s.io/v1beta1.

Signed-off-by: Bryan Hundven <bryanhundven@gmail.com>