### PR TITLE
Update name of default postgres label selector for backup role

### DIFF
--- a/roles/backup/tasks/postgres.yml
+++ b/roles/backup/tasks/postgres.yml
@@ -24,7 +24,7 @@
 - block:
     - name: Delete pod to reload a resource configuration
       set_fact:
-        postgres_label_selector: "app.kubernetes.io/name={{ deployment_name }}-postgres"
+        postgres_label_selector: "app.kubernetes.io/instance=postgres-{{ deployment_name }}"
       when: postgres_label_selector is not defined
 
     - name: Get the postgres pod information


### PR DESCRIPTION
Issue: https://github.com/ansible/awx-operator/issues/345

As mentioned by @Zokormazo , the backup is broken because the postgres pod is never found.  This is because the default value for the postgres_label_selector var isn't set correctly.  This value changed in this PR - https://github.com/ansible/awx-operator/pull/297/files, but this instance was missed.  