### PR TITLE
Extended labels to AWX Backup/Restore

### DIFF
--- a/roles/backup/tasks/main.yml
+++ b/roles/backup/tasks/main.yml
@@ -1,4 +1,21 @@
 ---
+- name: Patching labels to {{ kind }} kind
+  k8s:
+    state: present
+    definition:
+      apiVersion: '{{ api_version }}'
+      kind: '{{ kind }}'
+      name: '{{ meta.name }}'
+      namespace: '{{ meta.namespace }}'
+      metadata:
+        name: '{{ meta.name }}'
+        namespace: '{{ meta.namespace }}'
+        labels:
+          app.kubernetes.io/name: '{{ meta.name }}'
+          app.kubernetes.io/part-of: '{{ meta.name }}'
+          app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
+          app.kubernetes.io/component: '{{ deployment_type }}'
+          app.kubernetes.io/operator-version: '{{ lookup("env", "OPERATOR_VERSION") }}'
 
 - name: Look up details for this backup object
   k8s_info:

--- a/roles/backup/tasks/postgres.yml
+++ b/roles/backup/tasks/postgres.yml
@@ -19,29 +19,31 @@
     awx_postgres_database: "{{ pg_config['resources'][0]['data']['database'] | b64decode }}"
     awx_postgres_port: "{{ pg_config['resources'][0]['data']['port'] | b64decode }}"
     awx_postgres_host: "{{ pg_config['resources'][0]['data']['host'] | b64decode }}"
-    awx_postgres_type: "{{ pg_config['resources'][0]['data']['type'] | b64decode | default('unmanaged') }}"
+    awx_postgres_type: "{{ pg_config['resources'][0]['data']['type'] | default('unmanaged'|b64encode) | b64decode }}"
 
-- name: Default label selector to custom resource generated postgres
-  set_fact:
-    postgres_label_selector: "app.kubernetes.io/name={{ deployment_name }}-postgres"
-  when: postgres_label_selector is not defined
+- block:
+    - name: Delete pod to reload a resource configuration
+      set_fact:
+        postgres_label_selector: "app.kubernetes.io/name={{ deployment_name }}-postgres"
+      when: postgres_label_selector is not defined
 
-- name: Get the postgres pod information
-  k8s_info:
-    kind: Pod
-    namespace: '{{ meta.namespace }}'
-    label_selectors:
-      - "{{ postgres_label_selector }}"
-  register: postgres_pod
-  until:
-    - "postgres_pod['resources'] | length"
-    - "postgres_pod['resources'][0]['status']['phase'] == 'Running'"
-  delay: 5
-  retries: 60
+    - name: Get the postgres pod information
+      k8s_info:
+        kind: Pod
+        namespace: '{{ meta.namespace }}'
+        label_selectors:
+          - "{{ postgres_label_selector }}"
+      register: postgres_pod
+      until:
+        - "postgres_pod['resources'] | length"
+        - "postgres_pod['resources'][0]['status']['phase'] == 'Running'"
+      delay: 5
+      retries: 60
 
-- name: Set the resource pod name as a variable.
-  set_fact:
-    postgres_pod_name: "{{ postgres_pod['resources'][0]['metadata']['name'] }}"
+    - name: Set the resource pod name as a variable.
+      set_fact:
+        postgres_pod_name: "{{ postgres_pod['resources'][0]['metadata']['name'] }}"
+  when: awx_postgres_type == 'managed'
 
 - name: Determine the timestamp for the backup once for all nodes
   set_fact:
@@ -74,8 +76,7 @@
 
 - name: Set full resolvable host name for postgres pod
   set_fact:
-    resolvable_db_host: "{{ awx_postgres_host }}.{{ meta.namespace }}.svc.cluster.local"
-  when: awx_postgres_type == 'managed'
+    resolvable_db_host: '{{ (awx_postgres_type == "managed") | ternary(awx_postgres_host + "." + meta.namespace + ".svc.cluster.local", awx_postgres_host) }}'  # noqa 204
 
 - name: Set pg_dump command
   set_fact:

--- a/roles/backup/templates/backup_pvc.yml.j2
+++ b/roles/backup/templates/backup_pvc.yml.j2
@@ -4,6 +4,12 @@ kind: PersistentVolumeClaim
 metadata:
   name: {{ deployment_name }}-backup-claim
   namespace: {{ backup_pvc_namespace }}
+  labels:
+    app.kubernetes.io/name: '{{ meta.name }}'
+    app.kubernetes.io/part-of: '{{ meta.name }}'
+    app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
+    app.kubernetes.io/component: '{{ deployment_type }}'
+    app.kubernetes.io/operator-version: '{{ lookup("env", "OPERATOR_VERSION") }}'
 spec:
   accessModes:
     - ReadWriteOnce

--- a/roles/backup/templates/management-pod.yml.j2
+++ b/roles/backup/templates/management-pod.yml.j2
@@ -4,6 +4,12 @@ kind: Pod
 metadata:
   name: {{ meta.name }}-db-management
   namespace: {{ backup_pvc_namespace }}
+  labels:
+    app.kubernetes.io/name: '{{ meta.name }}'
+    app.kubernetes.io/part-of: '{{ meta.name }}'
+    app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
+    app.kubernetes.io/component: '{{ deployment_type }}'
+    app.kubernetes.io/operator-version: '{{ lookup("env", "OPERATOR_VERSION") }}'
 spec:
   containers:
   - name: {{ meta.name }}-db-management

