### PR TITLE
Persist secret names from old deployment & add them to the spec

### DIFF
--- a/ansible/templates/awxbackup_crd.yml.j2
+++ b/ansible/templates/awxbackup_crd.yml.j2
@@ -41,21 +41,8 @@ spec:
                 backup_storage_class:
                   description: Storage class to use when creating PVC for backup
                   type: string
-                tower_secret_key_secret:
-                  description: Custom secret_key secret name
-                  type: string
-                tower_admin_password_secret:
-                  description: Custom admin_password secret name
-                  type: string
-                tower_broadcast_websocket_secret:
-                  description: Custom broadcast_websocket secret name
-                  type: string
-                tower_postgres_configuration_secret:
-                  description: Custom postgres_configuration secret name
-                  type: string
                 postgres_label_selector:
                   description: Label selector used to identify postgres pod for backing up data
                   type: string
-
               oneOf:
                 - required: ["deployment_name"]

--- a/ansible/templates/awxrestore_crd.yml.j2
+++ b/ansible/templates/awxrestore_crd.yml.j2
@@ -29,7 +29,7 @@ spec:
                 deployment_name:
                   description: Name of the deployment to be restored to
                   type: string
-                backup:
+                backup_name:
                   description: AWXBackup object name
                   type: string
                 backup_pvc:
@@ -40,18 +40,6 @@ spec:
                   type: string
                 backup_dir:
                   description: Backup directory name, set as a status found on the awxbackup object (backupDirectory)
-                  type: string
-                tower_secret_key_secret:
-                  description: Custom secret_key secret name
-                  type: string
-                tower_admin_password_secret:
-                  description: Custom admin_password secret name
-                  type: string
-                tower_broadcast_websocket_secret:
-                  description: Custom broadcast_websocket secret name
-                  type: string
-                tower_postgres_configuration_secret:
-                  description: Custom postgres_configuration secret name
                   type: string
                 postgres_label_selector:
                   description: Label selector used to identify postgres pod for backing up data

--- a/ansible/templates/crd.yml.j2
+++ b/ansible/templates/crd.yml.j2
@@ -351,13 +351,13 @@ spec:
                 towerAdminPasswordSecret:
                   description: Admin password secret name of the deployed instance
                   type: string
-                towerPostgresConfigurationSecret:
+                postgresConfigurationSecret:
                   description: Postgres Configuration secret name of the deployed instance
                   type: string
-                towerBroadcastWebsocketSecret:
+                broadcastWebsocketSecret:
                   description: Broadcast websocket secret name of the deployed instance
                   type: string
-                towerSecretKeySecret:
+                secretKeySecret:
                   description: Secret key secret name of the deployed instance
                   type: string
                 towerMigratedFromSecret:

--- a/deploy/awx-operator.yaml
+++ b/deploy/awx-operator.yaml
@@ -353,13 +353,13 @@ spec:
                 towerAdminPasswordSecret:
                   description: Admin password secret name of the deployed instance
                   type: string
-                towerPostgresConfigurationSecret:
+                postgresConfigurationSecret:
                   description: Postgres Configuration secret name of the deployed instance
                   type: string
-                towerBroadcastWebsocketSecret:
+                broadcastWebsocketSecret:
                   description: Broadcast websocket secret name of the deployed instance
                   type: string
-                towerSecretKeySecret:
+                secretKeySecret:
                   description: Secret key secret name of the deployed instance
                   type: string
                 towerMigratedFromSecret:
@@ -431,22 +431,9 @@ spec:
                 backup_storage_class:
                   description: Storage class to use when creating PVC for backup
                   type: string
-                tower_secret_key_secret:
-                  description: Custom secret_key secret name
-                  type: string
-                tower_admin_password_secret:
-                  description: Custom admin_password secret name
-                  type: string
-                tower_broadcast_websocket_secret:
-                  description: Custom broadcast_websocket secret name
-                  type: string
-                tower_postgres_configuration_secret:
-                  description: Custom postgres_configuration secret name
-                  type: string
                 postgres_label_selector:
                   description: Label selector used to identify postgres pod for backing up data
                   type: string
-
               oneOf:
                 - required: ["deployment_name"]
 
@@ -481,7 +468,7 @@ spec:
                 deployment_name:
                   description: Name of the deployment to be restored to
                   type: string
