### PR TITLE
Scale down the new deployment before restoring

### DIFF
--- a/roles/installer/templates/tower_postgres.yaml.j2
+++ b/roles/installer/templates/tower_postgres.yaml.j2
@@ -30,6 +30,7 @@ spec:
     spec:
       containers:
         - image: '{{ tower_postgres_image }}:{{ tower_postgres_image_version }}'
+          imagePullPolicy: '{{ tower_image_pull_policy }}'
           name: postgres
           env:
             # For tower_postgres_image based on rhel8/postgresql-12

--- a/roles/restore/tasks/postgres.yml
+++ b/roles/restore/tasks/postgres.yml
@@ -42,7 +42,7 @@
   k8s_info:
     api_version: v1
     kind: Deployment
-    name: "{{ meta.name }}"
+    name: "{{ deployment_name }}"
     namespace: "{{ meta.namespace }}"
   register: this_deployment
 
@@ -50,9 +50,10 @@
   k8s_scale:
     api_version: v1
     kind: Deployment
-    name: "{{ meta.name }}"
+    name: "{{ deployment_name }}"
     namespace: "{{ meta.namespace }}"
     replicas: 0
+    wait: yes
   when: this_deployment['resources'] | length
 
 - name: Set full resolvable host name for postgres pod


### PR DESCRIPTION
Corrects a typo causing the awx-operator to never scale down the new awx deployment before restoring to it's db.  In it's current state, this task is be skipped (unless you happen to name the awxrestore object the same as your awx object.  

I also made it so that the `tower_image_pull_policy` variable applies to the postgres image as well, but am happy to remove it if people don't find this useful.  