### PR TITLE
Changelog for 0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 This is a list of high-level changes for each release of `awx-operator`. A full list of commits can be found at `https://github.com/ansible/awx-operator/releases/tag/<version>`.
 
+# 0.10.0 (Jun 1, 2021)
+
+- Make tower_ingress_type to respect ClusterIP definition (Marcelo Moreira de Mello) - e37c091 (breaking_change)
+- Add ability to get/create/delete secrets for the awx service account (Christian M. Adams) - 61b3cb4
+- Added ability to specify annotations to ServiceAccount (Marcelo Moreira de Mello) - 446ac0b
+- Do not shadow other variables (Yanis Guenane) - 223fe98
+- Do not prepend variables name with tower_ (Yanis Guenane) - 75458d0 (breaking_change)
+- Fully remove finalizer (Christian M. Adams) - fd92050
+- Use custom pg_dump format for faster restores (Christian M. Adams) - f16d9ac
+- Allow user to specify empty string for storage class on PVC (Christian M. Adams) - 818b837
+- Unset ownerRefs in the installer instead of the finalizer (Christian M. Adams) - c12a1f0
+- Make awx-operator compatible with Ansible 2.12 (Alan Rominger) - 5216489
+- Restore: set proper kind var after deploying AWX CR (Julen Landa Alustiza) - fc4687f
+- Add support for custom service labels (Jeremy Kimber) - fd42802
+- Rename product specific variable names (Christian M. Adams) - 5ae3636 (breaking_change)
+- Add watcher for backup CR (Christian M. Adams) - fdcc745
+
 # 0.9.0 (May 1, 2021)
 
 - Update playbook to allow for deploying custom image version/tag (Shane McDonald) - 77e7039 


### PR DESCRIPTION
**Worthy mention changelog**
```
- Make tower_ingress_type to respect ClusterIP definition (Marcelo Moreira de Mello) - e37c091 (breaking_change)
- Add ability to get/create/delete secrets for the awx service account (Christian M. Adams) - 61b3cb4
- Added ability to specify annotations to ServiceAccount (Marcelo Moreira de Mello) - 446ac0b
- Do not shadow other variables (Yanis Guenane) - 223fe98
- Do not prepend variables name with tower_ (Yanis Guenane) - 75458d0 (breaking_change)
- Fully remove finalizer (Christian M. Adams) - fd92050
- Use custom pg_dump format for faster restores (Christian M. Adams) - f16d9ac
- Allow user to specify empty string for storage class on PVC (Christian M. Adams) - 818b837
- Unset ownerRefs in the installer instead of the finalizer (Christian M. Adams) - c12a1f0
- Make awx-operator compatible with Ansible 2.12 (Alan Rominger) - 5216489
- Restore: set proper kind var after deploying AWX CR (Julen Landa Alustiza) - fc4687f
- Add support for custom service labels (Jeremy Kimber) - fd42802
- Rename product specific variable names (Christian M. Adams) - 5ae3636 (breaking_change)
- Add watcher for backup CR (Christian M. Adams) - fdcc745
```


Full commit list (to be added at the release page)
**generated with**: ```git log --no-merges --pretty="- %s (%an) - %h " 0.9.0..0.10.0```


