### PR TITLE
Adds operator-version to k8s resources

### DIFF
--- a/ansible/templates/operator.yml.j2
+++ b/ansible/templates/operator.yml.j2
@@ -33,6 +33,8 @@ spec:
               value: awx-operator
             - name: ANSIBLE_GATHERING
               value: explicit
+            - name: OPERATOR_VERSION
+              value: "{{ operator_version }}"
           livenessProbe:
             httpGet:
               path: /healthz

--- a/deploy/awx-operator.yaml
+++ b/deploy/awx-operator.yaml
@@ -635,6 +635,8 @@ spec:
               value: awx-operator
             - name: ANSIBLE_GATHERING
               value: explicit
+            - name: OPERATOR_VERSION
+              value: "0.9.0"
           livenessProbe:
             httpGet:
               path: /healthz

--- a/roles/installer/tasks/main.yml
+++ b/roles/installer/tasks/main.yml
@@ -15,6 +15,7 @@
           app.kubernetes.io/part-of: '{{ meta.name }}'
           app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
           app.kubernetes.io/component: '{{ deployment_type }}'
+          app.kubernetes.io/operator-version: '{{ lookup("env", "OPERATOR_VERSION") }}'
 
 - name: Include secret key configuration tasks
   include_tasks: secret_key_configuration.yml

--- a/roles/installer/templates/tower_admin_password_secret.yaml.j2
+++ b/roles/installer/templates/tower_admin_password_secret.yaml.j2
@@ -9,5 +9,6 @@ metadata:
     app.kubernetes.io/part-of: '{{ meta.name }}'
     app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
     app.kubernetes.io/component: '{{ deployment_type }}'
+    app.kubernetes.io/operator-version: '{{ lookup("env", "OPERATOR_VERSION") }}'
 stringData:
   password: '{{ lookup('password', '/dev/null length=32 chars=ascii_letters,digits') }}'

--- a/roles/installer/templates/tower_app_credentials.yaml.j2
+++ b/roles/installer/templates/tower_app_credentials.yaml.j2
@@ -10,6 +10,7 @@ metadata:
     app.kubernetes.io/part-of: '{{ meta.name }}'
     app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
     app.kubernetes.io/component: '{{ deployment_type }}'
+    app.kubernetes.io/operator-version: '{{ lookup("env", "OPERATOR_VERSION") }}'
 data:
   credentials.py: "{{ lookup('template', 'credentials.py.j2') | b64encode }}"
   ldap.py: "{{ lookup('template', 'ldap.py.j2') | b64encode }}"

--- a/roles/installer/templates/tower_broadcast_websocket_secret.yaml.j2
+++ b/roles/installer/templates/tower_broadcast_websocket_secret.yaml.j2
@@ -9,5 +9,6 @@ metadata:
     app.kubernetes.io/part-of: '{{ meta.name }}'
     app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
     app.kubernetes.io/component: '{{ deployment_type }}'
+    app.kubernetes.io/operator-version: '{{ lookup("env", "OPERATOR_VERSION") }}'
 stringData:
   secret: '{{ lookup('password', '/dev/null length=32 chars=ascii_letters,digits') }}'

--- a/roles/installer/templates/tower_config.yaml.j2
+++ b/roles/installer/templates/tower_config.yaml.j2
@@ -10,6 +10,7 @@ metadata:
     app.kubernetes.io/part-of: '{{ meta.name }}'
     app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
     app.kubernetes.io/component: '{{ deployment_type }}'
+    app.kubernetes.io/operator-version: '{{ lookup("env", "OPERATOR_VERSION") }}'
 data:
   environment: |
     AWX_SKIP_MIGRATIONS=true

--- a/roles/installer/templates/tower_deployment.yaml.j2
+++ b/roles/installer/templates/tower_deployment.yaml.j2
@@ -11,6 +11,7 @@ metadata:
     app.kubernetes.io/part-of: '{{ meta.name }}'
     app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
     app.kubernetes.io/component: '{{ deployment_type }}'
+    app.kubernetes.io/operator-version: '{{ lookup("env", "OPERATOR_VERSION") }}'
 spec:
   replicas: {{ tower_replicas }}
   selector:

--- a/roles/installer/templates/tower_ingress.yaml.j2
+++ b/roles/installer/templates/tower_ingress.yaml.j2
@@ -10,6 +10,7 @@ metadata:
     app.kubernetes.io/part-of: '{{ meta.name }}'
     app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
     app.kubernetes.io/component: '{{ deployment_type }}'
+    app.kubernetes.io/operator-version: '{{ lookup("env", "OPERATOR_VERSION") }}'
 {% if tower_ingress_annotations %}
   annotations:
     {{ tower_ingress_annotations | indent(width=4) }}
@@ -43,6 +44,7 @@ metadata:
     app.kubernetes.io/part-of: '{{ meta.name }}'
     app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
     app.kubernetes.io/component: '{{ deployment_type }}'
+    app.kubernetes.io/operator-version: '{{ lookup("env", "OPERATOR_VERSION") }}'
 spec:
 {% if tower_route_host != '' %}
   host: {{ tower_route_host }}

--- a/roles/installer/templates/tower_persistent.yaml.j2
+++ b/roles/installer/templates/tower_persistent.yaml.j2
@@ -5,10 +5,11 @@ metadata:
   name: '{{ meta.name }}-projects-claim'
   namespace: '{{ meta.namespace }}'
   labels:
