### PR TITLE
olm-catalog: Add statuses to schemas for awxbackup and awxrestore objects

### DIFF
--- a/ansible/templates/awxbackup_crd.yml.j2
+++ b/ansible/templates/awxbackup_crd.yml.j2
@@ -35,7 +35,7 @@ spec:
                   description: Name of the PVC to be used for storing the backup
                   type: string
                 backup_pvc_namespace:
-                  description: Namespace PVC is in
+                  description: Namespace the PVC is in
                   type: string
                 backup_storage_requirements:
                   description: Storage requirements for the PostgreSQL container
@@ -45,4 +45,28 @@ spec:
                   type: string
                 postgres_label_selector:
                   description: Label selector used to identify postgres pod for backing up data
+                  type: string
+            status:
+              type: object
+              properties:
+                conditions:
+                  description: The resulting conditions when a Service Telemetry is
+                    instantiated
+                  items:
+                    properties:
+                      lastTransitionTime:
+                        type: string
+                      reason:
+                        type: string
+                      status:
+                        type: string
+                      type:
+                        type: string
+                    type: object
+                  type: array
+                backupDirectory:
+                  description: Backup directory name on the specified pvc
+                  type: string
+                backupClaim:
+                  description: Backup persistent volume claim
                   type: string

--- a/ansible/templates/awxrestore_crd.yml.j2
+++ b/ansible/templates/awxrestore_crd.yml.j2
@@ -50,3 +50,24 @@ spec:
                 postgres_label_selector:
                   description: Label selector used to identify postgres pod for backing up data
                   type: string
+            status:
+              type: object
+              properties:
+                conditions:
+                  description: The resulting conditions when a Service Telemetry is
+                    instantiated
+                  items:
+                    properties:
+                      lastTransitionTime:
+                        type: string
+                      reason:
+                        type: string
+                      status:
+                        type: string
+                      type:
+                        type: string
+                    type: object
+                  type: array
+                restoreComplete:
+                  description: Restore process complete
+                  type: string

--- a/deploy/awx-operator.yaml
+++ b/deploy/awx-operator.yaml
@@ -437,7 +437,7 @@ spec:
                   description: Name of the PVC to be used for storing the backup
                   type: string
                 backup_pvc_namespace:
-                  description: Namespace PVC is in
+                  description: Namespace the PVC is in
                   type: string
                 backup_storage_requirements:
                   description: Storage requirements for the PostgreSQL container
@@ -447,6 +447,30 @@ spec:
                   type: string
                 postgres_label_selector:
                   description: Label selector used to identify postgres pod for backing up data
+                  type: string
+            status:
+              type: object
+              properties:
+                conditions:
+                  description: The resulting conditions when a Service Telemetry is
+                    instantiated
+                  items:
+                    properties:
+                      lastTransitionTime:
+                        type: string
+                      reason:
+                        type: string
+                      status:
+                        type: string
+                      type:
+                        type: string
+                    type: object
+                  type: array
+                backupDirectory:
+                  description: Backup directory name on the specified pvc
+                  type: string
+                backupClaim:
+                  description: Backup persistent volume claim
                   type: string
 
 ---
@@ -500,6 +524,27 @@ spec:
                   type: string
                 postgres_label_selector:
                   description: Label selector used to identify postgres pod for backing up data
+                  type: string
+            status:
+              type: object
+              properties:
+                conditions:
+                  description: The resulting conditions when a Service Telemetry is
+                    instantiated
+                  items:
+                    properties:
+                      lastTransitionTime:
+                        type: string
+                      reason:
+                        type: string
+                      status:
+                        type: string
+                      type:
+                        type: string
+                    type: object
+                  type: array
+                restoreComplete:
+                  description: Restore process complete
                   type: string
 
 ---

--- a/deploy/crds/awxbackup_v1beta1_crd.yaml
+++ b/deploy/crds/awxbackup_v1beta1_crd.yaml
@@ -35,7 +35,7 @@ spec:
                   description: Name of the PVC to be used for storing the backup
                   type: string
                 backup_pvc_namespace:
-                  description: Namespace PVC is in
+                  description: Namespace the PVC is in
                   type: string
                 backup_storage_requirements:
                   description: Storage requirements for the PostgreSQL container
@@ -45,4 +45,28 @@ spec:
                   type: string
                 postgres_label_selector:
                   description: Label selector used to identify postgres pod for backing up data
+                  type: string
+            status:
+              type: object
+              properties:
+                conditions:
+                  description: The resulting conditions when a Service Telemetry is
+                    instantiated
+                  items:
+                    properties:
+                      lastTransitionTime:
+                        type: string
+                      reason:
+                        type: string
+                      status:
+                        type: string
+                      type:
+                        type: string
+                    type: object
+                  type: array
+                backupDirectory:
+                  description: Backup directory name on the specified pvc
+                  type: string
+                backupClaim:
+                  description: Backup persistent volume claim
                   type: string

