### PR TITLE
Use custom pg_dump format for faster restores

### DIFF
--- a/roles/backup/tasks/postgres.yml
+++ b/roles/backup/tasks/postgres.yml
@@ -85,6 +85,7 @@
       -U {{ awx_postgres_user }}
       -d {{ awx_postgres_database }}
       -p {{ awx_postgres_port }}
+      -F custom
 
 - name: Write pg_dump to backup on PVC
   k8s_exec:

--- a/roles/restore/tasks/postgres.yml
+++ b/roles/restore/tasks/postgres.yml
@@ -63,8 +63,9 @@
 
 - name: Set pg_restore command
   set_fact:
-    psql_restore: >-
-      psql -U {{ awx_postgres_user }}
+    pg_restore: >-
+      pg_restore --clean --if-exists
+      -U {{ awx_postgres_user }}
       -h {{ resolvable_db_host }}
       -U {{ awx_postgres_user }}
       -d {{ awx_postgres_database }}
@@ -77,7 +78,7 @@
     command: |
       bash -c """
       set -e -o pipefail
-      cat {{ backup_dir }}/tower.db | PGPASSWORD={{ awx_postgres_pass }} {{ psql_restore }}
+      cat {{ backup_dir }}/tower.db | PGPASSWORD={{ awx_postgres_pass }} {{ pg_restore }}
       echo 'Successful'
       """
   register: data_migration


### PR DESCRIPTION
The custom format for pg_dump is much more performant for large databases and should be used instead of the text format.  This is already the case for the `migrate_data.yml` logic, this PR updates the backup and restore roles to similarly use the custom format.  