### PR TITLE
Fixed LoadBalancer required variables in Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ spec:
   ...
   tower_ingress_type: LoadBalancer
   tower_loadbalancer_protocol: http
+  tower_loadbalancer_annotations: ''
 ```
 
   * NodePort


### PR DESCRIPTION
Added tower_loadbalancer_annotations: '' to readme.md, annotations are required in the AWX spec, or the install will fail.