--- a/roles/restore/tasks/main.yml
+++ b/roles/restore/tasks/main.yml
@@ -1,4 +1,21 @@
 ---
+- name: Patching labels to {{ kind }} kind
+  k8s:
+    state: present
+    definition:
+      apiVersion: '{{ api_version }}'
+      kind: '{{ kind }}'
+      name: '{{ meta.name }}'
+      namespace: '{{ meta.namespace }}'
+      metadata:
+        name: '{{ meta.name }}'
+        namespace: '{{ meta.namespace }}'
+        labels:
+          app.kubernetes.io/name: '{{ meta.name }}'
+          app.kubernetes.io/part-of: '{{ meta.name }}'
+          app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
+          app.kubernetes.io/component: '{{ deployment_type }}'
+          app.kubernetes.io/operator-version: '{{ lookup("env", "OPERATOR_VERSION") }}'
 
 - name: Look up details for this restore object
   k8s_info:

--- a/roles/restore/templates/management-pod.yml.j2
+++ b/roles/restore/templates/management-pod.yml.j2
@@ -4,6 +4,12 @@ kind: Pod
 metadata:
   name: {{ meta.name }}-db-management
   namespace: {{ backup_pvc_namespace }}
+  labels:
+    app.kubernetes.io/name: '{{ meta.name }}'
+    app.kubernetes.io/part-of: '{{ meta.name }}'
+    app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
+    app.kubernetes.io/component: '{{ deployment_type }}'
+    app.kubernetes.io/operator-version: '{{ lookup("env", "OPERATOR_VERSION") }}'
 spec:
   containers:
   - name: {{ meta.name }}-db-management

--- a/roles/restore/templates/secrets.yml.j2
+++ b/roles/restore/templates/secrets.yml.j2
@@ -5,6 +5,12 @@ kind: Secret
 metadata:
   name: '{{ postgres_configuration_secret_name }}'
   namespace: '{{ meta.namespace }}'
+  labels:
+    app.kubernetes.io/name: '{{ meta.name }}'
+    app.kubernetes.io/part-of: '{{ meta.name }}'
+    app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
+    app.kubernetes.io/component: '{{ deployment_type }}'
+    app.kubernetes.io/operator-version: '{{ lookup("env", "OPERATOR_VERSION") }}'
 stringData:
   password: '{{ database_password }}'
   username: '{{ database_username }}'
@@ -20,6 +26,12 @@ kind: Secret
 metadata:
   name: '{{ secret_key_secret_name }}'
   namespace: '{{ meta.namespace }}'
+  labels:
+    app.kubernetes.io/name: '{{ meta.name }}'
+    app.kubernetes.io/part-of: '{{ meta.name }}'
+    app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
+    app.kubernetes.io/component: '{{ deployment_type }}'
+    app.kubernetes.io/operator-version: '{{ lookup("env", "OPERATOR_VERSION") }}'
 stringData:
   secret_key: '{{ secret_key }}'
 
@@ -30,6 +42,12 @@ kind: Secret
 metadata:
   name: '{{ admin_password_secret_name }}'
   namespace: '{{ meta.namespace }}'
+  labels:
+    app.kubernetes.io/name: '{{ meta.name }}'
+    app.kubernetes.io/part-of: '{{ meta.name }}'
+    app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
+    app.kubernetes.io/component: '{{ deployment_type }}'
+    app.kubernetes.io/operator-version: '{{ lookup("env", "OPERATOR_VERSION") }}'
 stringData:
   password: '{{ admin_password }}'
 
@@ -40,5 +58,11 @@ kind: Secret
 metadata:
   name: '{{ broadcast_websocket_secret_name }}'
   namespace: '{{ meta.namespace }}'
+  labels:
+    app.kubernetes.io/name: '{{ meta.name }}'
+    app.kubernetes.io/part-of: '{{ meta.name }}'
+    app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
+    app.kubernetes.io/component: '{{ deployment_type }}'
+    app.kubernetes.io/operator-version: '{{ lookup("env", "OPERATOR_VERSION") }}'
 stringData:
   secret: '{{ broadcast_websocket }}'


### PR DESCRIPTION
**cc**: @rooftopcellist 

This PR extends the labels used on the `AWX` kind to the `AWXBackup` and `AWXRestore` kinds. 

Also, it has a slight fix to allow backup for externals db (`unmanaged`)

```yaml
kubectl get awxbackup -o yaml awx-toca-backup-051721a  | kubectl neat                                                         17:39:27
apiVersion: awx.ansible.com/v1beta1
kind: AWXBackup
metadata:
  labels:
    app.kubernetes.io/component: awx
    app.kubernetes.io/managed-by: awx-operator
    app.kubernetes.io/name: awx-toca-backup-051721a
    app.kubernetes.io/operator-version: operator_labels_complementary
    app.kubernetes.io/part-of: awx-toca-backup-051721a
  name: awx-toca-backup-051721a
  namespace: default
name: awx-toca-backup-051721a
namespace: default
spec:
  deployment_name: awx-toca



kubectl get pvc  -l "app.kubernetes.io/name=awx-toca-backup-051721a"                                                          17:45:45
NAME                    STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
awx-toca-backup-claim   Bound    pvc-32a06243-5e73-490a-a7b6-c52604c18eab   5Gi        RWO            nfs-scratch    18m

```

