### PR TITLE
Fail task if pg_dump fails in backup role

### DIFF
--- a/ansible/templates/awxbackup_crd.yml.j2
+++ b/ansible/templates/awxbackup_crd.yml.j2
@@ -46,6 +46,12 @@ spec:
                 postgres_label_selector:
                   description: Label selector used to identify postgres pod for backing up data
                   type: string
+                postgres_image:
+                  description: Registry path to the PostgreSQL container to use
+                  type: string
+                postgres_image_version:
+                  description: PostgreSQL container image version to use
+                  type: string
             status:
               type: object
               properties:

--- a/ansible/templates/awxrestore_crd.yml.j2
+++ b/ansible/templates/awxrestore_crd.yml.j2
@@ -50,6 +50,12 @@ spec:
                 postgres_label_selector:
                   description: Label selector used to identify postgres pod for backing up data
                   type: string
+                postgres_image:
+                  description: Registry path to the PostgreSQL container to use
+                  type: string
+                postgres_image_version:
+                  description: PostgreSQL container image version to use
+                  type: string
             status:
               type: object
               properties:

--- a/deploy/awx-operator.yaml
+++ b/deploy/awx-operator.yaml
@@ -448,6 +448,12 @@ spec:
                 postgres_label_selector:
                   description: Label selector used to identify postgres pod for backing up data
                   type: string
+                postgres_image:
+                  description: Registry path to the PostgreSQL container to use
+                  type: string
+                postgres_image_version:
+                  description: PostgreSQL container image version to use
+                  type: string
             status:
               type: object
               properties:
@@ -524,6 +530,12 @@ spec:
                   type: string
                 postgres_label_selector:
                   description: Label selector used to identify postgres pod for backing up data
+                  type: string
+                postgres_image:
+                  description: Registry path to the PostgreSQL container to use
+                  type: string
+                postgres_image_version:
+                  description: PostgreSQL container image version to use
                   type: string
             status:
               type: object

--- a/deploy/crds/awxbackup_v1beta1_crd.yaml
+++ b/deploy/crds/awxbackup_v1beta1_crd.yaml
@@ -46,6 +46,12 @@ spec:
                 postgres_label_selector:
                   description: Label selector used to identify postgres pod for backing up data
                   type: string
+                postgres_image:
+                  description: Registry path to the PostgreSQL container to use
+                  type: string
+                postgres_image_version:
+                  description: PostgreSQL container image version to use
+                  type: string
             status:
               type: object
               properties:

--- a/deploy/crds/awxrestore_v1beta1_crd.yaml
+++ b/deploy/crds/awxrestore_v1beta1_crd.yaml
@@ -50,6 +50,12 @@ spec:
                 postgres_label_selector:
                   description: Label selector used to identify postgres pod for backing up data
                   type: string
+                postgres_image:
+                  description: Registry path to the PostgreSQL container to use
+                  type: string
+                postgres_image_version:
+                  description: PostgreSQL container image version to use
+                  type: string
             status:
               type: object
               properties:

--- a/deploy/olm-catalog/awx-operator/manifests/awx.ansible.com_awxbackups_crd.yaml
+++ b/deploy/olm-catalog/awx-operator/manifests/awx.ansible.com_awxbackups_crd.yaml
@@ -34,6 +34,12 @@ spec:
               deployment_name:
                 description: Name of the deployment to be backed up
                 type: string
+              postgres_image:
+                description: Registry path to the PostgreSQL container to use
+                type: string
+              postgres_image_version:
+                description: PostgreSQL container image version to use
+                type: string
               postgres_label_selector:
                 description: Label selector used to identify postgres pod for backing
                   up data

--- a/deploy/olm-catalog/awx-operator/manifests/awx.ansible.com_awxrestores_crd.yaml
+++ b/deploy/olm-catalog/awx-operator/manifests/awx.ansible.com_awxrestores_crd.yaml
@@ -42,6 +42,12 @@ spec:
               deployment_name:
                 description: Name of the deployment to be restored to
                 type: string
