### PR TITLE
Add templated EE volume mount var to operator config

### DIFF
--- a/deploy/awx-operator.yaml
+++ b/deploy/awx-operator.yaml
@@ -216,9 +216,14 @@ spec:
                   type: string
                 tower_web_extra_env:
                   type: string
+                tower_ee_extra_volume_mounts:
+                  description: Specify volume mounts to be added to Execution container
+                  type: string
                 tower_task_extra_volume_mounts:
+                  description: Specify volume mounts to be added to Task container
                   type: string
                 tower_web_extra_volume_mounts:
+                  description: Specify volume mounts to be added to the Web container
                   type: string
                 tower_redis_image:
                   description: Registry path to the redis container to use

--- a/deploy/crds/awx_v1beta1_crd.yaml
+++ b/deploy/crds/awx_v1beta1_crd.yaml
@@ -214,9 +214,14 @@ spec:
                   type: string
                 tower_web_extra_env:
                   type: string
+                tower_ee_extra_volume_mounts:
+                  description: Specify volume mounts to be added to Execution container
+                  type: string
                 tower_task_extra_volume_mounts:
+                  description: Specify volume mounts to be added to Task container
                   type: string
                 tower_web_extra_volume_mounts:
+                  description: Specify volume mounts to be added to the Web container
                   type: string
                 tower_redis_image:
                   description: Registry path to the redis container to use


### PR DESCRIPTION
It looks like the `tower_ee_extra_volume_mounts` var got added [here](https://github.com/ansible/awx-operator/commit/90f25ab20cef7a420338428b41dc0b61f71c59cb#diff-7f28409549c4d80fd71235160e550a93285f14ab0a26e911c3ce9ff9400c890eR217-R219), but never got added to the `awx-operator.yml` file resulting from the template.  

This would normally get picked up when we release the next awx-operator version, but it is showing up in my diffs during development, so I figured I'd put up a PR for it.  