-                backup:
+                backup_name:
                   description: AWXBackup object name
                   type: string
                 backup_pvc:
@@ -492,18 +479,6 @@ spec:
                   type: string
                 backup_dir:
                   description: Backup directory name, set as a status found on the awxbackup object (backupDirectory)
-                  type: string
-                tower_secret_key_secret:
-                  description: Custom secret_key secret name
-                  type: string
-                tower_admin_password_secret:
-                  description: Custom admin_password secret name
-                  type: string
-                tower_broadcast_websocket_secret:
-                  description: Custom broadcast_websocket secret name
-                  type: string
-                tower_postgres_configuration_secret:
-                  description: Custom postgres_configuration secret name
                   type: string
                 postgres_label_selector:
                   description: Label selector used to identify postgres pod for backing up data

--- a/deploy/crds/awx_v1beta1_crd.yaml
+++ b/deploy/crds/awx_v1beta1_crd.yaml
@@ -351,13 +351,13 @@ spec:
                 towerAdminPasswordSecret:
                   description: Admin password secret name of the deployed instance
                   type: string
-                towerPostgresConfigurationSecret:
+                postgresConfigurationSecret:
                   description: Postgres Configuration secret name of the deployed instance
                   type: string
-                towerBroadcastWebsocketSecret:
+                broadcastWebsocketSecret:
                   description: Broadcast websocket secret name of the deployed instance
                   type: string
-                towerSecretKeySecret:
+                secretKeySecret:
                   description: Secret key secret name of the deployed instance
                   type: string
                 towerMigratedFromSecret:

--- a/deploy/crds/awxbackup_v1beta1_crd.yaml
+++ b/deploy/crds/awxbackup_v1beta1_crd.yaml
@@ -41,21 +41,8 @@ spec:
                 backup_storage_class:
                   description: Storage class to use when creating PVC for backup
                   type: string
-                tower_secret_key_secret:
-                  description: Custom secret_key secret name
-                  type: string
-                tower_admin_password_secret:
-                  description: Custom admin_password secret name
-                  type: string
-                tower_broadcast_websocket_secret:
-                  description: Custom broadcast_websocket secret name
-                  type: string
-                tower_postgres_configuration_secret:
-                  description: Custom postgres_configuration secret name
-                  type: string
                 postgres_label_selector:
                   description: Label selector used to identify postgres pod for backing up data
                   type: string
-
               oneOf:
                 - required: ["deployment_name"]

--- a/deploy/crds/awxrestore_v1beta1_crd.yaml
+++ b/deploy/crds/awxrestore_v1beta1_crd.yaml
@@ -29,7 +29,7 @@ spec:
                 deployment_name:
                   description: Name of the deployment to be restored to
                   type: string
-                backup:
+                backup_name:
                   description: AWXBackup object name
                   type: string
                 backup_pvc:
@@ -40,18 +40,6 @@ spec:
                   type: string
                 backup_dir:
                   description: Backup directory name, set as a status found on the awxbackup object (backupDirectory)
-                  type: string
-                tower_secret_key_secret:
-                  description: Custom secret_key secret name
-                  type: string
-                tower_admin_password_secret:
-                  description: Custom admin_password secret name
-                  type: string
-                tower_broadcast_websocket_secret:
-                  description: Custom broadcast_websocket secret name
-                  type: string
-                tower_postgres_configuration_secret:
-                  description: Custom postgres_configuration secret name
                   type: string
                 postgres_label_selector:
                   description: Label selector used to identify postgres pod for backing up data

