### PR TITLE
Make awx-operator compatible with Ansible 2.12

### DIFF
--- a/ansible/deploy-operator.yml
+++ b/ansible/deploy-operator.yml
@@ -1,6 +1,6 @@
 ---
 - name: Reconstruct awx-operator.yaml
-  include: chain-operator-files.yml
+  import_playbook: chain-operator-files.yml
 
 - name: Deploy Operator
   hosts: localhost


### PR DESCRIPTION
I'm still getting spun up with this stuff, so tacking some easy stuff to begin with, which I got from jam sessions with @shanemcd 

https://docs.ansible.com/ansible/2.4/include_module.html

> The include action was too confusing, dealing with both plays and tasks, being both dynamic and static. This module will be removed in version 2.8. As alternatives use include_tasks, import_playbook, import_tasks.

It might have been removed _after_ 2.9 as they punted.

Anyway, this new solution here:

https://docs.ansible.com/ansible/2.4/import_playbook_module.html#import-playbook

looks like it's been there since 2.4. I need this to work with Ansible devel, and doesn't seem to be any drawbacks.