--- a/deploy/crds/awxrestore_v1beta1_crd.yaml
+++ b/deploy/crds/awxrestore_v1beta1_crd.yaml
@@ -50,3 +50,24 @@ spec:
                 postgres_label_selector:
                   description: Label selector used to identify postgres pod for backing up data
                   type: string
+            status:
+              type: object
+              properties:
+                conditions:
+                  description: The resulting conditions when a Service Telemetry is
+                    instantiated
+                  items:
+                    properties:
+                      lastTransitionTime:
+                        type: string
+                      reason:
+                        type: string
+                      status:
+                        type: string
+                      type:
+                        type: string
+                    type: object
+                  type: array
+                restoreComplete:
+                  description: Restore process complete
+                  type: string

--- a/deploy/olm-catalog/awx-operator/manifests/awx-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/awx-operator/manifests/awx-operator.clusterserviceversion.yaml
@@ -33,7 +33,7 @@ metadata:
     capabilities: Basic Install
     operators.operatorframework.io/builder: operator-sdk-v0.19.4
     operators.operatorframework.io/project_layout: ansible
-  name: awx-operator.v0.0.1
+  name: awx-operator.v0.10.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -685,4 +685,5 @@ spec:
   provider:
     name: AWX Community
     url: https://github.com/ansible/awx-operator
-  version: 0.0.1
+  replaces: awx-operator.v0.0.1
+  version: 0.10.0

--- a/deploy/olm-catalog/awx-operator/manifests/awx.ansible.com_awxbackups_crd.yaml
+++ b/deploy/olm-catalog/awx-operator/manifests/awx.ansible.com_awxbackups_crd.yaml
@@ -23,7 +23,7 @@ spec:
                 description: Name of the PVC to be used for storing the backup
                 type: string
               backup_pvc_namespace:
-                description: Namespace PVC is in
+                description: Namespace the PVC is in
                 type: string
               backup_storage_class:
                 description: Storage class to use when creating PVC for backup
@@ -40,6 +40,30 @@ spec:
                 type: string
             required:
             - deployment_name
+            type: object
+          status:
+            properties:
+              backupClaim:
+                description: Backup persistent volume claim
+                type: string
+              backupDirectory:
+                description: Backup directory name on the specified pvc
+                type: string
+              conditions:
+                description: The resulting conditions when a Service Telemetry is
+                  instantiated
+                items:
+                  properties:
+                    lastTransitionTime:
+                      type: string
+                    reason:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      type: string
+                  type: object
+                type: array
             type: object
         type: object
         x-kubernetes-preserve-unknown-fields: true

--- a/deploy/olm-catalog/awx-operator/manifests/awx.ansible.com_awxrestores_crd.yaml
+++ b/deploy/olm-catalog/awx-operator/manifests/awx.ansible.com_awxrestores_crd.yaml
@@ -47,6 +47,27 @@ spec:
                   up data
                 type: string
             type: object
+          status:
+            properties:
+              conditions:
+                description: The resulting conditions when a Service Telemetry is
+                  instantiated
+                items:
+                  properties:
+                    lastTransitionTime:
+                      type: string
+                    reason:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      type: string
+                  type: object
+                type: array
+              restoreComplete:
+                description: Restore process complete
+                type: string
+            type: object
         type: object
         x-kubernetes-preserve-unknown-fields: true
     served: true

--- a/deploy/olm-catalog/awx-operator/manifests/awx.ansible.com_awxs_crd.yaml
+++ b/deploy/olm-catalog/awx-operator/manifests/awx.ansible.com_awxs_crd.yaml
@@ -385,15 +385,6 @@ spec:
               image:
                 description: URL of the image used for the deployed instance
                 type: string
-              postgresConfigurationSecret:
-                description: Postgres Configuration secret name of the deployed instance
-                type: string
-              broadcastWebsocketSecret:
-                description: Broadcast websocket secret name of the deployed instance
-                type: string
-              secretKeySecret:
-                description: Secret key secret name of the deployed instance
-                type: string
               migratedFromSecret:
                 description: The secret used for migrating an old instance.
                 type: string

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-## This script will be build 3 images awx-{operator,bundle,catalog}
+## This script will build 3 images awx-{operator,bundle,catalog}
 ## and push to the $REGISTRY specified.
 ##
 ## The goal is provide an quick way to build a test image.
@@ -10,7 +10,7 @@
 ## cd awx-operator
 ## REGISTRY=registry.example.com/ansible TAG=mytag ANSIBLE_DEBUG_LOGS=true scripts/build.sh
 ##
-## As a result, the $REGISTRY will be populated with 2 images
+## As a result, the $REGISTRY will be populated with 3 images
 ## registry.example.com/ansible/awx-operator:mytag
 ## registry.example.com/ansible/awx-operator-bundle:mytag
 ## registry.example.com/ansible/awx-operator-catalog:mytag


### PR DESCRIPTION
This PR adds statuses to the olm-catalog and crd schema's.  It also adds in the Telemetry statuses.  