--- a/roles/backup/README.md
+++ b/roles/backup/README.md
@@ -69,7 +69,7 @@ backup_pvc_namespace: 'custom-namespace'
 ```
 
 If a custom postgres configuration secret was used when deploying AWX, it will automatically be used by the backup role.  
-To check the name of this secret, look at the towerPostgresConfigurationSecret status on your AWX object.  
+To check the name of this secret, look at the postgresConfigurationSecret status on your AWX object.  
 
 The postgresql pod for the old deployment is used when backing up data to the new postgresql pod.  If your postgresql pod has a custom label,
 you can pass that via the `postgres_label_selector` variable to make sure the postgresql pod can be found.

--- a/roles/backup/tasks/postgres.yml
+++ b/roles/backup/tasks/postgres.yml
@@ -4,12 +4,12 @@
   k8s_info:
     kind: Secret
     namespace: '{{ meta.namespace }}'
-    name: "{{ this_awx['resources'][0]['status']['towerPostgresConfigurationSecret'] }}"
+    name: "{{ this_awx['resources'][0]['status']['postgresConfigurationSecret'] }}"
   register: pg_config
 
 - name: Fail if postgres configuration secret status does not exist
   fail:
-    msg: "The towerPostgresConfigurationSecret status is not set on the AWX object yet or the secret has been deleted."
+    msg: "The postgresConfigurationSecret status is not set on the AWX object yet or the secret has been deleted."
   when: not pg_config | default([]) | length
 
 - name: Store Database Configuration

--- a/roles/backup/tasks/secrets.yml
+++ b/roles/backup/tasks/secrets.yml
@@ -4,7 +4,7 @@
   k8s_info:
     kind: Secret
     namespace: '{{ meta.namespace }}'
-    name: "{{ this_awx['resources'][0]['status']['towerSecretKeySecret'] }}"
+    name: "{{ this_awx['resources'][0]['status']['secretKeySecret'] }}"
   register: _secret_key
 
 - name: Set secret key
@@ -26,7 +26,7 @@
   k8s_info:
     kind: Secret
     namespace: '{{ meta.namespace }}'
-    name: "{{ this_awx['resources'][0]['status']['towerBroadcastWebsocketSecret'] }}"
+    name: "{{ this_awx['resources'][0]['status']['broadcastWebsocketSecret'] }}"
   register: _broadcast_websocket
 
 - name: Set broadcast_websocket key
@@ -37,8 +37,13 @@
   k8s_info:
     kind: Secret
     namespace: '{{ meta.namespace }}'
-    name: "{{ this_awx['resources'][0]['status']['towerPostgresConfigurationSecret'] }}"
+    name: "{{ this_awx['resources'][0]['status']['postgresConfigurationSecret'] }}"
   register: _postgres_configuration
+
+- name: Set postgres type
+  set_fact:
+    database_type: "{{ _postgres_configuration['resources'][0]['data']['type'] | b64decode }}"
+  when: _postgres_configuration['resources'][0]['data']['type'] is defined
 
 - name: Set postgres configuration
   set_fact:
@@ -47,7 +52,6 @@
     database_name: "{{ _postgres_configuration['resources'][0]['data']['database'] | b64decode }}"
     database_port: "{{ _postgres_configuration['resources'][0]['data']['port'] | b64decode }}"
     database_host: "{{ _postgres_configuration['resources'][0]['data']['host'] | b64decode }}"
-    database_type: "{{ _postgres_configuration['resources'][0]['data']['type'] | b64decode | default('unmanaged') }}"
 
 - name: Template secrets into yaml
   set_fact:

--- a/roles/backup/templates/secrets.yml.j2
+++ b/roles/backup/templates/secrets.yml.j2
@@ -1,4 +1,8 @@
 ---
+secret_key_secret_name: "{{ _secret_key['resources'][0]['metadata']['name'] }}"
+admin_password_secret_name: "{{ _admin_password['resources'][0]['metadata']['name'] }}"
+broadcast_websocket_secret_name: "{{ _broadcast_websocket['resources'][0]['metadata']['name'] }}"
+postgres_configuration_secret_name: "{{ _postgres_configuration['resources'][0]['metadata']['name'] }}"
 secret_key: {{ secret_key }}
 admin_password: {{ admin_password }}
 broadcast_websocket: {{ broadcast_websocket }}

--- a/roles/backup/vars/main.yml
+++ b/roles/backup/vars/main.yml
@@ -2,3 +2,4 @@
 deployment_type: "awx"
 postgres_image: postgres:12
 backup_complete: false
+database_type: "unmanaged"

--- a/roles/installer/tasks/update_status.yml
+++ b/roles/installer/tasks/update_status.yml
@@ -24,7 +24,7 @@
     name: "{{ meta.name }}"
     namespace: "{{ meta.namespace }}"
     status:
-      towerPostgresConfigurationSecret: "{{ pg_config['resources'][0]['metadata']['name'] }}"
+      postgresConfigurationSecret: "{{ pg_config['resources'][0]['metadata']['name'] }}"
 
 - name: Update broadcast websocket status
   operator_sdk.util.k8s_status:
@@ -33,7 +33,7 @@
     name: "{{ meta.name }}"
     namespace: "{{ meta.namespace }}"
     status:
-      towerBroadcastWebsocketSecret: "{{ broadcast_websocket_secret['resources'][0]['metadata']['name'] }}"
+      broadcastWebsocketSecret: "{{ broadcast_websocket_secret['resources'][0]['metadata']['name'] }}"
 
 - name: Update secret key status
   operator_sdk.util.k8s_status:
@@ -42,7 +42,7 @@
     name: "{{ meta.name }}"
     namespace: "{{ meta.namespace }}"
     status:
-      towerSecretKeySecret: "{{ secret_key_secret_name }}"
+      secretKeySecret: "{{ secret_key_secret_name }}"
 
 - name: Retrieve instance version
   k8s_exec:

--- a/roles/installer/templates/tower_postgres.yaml.j2
+++ b/roles/installer/templates/tower_postgres.yaml.j2
@@ -36,17 +36,17 @@ spec:
             - name: POSTGRESQL_DATABASE
               valueFrom:
                 secretKeyRef:
-                  name: '{{ meta.name }}-postgres-configuration'
+                  name: '{{ postgres_configuration_secret }}'
                   key: database
             - name: POSTGRESQL_USER
               valueFrom:
                 secretKeyRef:
-                  name: '{{ meta.name }}-postgres-configuration'
+                  name: '{{ postgres_configuration_secret }}'
                   key: username
             - name: POSTGRESQL_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: '{{ meta.name }}-postgres-configuration'
+                  name: '{{ postgres_configuration_secret }}'
                   key: password
 
             # For tower_postgres_image based on postgres

--- a/roles/restore/README.md
+++ b/roles/restore/README.md
@@ -32,7 +32,7 @@ metadata:
   namespace: my-namespace
 spec:
   deployment_name: mytower
-  backup: awxbackup-2021-04-22
+  backup_name: awxbackup-2021-04-22
   backup_pvc_namespace: 'old-awx-namespace'
 ```
 

