### PR TITLE
Added ability to specify annotations to ServiceAccount

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ An [Ansible AWX](https://github.com/ansible/awx) operator for Kubernetes built w
          * [Persisting Projects Directory](#persisting-projects-directory)
          * [Custom Volume and Volume Mount Options](#custom-volume-and-volume-mount-options)
          * [Exporting Environment Variables to Containers](#exporting-environment-variables-to-containers)
+         * [Service Account](#service-account)
    * [Upgrading](#upgrading)
    * [Contributing](#contributing)
    * [Release Process](#release-process)
@@ -533,6 +534,22 @@ Example configuration of environment variables
     web_extra_env: |
       - name: MYCUSTOMVAR
         value: foo
+```
+
+#### Service Account
+
+If you need to modify some `ServiceAccount` proprieties
+
+| Name                          | Description                                              | Default |
+| ----------------------------- | -------------------------------------------------------- | ------- |
+| service_account_annotations   | Annotations to the ServiceAccount                        | ''      |
+
+Example configuration of environment variables
+
+```yaml
+  spec:
+    service_account_annotations: |
+      eks.amazonaws.com/role-arn: arn:aws:iam::<ACCOUNT_ID>:role/<IAM_ROLE_NAME>
 ```
 
 ### Upgrading

--- a/ansible/templates/crd.yml.j2
+++ b/ansible/templates/crd.yml.j2
@@ -201,6 +201,9 @@ spec:
                           type: string
                       type: object
                   type: object
+                service_account_annotations:
+                  description: ServiceAccount annotations
+                  type: string
                 replicas:
                   description: Number of instance replicas
                   type: integer

--- a/deploy/awx-operator.yaml
+++ b/deploy/awx-operator.yaml
@@ -203,6 +203,9 @@ spec:
                           type: string
                       type: object
                   type: object
+                service_account_annotations:
+                  description: ServiceAccount annotations
+                  type: string
                 replicas:
                   description: Number of instance replicas
                   type: integer

--- a/deploy/crds/awx_v1beta1_crd.yaml
+++ b/deploy/crds/awx_v1beta1_crd.yaml
@@ -201,6 +201,9 @@ spec:
                           type: string
                       type: object
                   type: object
+                service_account_annotations:
+                  description: ServiceAccount annotations
+                  type: string
                 replicas:
                   description: Number of instance replicas
                   type: integer

--- a/deploy/crds/awx_v1beta1_molecule.yaml
+++ b/deploy/crds/awx_v1beta1_molecule.yaml
@@ -5,6 +5,8 @@ metadata:
   name: example-awx
   namespace: example-awx
 spec:
+  service_account_annotations: |
+    foo: bar
   deployment_type: awx
   ingress_type: ingress
   web_resource_requirements:

--- a/deploy/olm-catalog/awx-operator/manifests/awx-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/awx-operator/manifests/awx-operator.clusterserviceversion.yaml
@@ -173,6 +173,11 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:io.kubernetes:Secret
+      - displayName: Service Account Annotations
+        path: service_account_annotations
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:text
       - displayName: Ingress Type
         path: ingress_type
         x-descriptors:

--- a/deploy/olm-catalog/awx-operator/manifests/awx.ansible.com_awxs_crd.yaml
+++ b/deploy/olm-catalog/awx-operator/manifests/awx.ansible.com_awxs_crd.yaml
@@ -226,6 +226,9 @@ spec:
               redis_image_version:
                 description: Redis container image version to use
                 type: string
+              service_account_annotations:
+                description: ServiceAccount annotations
+                type: string
               replicas:
                 default: 1
                 description: Number of instance replicas

--- a/roles/installer/defaults/main.yml
+++ b/roles/installer/defaults/main.yml
@@ -9,6 +9,11 @@ database_username: "{{ deployment_type }}"
 task_privileged: false
 ingress_type: none
 
+# Add annotations to the service account. Specify as literal block. E.g.:
+# service_account_annotations: |
+#   eks.amazonaws.com/role-arn: arn:aws:iam::<ACCOUNT_ID>:role/<IAM_ROLE_NAME>
+service_account_annotations: ''
+
 # Custom labels for the tower service. Specify as literal block. E.g.:
 # service_labels: |
 #   environment: non-production

--- a/roles/installer/templates/service_account.yaml.j2
+++ b/roles/installer/templates/service_account.yaml.j2
@@ -10,6 +10,10 @@ metadata:
     app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
     app.kubernetes.io/component: '{{ deployment_type }}'
     app.kubernetes.io/operator-version: '{{ lookup("env", "OPERATOR_VERSION") }}'
+{% if service_account_annotations %}
+  annotations:
+    {{ service_account_annotations | indent(width=4) }}
+{% endif %}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role


### PR DESCRIPTION
Add annotations to `ServiceAccount` 

Fixes: https://github.com/ansible/awx-operator/issues/326


```yaml
---
apiVersion: awx.ansible.com/v1beta1
kind: AWX
metadata:
  name: awx-sa-annotations
spec:
  service_account_annotations: |
    foo: bar
    eks.amazonaws.com/role-arn: arn:aws:iam::abc123:role/testing

====

$ kubectl describe sa awx-sa-annotations               
Name:                awx-sa-annotations
Namespace:           default
Labels:              app.kubernetes.io/component=awx
                     app.kubernetes.io/managed-by=awx-operator
                     app.kubernetes.io/name=awx-sa-annotations
                     app.kubernetes.io/operator-version=sa_annotations
                     app.kubernetes.io/part-of=awx-sa-annotations
Annotations:         eks.amazonaws.com/role-arn: arn:aws:iam::abc123:role/testing
                     foo: bar
Image pull secrets:  <none>
Mountable secrets:   awx-sa-annotations-token-7kgqw
Tokens:              awx-sa-annotations-token-7kgqw
Events:              <none>
```