-   app.kubernetes.io/name: '{{ meta.name }}'
-   app.kubernetes.io/part-of: '{{ meta.name }}'
-   app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
-   app.kubernetes.io/component: '{{ deployment_type }}'
+    app.kubernetes.io/name: '{{ meta.name }}'
+    app.kubernetes.io/part-of: '{{ meta.name }}'
+    app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
+    app.kubernetes.io/component: '{{ deployment_type }}'
+    app.kubernetes.io/operator-version: '{{ lookup("env", "OPERATOR_VERSION") }}'
 spec:
   accessModes:
     - {{ tower_projects_storage_access_mode }}

--- a/roles/installer/templates/tower_postgres.yaml.j2
+++ b/roles/installer/templates/tower_postgres.yaml.j2
@@ -9,6 +9,7 @@ metadata:
     app.kubernetes.io/name: '{{ meta.name }}-postgres'
     app.kubernetes.io/part-of: '{{ meta.name }}'
     app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
+    app.kubernetes.io/operator-version: '{{ lookup("env", "OPERATOR_VERSION") }}'
     app.kubernetes.io/component: database
 spec:
   selector:
@@ -110,6 +111,7 @@ metadata:
     app.kubernetes.io/name: '{{ meta.name }}-postgres'
     app.kubernetes.io/part-of: '{{ meta.name }}'
     app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
+    app.kubernetes.io/operator-version: '{{ lookup("env", "OPERATOR_VERSION") }}'
     app.kubernetes.io/component: database
 spec:
   ports:

--- a/roles/installer/templates/tower_postgres_secret.yaml.j2
+++ b/roles/installer/templates/tower_postgres_secret.yaml.j2
@@ -10,6 +10,7 @@ metadata:
     app.kubernetes.io/part-of: '{{ meta.name }}'
     app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
     app.kubernetes.io/component: '{{ deployment_type }}'
+    app.kubernetes.io/operator-version: '{{ lookup("env", "OPERATOR_VERSION") }}'
 stringData:
   password: '{{ lookup('password', '/dev/null length=32 chars=ascii_letters,digits') }}'
   username: '{{ database_username }}'

--- a/roles/installer/templates/tower_secret_key.yaml.j2
+++ b/roles/installer/templates/tower_secret_key.yaml.j2
@@ -9,5 +9,6 @@ metadata:
     app.kubernetes.io/part-of: '{{ meta.name }}'
     app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
     app.kubernetes.io/component: '{{ deployment_type }}'
+    app.kubernetes.io/operator-version: '{{ lookup("env", "OPERATOR_VERSION") }}'
 stringData:
   secret_key: '{{ lookup('password', '/dev/null length=32 chars=ascii_letters,digits') }}'

--- a/roles/installer/templates/tower_service.yaml.j2
+++ b/roles/installer/templates/tower_service.yaml.j2
@@ -9,6 +9,7 @@ metadata:
     app.kubernetes.io/part-of: '{{ meta.name }}'
     app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
     app.kubernetes.io/component: '{{ deployment_type }}'
+    app.kubernetes.io/operator-version: '{{ lookup("env", "OPERATOR_VERSION") }}'
     {{ tower_service_labels | indent(width=4) }}
 {% if tower_ingress_type | lower == 'loadbalancer' and tower_loadbalancer_annotations %}
   annotations:

--- a/roles/installer/templates/tower_service_account.yaml.j2
+++ b/roles/installer/templates/tower_service_account.yaml.j2
@@ -9,6 +9,7 @@ metadata:
     app.kubernetes.io/part-of: '{{ meta.name }}'
     app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
     app.kubernetes.io/component: '{{ deployment_type }}'
+    app.kubernetes.io/operator-version: '{{ lookup("env", "OPERATOR_VERSION") }}'
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role


### PR DESCRIPTION
cc: @rooftopcellist 

After working on a few issues, it is a good troubleshooting resource to be able to determine which `awx-operator` version was used to create a given resource (`deployment`, `statefulset`, `secret`,  `configmap`, `awx`, etc..). 

This PR introduces this ability and added the `operator-version` as  k8s label on the expected resources. For example:

```yaml
# kubectl describe awx awx-toca  
Name:         awx-toca
Namespace:    default
Labels:       app.kubernetes.io/component=awx
              app.kubernetes.io/managed-by=awx-operator
              app.kubernetes.io/name=awx-toca
              app.kubernetes.io/operator-version=0.10.0
              app.kubernetes.io/part-of=awx-toca
Annotations:  <none>
API Version:  awx.ansible.com/v1beta1
Kind:         AWX

# kubectl get all -l  "app.kubernetes.io/operator-version=0.10.0"
NAME                            TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)    AGE
service/awx-devel-ee-postgres   ClusterIP   None           <none>        5432/TCP   35h
service/awx-devel-ee-service    ClusterIP   10.233.45.62   <none>        80/TCP     35h
service/awx-toca-service        ClusterIP   10.233.9.69    <none>        80/TCP     45h

NAME                           READY   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/awx-devel-ee   1/1     1            1           35h
deployment.apps/awx-toca       1/1     1            1           45h

NAME                                     READY   AGE
statefulset.apps/awx-devel-ee-postgres   1/1     35h

```

This will provide a quick mechanism for cross-checking information and debug. 