### PR TITLE
Added initial CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+This is a list of high-level changes for each release of `awx-operator`. A full list of commits can be found at `https://github.com/ansible/awx-operator/releases/tag/<version>`.
+
+# 0.9.0 (May 1, 2021)
+
+- Update playbook to allow for deploying custom image version/tag (Shane McDonald) - 77e7039 
+- Mounts /var/lib/awx/projects on awx-web container (Marcelo Moreira de Mello) - f21ec4d 
+- Extra Settings: Allow one to pass extra API configuration settings. (Yanis Guenane) - 1d14ebc 
+- PostgreSQL: Properly handle variable name difference when using Red Hat containers (Yanis Guenane) - 2965a90 
+- Deployment type: Make more fields dynamic based on that field (Yanis Guenane) - 4706aa9 
+- Add templated EE volume mount var to operator config (Christian M. Adams) - e55d83f 
+- Add NodePort to tower_ingress_type enum (TheStally) - 96b878f 
+- Split container image and version in 2 variables (Marcelo Moreira de Mello) - bc34758 (breaking_change)
+- Handles deleting and recreating statefulset and deployment when needed (Marcelo Moreira de Mello) - 597356f 
+- Add tower_ingress_type NodePort (stal) - 1b87616 
+- expose settings to use custom volumes and volume mounts (Gabe Muniz) - 8d65b84 
+- Inherit imagePullPolicy to redis container (Marcelo Moreira de Mello) - 83a85d1 
+- Add nodeSelector and tolerations for Postgres pod (Ernesto Pérez) - 151ff11 
+- Added support to override pg_sslmode (Marcelo Moreira de Mello) - 298d39c 

--- a/README.md
+++ b/README.md
@@ -636,6 +636,10 @@ There are a few moving parts to this project:
 
   1. The Docker image which powers AWX Operator.
   2. The `awx-operator.yaml` Kubernetes manifest file which initially deploys the Operator into a cluster.
+  3. Then use the command below to generate a list of commits between the versions.
+  ```sh
+  #> git log --pretty="- %s (%an) - %h " <old_tag>..<new_tag> | grep -v Merge
+  ```
 
 Each of these must be appropriately built in preparation for a new tag:
 


### PR DESCRIPTION
Added initial `CHANGELOG.md` which should highlight important commits and `breaking_changes` between versions. 

On the `Release Notes` for `0.9.0`, we could add the full list of commits 

```bash
git log --pretty="- %s (%an) - %h " 0.8.0..0.9.0| grep -v Merge
- Use 'admin' username in tests (Shane McDonald) - ca20dcf 
- Remove isolated logger from configmap (Shane McDonald) - 67a650c 
- Bump version (Shane McDonald) - acb4434 
- Regenerate files (Shane McDonald) - 3f2bb3e 
- Bump AWX version (Shane McDonald) - c318611 
- Update playbook to allow for deploying custom image version/tag (Shane McDonald) - 77e7039 
- Mounts /var/lib/awx/projects on awx-web container (Marcelo Moreira de Mello) - f21ec4d 
- Extra Settings: Allow one to pass extra API configuration settings. (Yanis Guenane) - 1d14ebc 
- PostgreSQL: Properly handle variable name difference when using Red Hat containers (Yanis Guenane) - 2965a90 
- Properly hide tower_ee_images (Yanis Guenane) - 1602096 
- Deployment type: Make more fields dynamic based on that field (Yanis Guenane) - 4706aa9 
- Handle statefulset updates (Marcelo Moreira de Mello) - 3d5a9ea 
- Add templated EE volume mount var to operator config (Christian M. Adams) - e55d83f 
- olm manifests: fix wrong identation making file incorrect (Yanis Guenane) - 1262287 
- Fix service type logic (Shane McDonald) - c0e164d 
- Extra changes for new tower_ingress_type  NodePort (stal) - 5b38c85 
- added missing comma, to AWX execution_environets.py file (Ilija Matoski) - 72c122d 
- Update default ee version (Shane McDonald) - 5779afd 
- updated coumentation (Marcelo Moreira de Mello) - 52768c9 
- Add NodePort to tower_ingress_type enum (TheStally) - 96b878f 
- Fix template logic (TheStally) - a00052a 
- Make displayName for PostgreSQL parameters single line (Thom Wijtenburg) - 4596c30 
- updated documentation (Marcelo Moreira de Mello) - 051500f 
- Split container image and version in 2 variables (Marcelo Moreira de Mello) - bc34758 
- updated (Marcelo Moreira de Mello) - 46fca2a 
- updated (Marcelo Moreira de Mello) - dc073c8 
- Handles deleting and recreating statefulset and deployment when needed (Marcelo Moreira de Mello) - 597356f 
- Stop telling folks to use devel (Shane McDonald) - 51ea411 
- migration: Clarify you can migrate in-place (Daniele Sluijters) - ea018be 
- Change default resource requirement to object (Thom Wijtenburg) - 841d1f9 
- Update variable table for PostgreSQL service (Thom Wijtenburg) - 262b1cc 
- Fix PostgreSQL resource requests (Thom Wijtenburg) - 378a33a 
- Added initial upgrade documentation (Marcelo Moreira de Mello) - 0965205 
- Updated logic to avoid crash during upgrades (Marcelo Moreira de Mello) - 39ef816 
- added documentation around environment variables (Gabe Muniz) - f68dc77 
- added default value for ee extra mounts (Gabe Muniz) - 9de67ad 
- added warning about kubernetes api naming (Gabe Muniz) - 8922e9f 
- added ability to mount to Execution container with example (Gabe Muniz) - 90f25ab 
- added ability to mount conf.d and fixed underscore api issue (Gabe Muniz) - 6c476a9 
- Add tower_ingress_type NodePort (stal) - 1b87616 
- expose settings to use custom volumes and volume mounts (Gabe Muniz) - 8d65b84 
- Correction, replace tower_tolerations by tower_postgres_tolerations (Ernesto Pérez) - d4d9d2a 
- Correction, replace tower_node_selector by tower_postgres_selector (Ernesto Pérez) - 1cc47f7 
- Inherit imagePullPolicy to redis container (Marcelo Moreira de Mello) - 83a85d1 
- Fix yaml missing starting space in comment (Ernesto Pérez) - 0ab33a1 
- Postgres selector and tolerations description included in README.md (Ernesto Pérez) - 30e4ad0 
- Add nodeSelector and tolerations for Postgres pod (Ernesto Pérez) - 151ff11 
- Removed jinja2 filter 'quote' for db password (Marcelo Moreira de Mello) - 5707112 
- Add Service types to docs based on Ingress used (stal) - 0f90847 
- use ClusterIP service when ingress type is Ingress (stal) - e091b32 
- Added support to override pg_sslmode (Marcelo Moreira de Mello) - 298d39c 
- Added conditional to validate that tower_loadbalancer_annotations is defined (Ryland DeGregory) - 95f04ab 
- Updated protocol var in LoadBalancer ingress spec (Ryland DeGregory) - 7e3f504 
- Add GHA workflow for pushing releases to Quay (Shane McDonald) - 295ed47 



``` 
