### PR TITLE
Mounts /var/lib/awx/projects on awx-web container

### DIFF
--- a/roles/installer/templates/tower_deployment.yaml.j2
+++ b/roles/installer/templates/tower_deployment.yaml.j2
@@ -104,6 +104,8 @@ spec:
               mountPath: "/var/run/awx-rsyslog"
             - name: rsyslog-dir
               mountPath: "/var/lib/awx/rsyslog"
+            - name: "{{ meta.name }}-projects"
+              mountPath: "/var/lib/awx/projects"
 {% if development_mode | bool %}
             - name: awx-devel
               mountPath: "/awx_devel"


### PR DESCRIPTION
To support manual SCM projects, the `awx-web` must mount the `/var/lib/awx/projects` directory. 

Fixes: #259 

Check https://github.com/ansible/awx-operator/issues/259#issuecomment-830250608 for more details