--- a/roles/restore/defaults/main.yml
+++ b/roles/restore/defaults/main.yml
@@ -10,5 +10,3 @@ backup_pvc_namespace: ''
 
 # Required: backup name, found on the awxbackup object
 backup_dir: ''
-
-tower_postgres_configuration_secret: "{{ deployment_name }}-postgres-configuration"

--- a/roles/restore/tasks/cleanup.yml
+++ b/roles/restore/tasks/cleanup.yml
@@ -18,7 +18,7 @@
         namespace: '{{ meta.namespace }}'
         ownerReferences: null
   loop:
-    - '{{ deployment_name }}-admin-password'
-    - '{{ deployment_name }}-secret-key'
-    - '{{ deployment_name }}-postgres-configuration'
-    - '{{ deployment_name }}-broadcast-websocket'
+    - '{{ secret_key_secret_name }}'
+    - '{{ admin_password_secret_name }}'
+    - '{{ broadcast_websocket_secret_name }}'
+    - '{{ postgres_configuration_secret_name }}'

--- a/roles/restore/tasks/deploy_awx.yml
+++ b/roles/restore/tasks/deploy_awx.yml
@@ -8,9 +8,30 @@
       bash -c "cat '{{ backup_dir }}/awx_object'"
   register: awx_object
 
