### PR TITLE
Set initial value for tower_loadbalancer_annotations

### DIFF
--- a/roles/installer/defaults/main.yml
+++ b/roles/installer/defaults/main.yml
@@ -28,6 +28,7 @@ tower_ingress_tls_secret: ''
 
 tower_loadbalancer_protocol: 'http'
 tower_loadbalancer_port: '80'
+tower_loadbalancer_annotations: ''
 
 # The TLS termination mechanism to use to access
 # the services. Supported mechanism are: edge, passthrough


### PR DESCRIPTION
Fixes: #260

Fixes: #275


Using `devel`,  create a simple `AWX` with the following:

```yaml
apiVersion: awx.ansible.com/v1beta1
kind: AWX
metadata:
  name: awx-lb-annotations
  namespace: default
spec:
  kind: AWX
  tower_admin_user: admin
  tower_ingress_type: LoadBalancer
```
Here is the error:
```yaml
[awx-operator-84694f9865-kvbc2] ok: [localhost] => (item=tower_persistent) => {"ansible_loop_var": "item", "changed": false, "item": "tower_persistent", "result": {"results": []}} 
[awx-operator-84694f9865-kvbc2] fatal: [localhost]: FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: 'tower_loadbalancer_annotations' is undefined\n\nThe error appears to be in '/opt/ansible/roles/installer/tasks/resources_configuration.yml': line 20, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: Apply Resources\n  ^ here\n"} 
 awx-operator-84694f9865-kvbc2] 
 awx-operator-84694f9865-kvbc2] PLAY RECAP *********************************************************************
 awx-operator-84694f9865-kvbc2] localhost                  : ok=29   changed=0    unreachable=0    failed=1    skipped=26   rescued=0    ignored=0   
```
This PR address the initial value required which then returns the `service` entry as expected

```yaml
# kubectl get svc -o yaml awx-lb-annotations-service | kubectl neat
apiVersion: v1
kind: Service
metadata:
  labels:
    app.kubernetes.io/component: awx
    app.kubernetes.io/managed-by: awx-operator
    app.kubernetes.io/name: awx-lb-annotations
    app.kubernetes.io/part-of: awx-lb-annotations
  name: awx-lb-annotations-service
  namespace: default
spec:
  clusterIP: 10.233.57.245
  clusterIPs:
  - 10.233.57.245
  ports:
  - name: http
    nodePort: 31341
    port: 80
    targetPort: 8052
  selector:
    app.kubernetes.io/component: awx
    app.kubernetes.io/managed-by: awx-operator
    app.kubernetes.io/name: awx-lb-annotations
  type: LoadBalancer
```
