### PR TITLE
Default to storage class being undefined

### DIFF
--- a/roles/backup/defaults/main.yml
+++ b/roles/backup/defaults/main.yml
@@ -10,6 +10,3 @@ backup_pvc_namespace: "{{ meta.namespace }}"
 
 # Size of backup PVC if created dynamically
 backup_storage_requirements: ''
-
-# Specify storage class to determine how to dynamically create PVC's with
-backup_storage_class: ''

--- a/roles/backup/templates/backup_pvc.yml.j2
+++ b/roles/backup/templates/backup_pvc.yml.j2
@@ -7,7 +7,7 @@ metadata:
 spec:
   accessModes:
     - ReadWriteOnce
-{% if backup_storage_class != '' %}
+{% if backup_storage_class is defined %}
   storageClassName: {{ backup_storage_class }}
 {% endif %}
   resources:

--- a/roles/installer/defaults/main.yml
+++ b/roles/installer/defaults/main.yml
@@ -178,7 +178,6 @@ tower_projects_existing_claim: ''
 #
 # Define the storage_class, size and access_mode
 # when not using an existing claim
-tower_projects_storage_class: ''
 tower_projects_storage_size: 8Gi
 tower_projects_storage_access_mode: ReadWriteMany
 

--- a/roles/installer/templates/tower_persistent.yaml.j2
+++ b/roles/installer/templates/tower_persistent.yaml.j2
@@ -16,7 +16,7 @@ spec:
   resources:
     requests:
       storage: {{ tower_projects_storage_size }}
-{% if tower_projects_storage_class != '' %}
+{% if tower_projects_storage_class is defined %}
   storageClassName: {{ tower_projects_storage_class }}
 {% endif %}
 {% endif %}


### PR DESCRIPTION
Follow-up for this PR: https://github.com/ansible/awx-operator/pull/315

Issue: https://github.com/ansible/awx-operator/issues/304

  * This is so that users can intentially set it to an empty string if they want to use the default storage class
  * conversely, now users can manually create a pvc that does not utilize the default storage class