-- name: Set AWX spec variable from backup
+- name: Create temp file for spec dict
+  tempfile:
+    state: file
+  register: tmp_spec
+
+- name: Write spec vars to temp file
+  shell: |
+    echo '{{ awx_object.stdout }} > {{ tmp_spec.path }}'
+
+- include_vars: "{{ tmp_spec.path }}"
+  register: spec
+
+- name: Use include_vars to read in spec as a dict (because spec doesn't have quotes)
   set_fact:
-    awx_spec: "{{ awx_object.stdout }}"
+    awx_spec: "{{ spec.ansible_facts }}"
+
+- name: Set names of backed up secrets in the CR spec
+  set_fact:
+    awx_spec: "{{ awx_spec | combine ({ item.key : item.value }) }}"
+  with_items:
+    - {'key': 'tower_secret_key_secret', 'value': '{{ secret_key_secret_name }}'}
+    - {'key': 'tower_admin_password_secret', 'value': '{{ admin_password_secret_name }}'}
+    - {'key': 'tower_broadcast_websocket_secret', 'value': '{{ broadcast_websocket_secret_name }}'}
+    - {'key': 'tower_postgres_configuration_secret', 'value': '{{ postgres_configuration_secret_name }}'}
 
 - name: Deploy AWX
   k8s:
@@ -22,10 +43,6 @@
     wait_condition:
       type: "Running"
       status: "True"
-
-# TODO: Add logic to allow users to provide override values here,
-#       or to specify spec values that were not in the backed up AWX object.
-#       This may involve changing how we back up the spec section of the AWX object
 
 - name: Remove ownerReferences to prevent garbage collection of new AWX CRO
   k8s:

--- a/roles/restore/tasks/deploy_awx.yml
+++ b/roles/restore/tasks/deploy_awx.yml
@@ -14,9 +14,9 @@
   register: tmp_spec
 
 - name: Write spec vars to temp file
-  shell: |
-    echo '{{ awx_object.stdout }} > {{ tmp_spec.path }}'
-  changed_when: false
+  copy:
+    content: "{{ awx_object.stdout }}"
+    dest: "{{ tmp_spec.path }}"
 
 - name: Include spec vars to save them as a dict
   include_vars: "{{ tmp_spec.path }}"

--- a/roles/restore/tasks/deploy_awx.yml
+++ b/roles/restore/tasks/deploy_awx.yml
@@ -16,8 +16,10 @@
 - name: Write spec vars to temp file
   shell: |
     echo '{{ awx_object.stdout }} > {{ tmp_spec.path }}'
+  changed_when: false
 
-- include_vars: "{{ tmp_spec.path }}"
+- name: Include spec vars to save them as a dict
+  include_vars: "{{ tmp_spec.path }}"
   register: spec
 
 - name: Use include_vars to read in spec as a dict (because spec doesn't have quotes)

--- a/roles/restore/tasks/init.yml
+++ b/roles/restore/tasks/init.yml
@@ -2,23 +2,39 @@
 
 - name: Set variables from awxbackup object statuses if provided
   block:
-  - name: Look up details for the backup object
+  - name: Look up details for the backup
     k8s_info:
-      api_version: "{{ api_version }}"
-      kind: "AWXBackup"
-      name: "{{ backup }}"
+      api_version: "{{ backup_api_version }}"
+      kind: "{{ backup_kind }}"
+      name: "{{ backup_name }}"
       namespace: "{{ backup_pvc_namespace }}"
     register: this_backup
 
-  - name: Set backup pvc name from status
+  - name: Surface error to user
+    block:
+      - name: Set error message
+        set_fact:
+          error_msg: "Cannot read the backup status variables for {{ backup_kind }} {{ backup_name  }}."
+
+      - name: Handle error
+        import_tasks: error_handling.yml
+
+      - name: Fail early if pvc is defined but does not exist
+        fail:
+          msg: "{{ error_msg }}"
+    when:
+      - this_backup['resources'] | length == 0
+      - this_backup['resources'][0] is not defined
+      - this_backup['resources'][0]['status'] is not defined
+      - this_backup['resources'][0]['status']['backupClaim'] is not defined
+      - this_backup['resources'][0]['status']['backupDirectory'] is not defined
+
+  - name: Set backup facts
     set_fact:
       backup_pvc: "{{ this_backup['resources'][0]['status']['backupClaim'] }}"
-
-  - name: Set tmp backup directory from status
-    set_fact:
       backup_dir: "{{ this_backup['resources'][0]['status']['backupDirectory'] }}"
   when:
-    - backup != '' or backup is defined
+    - backup_name != '' or backup_name is defined
 
 # Check to make sure provided pvc exists, error loudly if not.  Otherwise, the management pod will just stay in pending state forever.
 - name: Check provided PVC exists

--- a/roles/restore/tasks/main.yml
+++ b/roles/restore/tasks/main.yml
@@ -28,5 +28,3 @@
 
 - name: Update status variables
   include_tasks: update_status.yml
-
-# TODO: backup tower settings or make sure that users only specify settings/config changes via AWX object.  See ticket

--- a/roles/restore/tasks/postgres.yml
+++ b/roles/restore/tasks/postgres.yml
@@ -4,20 +4,8 @@
   k8s_info:
     kind: Secret
     namespace: '{{ meta.namespace }}'
-    name: '{{ tower_postgres_configuration_secret }}'
-  register: _custom_pg_config_resources
-  when: tower_postgres_configuration_secret | length
-
-- name: Check for default PostgreSQL configuration
-  k8s_info:
-    kind: Secret
-    namespace: '{{ meta.namespace }}'
-    name: '{{ deployment_name }}-postgres-configuration'
-  register: _default_pg_config_resources
-
-- name: Set PostgreSQL configuration
-  set_fact:
-    pg_config: '{{ _custom_pg_config_resources["resources"] | default([]) | length | ternary(_custom_pg_config_resources, _default_pg_config_resources) }}'
+    name: '{{ postgres_configuration_secret_name }}'
+  register: pg_config
 
 - name: Store Database Configuration
   set_fact:

--- a/roles/restore/templates/secrets.yml.j2
+++ b/roles/restore/templates/secrets.yml.j2
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: '{{ deployment_name }}-postgres-configuration'
+  name: '{{ postgres_configuration_secret_name }}'
   namespace: '{{ meta.namespace }}'
 stringData:
   password: '{{ database_password }}'
@@ -18,7 +18,7 @@ stringData:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: '{{ deployment_name }}-secret-key'
+  name: '{{ secret_key_secret_name }}'
   namespace: '{{ meta.namespace }}'
 stringData:
   secret_key: '{{ secret_key }}'
@@ -28,7 +28,7 @@ stringData:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: '{{ deployment_name }}-admin-password'
+  name: '{{ admin_password_secret_name }}'
   namespace: '{{ meta.namespace }}'
 stringData:
   password: '{{ admin_password }}'
@@ -38,7 +38,7 @@ stringData:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: '{{ deployment_name }}-broadcast-websocket'
+  name: '{{ broadcast_websocket_secret_name }}'
   namespace: '{{ meta.namespace }}'
 stringData:
   secret: '{{ broadcast_websocket }}'

--- a/roles/restore/vars/main.yml
+++ b/roles/restore/vars/main.yml
@@ -2,3 +2,12 @@
 
 deployment_type: "awx"
 postgres_image: postgres:12
+
+backup_api_version: '{{ deployment_type }}.ansible.com/v1beta1'
+backup_kind: 'AWXBackup'
+
+# set default secret names to be used if a backup dir and claim are provided (not a backup_name)
+secret_key_secret_name: '{{ deployment_name }}-secret-key'
+admin_password_secret_name: '{{ deployment_name }}-admin-password'
+broadcast_websocket_secret_name: '{{ deployment_name }}-broadcast-websocket'
+postgres_configuration_secret_name: '{{ deployment_name }}-postgres-configuration'


### PR DESCRIPTION
## Summary

  - renamed some more variables to be consistent with the pulp-operator
  - removed unneeded vars from backup & restore crds
  - added a way to parse spec at restore time by including vars to
    get around the issue of triply nested quotes when using to_json

### Why?

1. Creating the secrets with default names in the new namespace is undesirable because the AWX CR spec will still include names to custom secrets the user specified.  So the new deployment ends up with a spec that doesn't match the state of the secrets being used, which would be a problem for future backups.  

2. After persisting the secret names to the new AWX CR spec, another problem arose, the secrets that didn't have a custom secret are now not set in the spec.  So we need to extend the spec.  See verbose explanation below:

At backup time, the secret gets named: `{{ old_tower_name }}-secret-key`, and that gets set as a var and written to the backup pvc.  Then at restore time, that secret gets created as {{ old_tower_name }}-secret-key and the {{ new_tower_name}} CR gets created.  The installer for that looks for an existing {{ new_tower_name }}-secret-key secret and doesn't find it, so it generates one by the name `{{ old_tower_name }}-secret-key`.  This means we end up with duplicate secrets with different values, which is confusing to the end user and not expected.  

![image](https://user-images.githubusercontent.com/11698892/116666868-7be1fc00-a969-11eb-958a-62f2f782f09a.png)


We don't know the name of the new deployment at the time of backup, so we are forced into passing the values into the spec vars.  We do this by combining the a dict of the secret names with the spec - [implemented here](https://github.com/rooftopcellist/awx-operator/pull/2/files#diff-15e71b7e97709f3557a1547aec4a94ddd121952ccc1b741308b45161ba8370d0R3-R34).  
