### PR TITLE
Do not clean up pvc when awxbackup cr is deleted

### DIFF
--- a/roles/backup/templates/backup_pvc.yml.j2
+++ b/roles/backup/templates/backup_pvc.yml.j2
@@ -4,6 +4,7 @@ kind: PersistentVolumeClaim
 metadata:
   name: {{ deployment_name }}-backup-claim
   namespace: {{ backup_pvc_namespace }}
+  ownerReferences: null
   labels:
     app.kubernetes.io/name: '{{ meta.name }}'
     app.kubernetes.io/part-of: '{{ meta.name }}'


### PR DESCRIPTION
Issue: https://github.com/ansible/awx-operator/issues/368

Openshift has a default finalizer that cleans up child objects when the parent is deleted.  It determines what to delete based on the ownerReferences on the objects.  To prevent the backup pvc's from being cleaned up, we now explicitly set ownerRefs to null for the backup pvc when it is created.  


Now when I delete the `awxbackup` object, the backup pvc remains.  

```
$ oc get pvc
NAME                      STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
awx-backup-claim          Bound    pvc-3ffcb83a-7376-4285-95bc-2411887d44cd   5Gi        RWO            standard       31m
postgres-awx-postgres-0   Bound    pvc-ae4fa85a-9abe-47b2-ba49-d04ce972dd4e   8Gi        RWO            standard       35m

$ oc delete awxbackup awxbackup1
awxbackup.awx.ansible.com "awxbackup1" deleted

$ oc get pvc
NAME                      STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
awx-backup-claim          Bound    pvc-3ffcb83a-7376-4285-95bc-2411887d44cd   5Gi        RWO            standard       32m
postgres-awx-postgres-0   Bound    pvc-ae4fa85a-9abe-47b2-ba49-d04ce972dd4e   8Gi        RWO            standard       35m
```