### PR TITLE
Make postgres sts labels consistent with k8s recommendations & pulp-operator

### DIFF
--- a/roles/installer/tasks/migrate_data.yml
+++ b/roles/installer/tasks/migrate_data.yml
@@ -14,7 +14,7 @@
 
 - name: Default label selector to custom resource generated postgres
   set_fact:
-    postgres_label_selector: "app.kubernetes.io/name={{ meta.name }}-postgres"
+    postgres_label_selector: "app.kubernetes.io/instance=postgres-{{ meta.name }}"
   when: postgres_label_selector is not defined
 
 - name: Get the postgres pod information

--- a/roles/installer/templates/tower_postgres.yaml.j2
+++ b/roles/installer/templates/tower_postgres.yaml.j2
@@ -6,7 +6,9 @@ metadata:
   name: '{{ meta.name }}-postgres'
   namespace: '{{ meta.namespace }}'
   labels:
-    app.kubernetes.io/name: '{{ meta.name }}-postgres'
+    app.kubernetes.io/name: 'postgres'
+    app.kubernetes.io/instance: 'postgres-{{ meta.name }}'
+    app.kubernetes.io/component: 'database'
     app.kubernetes.io/part-of: '{{ meta.name }}'
     app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
     app.kubernetes.io/operator-version: '{{ lookup("env", "OPERATOR_VERSION") }}'
@@ -14,9 +16,10 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: '{{ meta.name }}-postgres'
+      app.kubernetes.io/name: 'postgres'
+      app.kubernetes.io/instance: 'postgres-{{ meta.name }}'
+      app.kubernetes.io/component: 'database'
       app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
-      app.kubernetes.io/component: database
   serviceName: '{{ meta.name }}'
   replicas: 1
   updateStrategy:
@@ -24,10 +27,11 @@ spec:
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: '{{ meta.name }}-postgres'
+        app.kubernetes.io/name: 'postgres'
+        app.kubernetes.io/instance: 'postgres-{{ meta.name }}'
+        app.kubernetes.io/component: 'database'
         app.kubernetes.io/part-of: '{{ meta.name }}'
-        app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
-        app.kubernetes.io/component: database
+        app.kubernetes.io/managed-by: '{{ deployment_type }}-operator' 
     spec:
       containers:
         - image: '{{ tower_postgres_image }}:{{ tower_postgres_image_version }}'
@@ -108,7 +112,9 @@ metadata:
   name: '{{ meta.name }}-postgres'
   namespace: '{{ meta.namespace }}'
   labels:
-    app.kubernetes.io/name: '{{ meta.name }}-postgres'
+    app.kubernetes.io/name: 'postgres'
+    app.kubernetes.io/instance: 'postgres-{{ meta.name }}'
+    app.kubernetes.io/component: 'database'
     app.kubernetes.io/part-of: '{{ meta.name }}'
     app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
     app.kubernetes.io/operator-version: '{{ lookup("env", "OPERATOR_VERSION") }}'
@@ -118,6 +124,8 @@ spec:
     - port: 5432
   clusterIP: None
   selector:
-    app.kubernetes.io/name: '{{ meta.name }}-postgres'
+    app.kubernetes.io/name: 'postgres'
+    app.kubernetes.io/instance: 'postgres-{{ meta.name }}'
+    app.kubernetes.io/component: 'database'
+    app.kubernetes.io/part-of: '{{ meta.name }}'
     app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
-    app.kubernetes.io/component: database

--- a/roles/restore/tasks/postgres.yml
+++ b/roles/restore/tasks/postgres.yml
@@ -18,7 +18,7 @@
 
 - name: Default label selector to custom resource generated postgres
   set_fact:
-    postgres_label_selector: "app.kubernetes.io/name={{ deployment_name }}-postgres"
+    postgres_label_selector: "app.kubernetes.io/instance=postgres-{{ deployment_name }}"
   when: postgres_label_selector is not defined
 
 - name: Get the postgres pod information


### PR DESCRIPTION
This PR updates the postgres labels to conform with the recommendations in the kubernetes docs and to remain consistent with the pulp-operator.  
  - k8s recommended labels: https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/
  - [pulp-operator labels](https://github.com/pulp/pulp-operator/blob/31a60ca80f3e5484da1687d1d232e536e54eaa5e/roles/postgres/templates/postgres.yaml.j2#L7-L23)