### PR TITLE
Documenting extra_settings usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -657,7 +657,7 @@ Example configuration of environment variables
 
 #### Extra Settings
 
-With`extra_settings`, you can pass multiple custom settings via the `awx-operator`. The parameter `extra_settings`  will be appended to the `/etc/tower/settings.py` and be can an alternative to the `extra_volumes` parameter.
+With`extra_settings`, you can pass multiple custom settings via the `awx-operator`. The parameter `extra_settings`  will be appended to the `/etc/tower/settings.py` and can an alternative to the `extra_volumes` parameter.
 
 | Name                          | Description                                              | Default |
 | ----------------------------- | -------------------------------------------------------- | ------- |

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ An [Ansible AWX](https://github.com/ansible/awx) operator for Kubernetes built w
          * [Persisting Projects Directory](#persisting-projects-directory)
          * [Custom Volume and Volume Mount Options](#custom-volume-and-volume-mount-options)
          * [Exporting Environment Variables to Containers](#exporting-environment-variables-to-containers)
+         * [Extra Settings](#extra-settings)
          * [Service Account](#service-account)
    * [Upgrading](#upgrading)
    * [Contributing](#contributing)
@@ -652,6 +653,26 @@ Example configuration of environment variables
     web_extra_env: |
       - name: MYCUSTOMVAR
         value: foo
+```
+
+#### Extra Settings
+
+With`extra_settings`, you can pass multiple custom settings via the `awx-operator`. The parameter `extra_settings`  will be appended to the `/etc/tower/settings.py` and be can an alternative to the `extra_volumes` parameter.
+
+| Name                          | Description                                              | Default |
+| ----------------------------- | -------------------------------------------------------- | ------- |
+| extra_settings                | Extra settings                                           | ''      |
+
+Example configuration of `extra_settings` parameter
+
+```yaml
+  spec:
+    extra_settings:
+      - setting: MAX_PAGE_SIZE
+        value: "500"
+
+      - setting: AUTH_LDAP_BIND_DN
+        value: "cn=admin,dc=example,dc=com"
 ```
 
 #### Service Account

--- a/README.md
+++ b/README.md
@@ -657,7 +657,7 @@ Example configuration of environment variables
 
 #### Extra Settings
 
-With`extra_settings`, you can pass multiple custom settings via the `awx-operator`. The parameter `extra_settings`  will be appended to the `/etc/tower/settings.py` and can an alternative to the `extra_volumes` parameter.
+With`extra_settings`, you can pass multiple custom settings via the `awx-operator`. The parameter `extra_settings`  will be appended to the `/etc/tower/settings.py` and can be an alternative to the `extra_volumes` parameter.
 
 | Name                          | Description                                              | Default |
 | ----------------------------- | -------------------------------------------------------- | ------- |


### PR DESCRIPTION
Related: https://github.com/ansible/awx-operator/issues/13

Documents the usage of  `extra_settings`  parameter. 

```yaml
---
apiVersion: awx.ansible.com/v1beta1
kind: AWX
metadata:
  name: awx-ssl-ca
spec:
  service_type: nodeport
  ingress_type: none
  extra_settings:
    - setting: MAX_PAGE_SIZE
      value: "500"
    - setting: AUTH_LDAP_BIND_DN
      value: "cn=admin,dc=example,dc=com"
.....

$ kubectl iexec awx-ssl-ca  /bin/bash
Namespace: default | Pod: ✔ awx-ssl-ca-6cccf6577d-dmz5s
Container: ✔ awx-ssl-ca-web
bash-4.4$ awx-manage shell_plus --quiet
Python 3.8.3 (default, Aug 31 2020, 16:03:14) 
[GCC 8.3.1 20191121 (Red Hat 8.3.1-5)] on linux
Type "help", "copyright", "credits" or "license" for more information.
(InteractiveConsole)
>>> settings.MAX_PAGE_SIZE
'500'
>>> settings.AUTH_LDAP_BIND_DN
'cn=admin,dc=example,dc=com'
```