### PR TITLE
Update ingress template to remove k8s warning

### DIFF
--- a/roles/installer/templates/tower_ingress.yaml.j2
+++ b/roles/installer/templates/tower_ingress.yaml.j2
@@ -1,6 +1,6 @@
 {% if 'ingress' == tower_ingress_type|lower %}
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: '{{ meta.name }}-ingress'


### PR DESCRIPTION
Before this commit : Warning in k8s when checking ingress resource 
`Warning: extensions/v1beta1 Ingress is deprecated in v1.14+, unavailable in v1.22+; use networking.k8s.io/v1 Ingress`

After this commit: Warning no longer appears and some future proofing in place