### PR TITLE
Restore: set proper kind var after deploying AWX CR

### DIFF
--- a/roles/restore/tasks/deploy_awx.yml
+++ b/roles/restore/tasks/deploy_awx.yml
@@ -1,5 +1,9 @@
 ---
 
+- name: Save kind
+  set_fact:
+    _kind: "{{ kind }}"
+
 - name: Get AWX object definition from pvc
   k8s_exec:
     namespace: "{{ backup_pvc_namespace }}"
@@ -34,6 +38,10 @@
     - {'key': 'tower_admin_password_secret', 'value': '{{ admin_password_secret_name }}'}
     - {'key': 'tower_broadcast_websocket_secret', 'value': '{{ broadcast_websocket_secret_name }}'}
     - {'key': 'tower_postgres_configuration_secret', 'value': '{{ postgres_configuration_secret_name }}'}
+
+- name: Restore kind
+  set_fact:
+    kind: "{{ _kind }}"
 
 - name: Deploy AWX
   k8s:


### PR DESCRIPTION
https://github.com/ansible/awx-operator/blob/devel/roles/restore/tasks/deploy_awx.yml#L21-L23 overrides `kind` var, so https://github.com/ansible/awx-operator/blob/devel/roles/restore/tasks/update_status.yml#L6 tries to update the status of an AWX CR instead of AWXRestore one.

Fixes #292

Signed-off-by: Julen Landa Alustiza <jlanda@redhat.com>