### PR TITLE
Ensure image_pull_secret is an actual Secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,15 +282,15 @@ spec:
 
 There are a few variables that are customizable for awx the image management.
 
-| Name                      | Description                |
-| --------------------------| -------------------------- |
-| image                     | Path of the image to pull  |
-| image_version             | Image version to pull      |
-| image_pull_policy         | The pull policy to adopt   |
-| image_pull_secret         | The pull secret to use     |
-| ee_images                 | A list of EEs to register  |
-| redis_image               | Path of the image to pull  |
-| redis_image_version       | Image version to pull      |
+| Name                      | Description                      |
+| --------------------------| -------------------------------- |
+| image                     | Path of the image to pull        |
+| image_version             | Image version to pull            |
+| image_pull_policy         | The pull policy to adopt         |
+| image_pull_secret         | The pull secret's Secret to use  |
+| ee_images                 | A list of EEs to register        |
+| redis_image               | Path of the image to pull        |
+| redis_image_version       | Image version to pull            |
 
 Example of customization could be:
 

--- a/ansible/templates/crd.yml.j2
+++ b/ansible/templates/crd.yml.j2
@@ -155,7 +155,7 @@ spec:
                     - IfNotPresent
                     - ifnotpresent
                 image_pull_secret:
-                  description: The image pull secret
+                  description: The image pull secret's Secret
                   type: string
                 task_resource_requirements:
                   description: Resource requirements for the task container

--- a/deploy/awx-operator.yaml
+++ b/deploy/awx-operator.yaml
@@ -157,7 +157,7 @@ spec:
                     - IfNotPresent
                     - ifnotpresent
                 image_pull_secret:
-                  description: The image pull secret
+                  description: The image pull secret's Secret
                   type: string
                 task_resource_requirements:
                   description: Resource requirements for the task container

--- a/deploy/crds/awx_v1beta1_crd.yaml
+++ b/deploy/crds/awx_v1beta1_crd.yaml
@@ -155,7 +155,7 @@ spec:
                     - IfNotPresent
                     - ifnotpresent
                 image_pull_secret:
-                  description: The image pull secret
+                  description: The image pull secret's Secret
                   type: string
                 task_resource_requirements:
                   description: Resource requirements for the task container

--- a/deploy/olm-catalog/awx-operator/manifests/awx-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/awx-operator/manifests/awx-operator.clusterserviceversion.yaml
@@ -246,7 +246,7 @@ spec:
         path: image_pull_secret
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
-        - urn:alm:descriptor:com.tectonic.ui:imagePullSecret
+        - urn:alm:descriptor:io.kubernetes:Secret
       - displayName: Web container resource requirements
         path: web_resource_requirements
         x-descriptors:

--- a/deploy/olm-catalog/awx-operator/manifests/awx.ansible.com_awxs_crd.yaml
+++ b/deploy/olm-catalog/awx-operator/manifests/awx.ansible.com_awxs_crd.yaml
@@ -97,7 +97,7 @@ spec:
                 - ifnotpresent
                 type: string
               image_pull_secret:
-                description: The image pull secret
+                description: The image pull secret's Secret
                 type: string
               ingress_annotations:
                 description: Annotations to add to the ingress

--- a/roles/installer/tasks/resources_configuration.yml
+++ b/roles/installer/tasks/resources_configuration.yml
@@ -31,6 +31,21 @@
     - 'service'
     - 'ingress'
 
+- block:
+
+    - name: Extract image_pull_secret when specified
+      k8s_info:
+        kind: Secret
+        namespace: '{{ meta.namespace }}'
+        name: '{{ image_pull_secret }}'
+      register: _image_pull_secret
+
+    - name: Store image_pull_secret
+      set_fact:
+        __image_pull_secret: "{{ _image_pull_secret['resources'][0]['data']['secret'] | b64decode }}"
+
+  when: image_pull_secret | default('') | length
+
 - name: Apply deployment resources
   k8s:
     apply: yes

--- a/roles/installer/templates/deployment.yaml.j2
+++ b/roles/installer/templates/deployment.yaml.j2
@@ -29,9 +29,9 @@ spec:
         app.kubernetes.io/component: '{{ deployment_type }}'
     spec:
       serviceAccountName: '{{ meta.name }}'
-{% if image_pull_secret %}
+{% if __image_pull_secret is defined %}
       imagePullSecrets:
-        - name: {{ image_pull_secret }}
+        - name: {{ __image_pull_secret }}
 {% endif %}
       containers:
         - image: '{{ redis_image }}:{{ redis_image_version }}'


### PR DESCRIPTION
Currently, image_pull_secret is a plain string, making it viewable from
the custom resource definition.

This PR aims to make it a secret just like any other credential related
item.