### PR TITLE
Allow user to specify empty string for storage class on PVC

### DIFF
--- a/roles/installer/defaults/main.yml
+++ b/roles/installer/defaults/main.yml
@@ -167,7 +167,6 @@ tower_postgres_storage_requirements:
   requests:
     storage: 8Gi
 tower_postgres_resource_requirements: {}
-tower_postgres_storage_class: ''
 tower_postgres_data_path: '/var/lib/postgresql/data/pgdata'
 
 # Persistence to the AWX project data folder

--- a/roles/installer/templates/tower_postgres.yaml.j2
+++ b/roles/installer/templates/tower_postgres.yaml.j2
@@ -95,7 +95,7 @@ spec:
       spec:
         accessModes:
           - ReadWriteOnce
-{% if tower_postgres_storage_class != '' %}
+{% if tower_postgres_storage_class is defined %}
         storageClassName: '{{ tower_postgres_storage_class }}'
 {% endif %}
         resources: {{ tower_postgres_storage_requirements }}


### PR DESCRIPTION
Issue: https://github.com/ansible/awx-operator/issues/304

Related Pulp issue: https://pulp.plan.io/issues/8733

This will allow a user to bind a manually created pvc to a pv without a storage class. 