+              postgres_image:
+                description: Registry path to the PostgreSQL container to use
+                type: string
+              postgres_image_version:
+                description: PostgreSQL container image version to use
+                type: string
               postgres_label_selector:
                 description: Label selector used to identify postgres pod for backing
                   up data

--- a/roles/backup/tasks/postgres.yml
+++ b/roles/backup/tasks/postgres.yml
@@ -92,6 +92,11 @@
   k8s_exec:
     namespace: "{{ backup_pvc_namespace }}"
     pod: "{{ meta.name }}-db-management"
-    command: >-
-      bash -c "PGPASSWORD={{ awx_postgres_pass }} {{ pgdump }} > {{ backup_dir }}/tower.db"
+    command: |
+      bash -c """
+      set -e -o pipefail
+      PGPASSWORD={{ awx_postgres_pass }} {{ pgdump }} > {{ backup_dir }}/tower.db
+      echo 'Successful'
+      """
   register: data_migration
+  failed_when: "'Successful' not in data_migration.stdout"

--- a/roles/backup/templates/management-pod.yml.j2
+++ b/roles/backup/templates/management-pod.yml.j2
@@ -13,7 +13,7 @@ metadata:
 spec:
   containers:
   - name: {{ meta.name }}-db-management
-    image: "{{ postgres_image }}"
+    image: "{{ postgres_image }}:{{ postgres_image_version }}"
     imagePullPolicy: Always
     command: ["sleep", "infinity"]
     volumeMounts:

--- a/roles/backup/vars/main.yml
+++ b/roles/backup/vars/main.yml
@@ -1,5 +1,6 @@
 ---
 deployment_type: "awx"
-postgres_image: postgres:12
+postgres_image: postgres
+postgres_image_version: 12
 backup_complete: false
 database_type: "unmanaged"

--- a/roles/restore/templates/management-pod.yml.j2
+++ b/roles/restore/templates/management-pod.yml.j2
@@ -13,7 +13,7 @@ metadata:
 spec:
   containers:
   - name: {{ meta.name }}-db-management
-    image: "{{ postgres_image }}"
+    image: "{{ postgres_image }}:{{ postgres_image_version }}"
     imagePullPolicy: Always
     command: ["sleep", "infinity"]
     volumeMounts:

--- a/roles/restore/vars/main.yml
+++ b/roles/restore/vars/main.yml
@@ -1,7 +1,8 @@
 ---
 
 deployment_type: "awx"
-postgres_image: postgres:12
+postgres_image: postgres
+postgres_image_version: 12
 
 backup_api_version: '{{ deployment_type }}.ansible.com/v1beta1'
 backup_kind: 'AWXBackup'


### PR DESCRIPTION
Issue: https://github.com/ansible/awx-operator/issues/320

Previously, if the `pg_dump` exec task failed in the backup role, it would fail silently and keep running.  

![3e3c6b0e96fc4a18a8bc5af215de7067](https://user-images.githubusercontent.com/11698892/120818368-8e2ef700-c520-11eb-9d99-460039ce0274.png)

> The output above was from running the backup role directly as a playbook with the status tasks commented out

Now, it will fail:

![image](https://user-images.githubusercontent.com/11698892/120818683-d4845600-c520-11eb-8004-25dba497ddf6.png)


Similarly, if I deploy the operator and create a backup object, it will set the Failed status condition.

```
  status:
    conditions:
    - lastTransitionTime: "2021-06-04T15:15:17Z"
      reason: Failed
      status: "False"
      type: Failure
```




#### Additional Info

As part of this PR, I made `postgres_image` and `postgres_image_version` configurable, which made testing this a bit easier.  It also servce the use case of a user who has an external postgres database they manage, but would still like to use our backup/restore roles.  