### PR TITLE
olm manifests: fix wrong identation making file incorrect

### DIFF
--- a/deploy/olm-catalog/awx-operator/manifests/awx.ansible.com_awxs_crd.yaml
+++ b/deploy/olm-catalog/awx-operator/manifests/awx.ansible.com_awxs_crd.yaml
@@ -149,37 +149,37 @@ spec:
                 description: node tolerations for the Postgres pods
                 type: string
               tower_postgres_storage_requirements:
-                  description: Storage requirements for the PostgreSQL container
-                  properties:
-                    requests:
-                      properties:
-                        storage:
-                          type: string
-                      type: object
-                    limits:
-                      properties:
-                        storage:
-                          type: string
-                      type: object
-                  type: object
-                tower_postgres_resource_requirements:
-                  description: Resource requirements for the PostgreSQL container
-                  properties:
-                    requests:
-                      properties:
-                        cpu:
-                          type: string
-                        memory:
-                          type: string
-                      type: object
-                    limits:
-                      properties:
-                        cpu:
-                          type: string
-                        memory:
-                          type: string
-                      type: object
-                  type: object
+                description: Storage requirements for the PostgreSQL container
+                properties:
+                  requests:
+                    properties:
+                      storage:
+                        type: string
+                    type: object
+                  limits:
+                    properties:
+                      storage:
+                        type: string
+                    type: object
+                type: object
+              tower_postgres_resource_requirements:
+                description: Resource requirements for the PostgreSQL container
+                properties:
+                  requests:
+                    properties:
+                      cpu:
+                        type: string
+                      memory:
+                        type: string
+                    type: object
+                  limits:
+                    properties:
+                      cpu:
+                        type: string
+                      memory:
+                        type: string
+                    type: object
+                type: object
               tower_postgres_storage_class:
                 description: Storage class to use for the PostgreSQL PVC
                 type: string


### PR DESCRIPTION
Currently the file is inacurrate and yaml parsing would fail on line 166
with

>  syntax error: expected < block end >, but found '< block mapping start >' (syntax)