```yaml
- Bump versions for 0.10.0 (Shane McDonald) - b74d6a5 
- Updated README.md to point to released version (Marcelo Moreira de Mello) - 5e58da7 
- Make tower_ingress_type to respect ClusterIP definition (Marcelo Moreira de Mello) - e37c091 
- Add quotes to string type extra_settings (Julen Landa Alustiza) - 899a8e7 
- Add ability to get/create/delete secrets for the awx service account (Christian M. Adams) - 61b3cb4 
- Added ability to specify annotations to ServiceAccount (Marcelo Moreira de Mello) - 446ac0b 
- Do not shadow other variables (Yanis Guenane) - 223fe98 
- Do not prepend variables name with tower_ (Yanis Guenane) - 75458d0 
- Fully remove finalizer (Christian M. Adams) - fd92050 
- Make postgres sts labels consistent with k8s recommendations & pulp-operator   - k8s recommended labels: https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/ (Christian M. Adams) - 406bbf9 
- Extended labels to AWX Backup/Restore (Marcelo Moreira de Mello) - 08776ca 
- Adding contributing guidelines (Marcelo Moreira de Mello) - 68e0de4 
- Use custom pg_dump format for faster restores (Christian M. Adams) - f16d9ac 
- Default to storage class being undefined   * This is so that users can intentially set it to an empty string if they want to use the default storage class   * conversely, now users can manually create a pvc that does not utilize the default storage class (Christian M. Adams) - 82ed9d6 
- Allow user to specify empty string for storage class on PVC (Christian M. Adams) - 818b837 
- Adds operator-version to k8s resources (Marcelo Moreira de Mello) - 5266cc2 
- Set initial value for tower_loadbalancer_annotations (Marcelo Moreira de Mello) - b2b1e07 
- Add note about how to upgrade AWX and the operator (Christian M. Adams) - c16e53d 
- Unset ownerRefs in the installer instead of the finalizer (Christian M. Adams) - c12a1f0 
- Use custom archive format when migrating data   - this approach is compatible with the RH postgresql container (Christian M. Adams) - 9145b32 
- Scale down the new deployment before restoring (Christian M. Adams) - ca81274 
- Restore: set proper kind var after deploying AWX CR (Julen Landa Alustiza) - fc4687f 
- Make awx-operator compatible with Ansible 2.12 (Alan Rominger) - 5216489 
- Fix file permissions for tmp spec vars file (Christian M. Adams) - c551d05 
- olm-catalog: Update with latest content from AWXBackup and AWXRestore (Yanis Guenane) - ce0a251 
- Use copy module, not shell (Christian M. Adams) - 9532cc7 
- Remove ownerReferences based on secret name from backup (Christian M. Adams) - 15bc12b 
- Retrieve pg secret values consistently, do not hardcode secret names (Christian M. Adams) - a46938e 
- Persist secret names from old deployment & add them to the spec   - renamed some more variables to be consistent with the pulp-operator   - removed unneeded vars from backup & restore crds   - added a way to parse spec at restore time by including vars to     get around the issue of triply nested quotes when using to_json (Christian M. Adams) - 8af0681 
- fix example to use correct label (Jeremy Kimber) - 51435e3 
- set tower_service_labels field to hidden (Jeremy Kimber) - b204c91 
- Added initial CHANGELOG.md (Marcelo Moreira de Mello) - b50cf82 
- Add support for custom service labels (Jeremy Kimber) - fd42802 
- Update bug_report.md (Marcelo Moreira de Mello) - b7e043e 
- Updated bug report template (Marcelo Moreira de Mello) - 78d03e0 
- Fix rebase issue & remove dynamic kind/version var setting (Christian M. Adams) - 5e2d118 
- Remove unnecessary intermediate awx_spec var (Christian M. Adams) - cdbaf94 
- Fix rebase issue due to order or pg config tasks (Christian M. Adams) - 5439681 
- update templated files with new var names (Christian M. Adams) - 9cfb792 
- remove unused variables in restore role (Christian M. Adams) - 36852cd 
- revert unneccesary admin password update (Christian M. Adams) - b5c5a17 
- Rename product specific variable names (Christian M. Adams) - 5ae3636 
- Update admin user password with value in provided/generated secret (Christian M. Adams) - d743936 
- Simplify vars needed for restore CR & do not garbage collect secrets (Christian M. Adams) - c817a22 
- Simplify pvc naming scheme, one pvc per deployment (Christian M. Adams) - 57f9530 
- Set ownerRef to null for restore created AWX object to avoid garbage collection   - Set defaults for pg type to satisfy conditional (Christian M. Adams) - 3e444da 
- Allow custom postgres pod label to support user managed pg pods  - Only set resolvable pg host path for pg container when managed (Christian M. Adams) - 867bc25 
- create pvc in namespace of old awx by default, update docs, fix bug with secret statuses (Christian M. Adams) - ff9248e 
- Add secret names as statuses on the AWX object  - set migrate data status even if custom name for old postgres config is not used  - Allow users to change pg name, pw & db name for a managed postgres  - set default value for postgres-configuration type as unmanaged if secret is created  - Make pg port configurable for managed deployments (Christian M. Adams) - 38a6a02 
- Make pg port configurable for managed deployments (Christian M. Adams) - 90f4d71 
- Allow users to change pg name, pw & db name for a managed postgres  - set default value for postgres-configuration type as unmanaged if secret is created (Christian M. Adams) - 8f760e2 
- Fix retry for checking postgres pod & fix secrets template  - fixed a lot of typos & updated the README.md files (Christian M. Adams) - 5b32c41 
- Only write values for spec section of awx object in backup (Christian M. Adams) - fb612c2 
- Template only what is needed from secrets and awx cro (Christian M. Adams) - 8ed0b1f 
- store secrets & definitions in a tempfile dir, fix postgres label (Christian M. Adams) - 82efe05 
- Remove unneeded fqcn for modules & fix CI (Christian M. Adams) - 2cbf60f 
- added secrets logic, fixed permissions issues (Christian M. Adams) - ce8c58f 
- Fix small namespace issue (Christian M. Adams) - b9d0852 
- Scope pvc and management pod to default namespace   - make this configurable via tower_backup_pvc_namespace var   - remove redundant k8s task info (Christian M. Adams) - 5669747 
- Finish db restore logic   - rename _backup_dir to backup_dir   - add towerBackupClaim status to make the pvc name easier to find for users (Christian M. Adams) - 0580398 
- rename db task vars with awx instead of tower for consistency (Christian M. Adams) - 8422f6f 
- init restore (Christian M. Adams) - 8467209 
- Create an event when pvc is not set to alert the user (Christian M. Adams) - 80c8d87 
- template awxbackup crd into awx-operator.yml for easy deployment (Christian M. Adams) - 6bc149b 
- Add awxbackup CRD creation to molecule to get tests passing (Christian M. Adams) - 250ff96 
- Fix backup reconciliation loop, add error status (Christian M. Adams) - e1dca00 
- Swap vars and defaults, rename to awxbackups (Christian M. Adams) - f17dcdc 
- Rename Backup CR to AWXBackup to be more unique  - we could alternatively direct users to use the full GVK.  Issue is potential conflict with AH operator CRs (Christian M. Adams) - 4839bdc 
- backup secrets to YAML files (Christian M. Adams) - 91dda5c 
- Refactor backup role & store secrets as well (Christian M. Adams) - 0a82fec 
- use meta.data to keep pods and pvcs unique in the same namespace (Christian M. Adams) - 13397f4 
- Rename pvc name var to be consistent with other backup variables (Christian M. Adams) - 9e44e21 
- Use default cluster storage class if none is provided (Christian M. Adams) - 54efda1 
- init backup CR files (Christian M. Adams) - bcd1410 
- Add watcher for backup CR (Christian M. Adams) - fdcc745 
- Use storage class to dynamically create volume for backups (Christian M. Adams) - 4a5ca18 
- Create management pod and pvc for backup (Christian M. Adams) - e037fea 
- wip deployment podspec or sts (Christian M. Adams) - 0220c75 
- Fixed indentation lint (Marcelo Moreira de Mello) - 13f7b2a 
- Fixing lint (Marcelo Moreira de Mello) - bdcd95a 
- Added OKD console deployment (Marcelo Moreira de Mello) - 032d6b7 
```