### PR TITLE
Add quotes to string type extra_settings

### DIFF
--- a/roles/installer/templates/config.yaml.j2
+++ b/roles/installer/templates/config.yaml.j2
@@ -90,7 +90,11 @@ data:
     BROADCAST_WEBSOCKET_PROTOCOL = 'http'
 
 {% for item in extra_settings | default([]) %}
+{% if item.value is string %}
+    {{ item.setting }} = '{{ item.value }}'
+{% else %}
     {{ item.setting }} = {{ item.value }}
+{% endif %}
 {% endfor %}
 
   nginx_conf: |


### PR DESCRIPTION
This fixes https://github.com/ansible/awx-operator/issues/311 and avoid using `"''"` on the spec file

Signed-off-by: Julen Landa Alustiza <jlanda@redhat.com>