### PR TITLE
Added ability to trust a custom bundle CA

### DIFF
--- a/ansible/templates/crd.yml.j2
+++ b/ansible/templates/crd.yml.j2
@@ -285,6 +285,12 @@ spec:
                 redis_image_version:
                   description: Redis container image version to use
                   type: string
+                init_container_image:
+                  description: Registry path to the init container to use
+                  type: string
+                init_container_image_version:
+                  description: Init container image version to use
+                  type: string
                 postgres_image:
                   description: Registry path to the PostgreSQL container to use
                   type: string
@@ -343,6 +349,9 @@ spec:
                   type: boolean
                 ldap_cacert_secret:
                   description: Secret where can be found the LDAP trusted Certificate Authority Bundle
+                  type: string
+                bundle_cacert_secret:
+                  description: Secret where can be found the trusted Certificate Authority Bundle
                   type: string
                 projects_persistence:
                   description: Whether or not the /var/lib/projects directory will be persistent

--- a/deploy/awx-operator.yaml
+++ b/deploy/awx-operator.yaml
@@ -287,6 +287,12 @@ spec:
                 redis_image_version:
                   description: Redis container image version to use
                   type: string
+                init_container_image:
+                  description: Registry path to the init container to use
+                  type: string
+                init_container_image_version:
+                  description: Init container image version to use
+                  type: string
                 postgres_image:
                   description: Registry path to the PostgreSQL container to use
                   type: string
@@ -345,6 +351,9 @@ spec:
                   type: boolean
                 ldap_cacert_secret:
                   description: Secret where can be found the LDAP trusted Certificate Authority Bundle
+                  type: string
+                bundle_cacert_secret:
+                  description: Secret where can be found the trusted Certificate Authority Bundle
                   type: string
                 projects_persistence:
                   description: Whether or not the /var/lib/projects directory will be persistent

--- a/deploy/crds/awx_v1beta1_crd.yaml
+++ b/deploy/crds/awx_v1beta1_crd.yaml
@@ -285,6 +285,12 @@ spec:
                 redis_image_version:
                   description: Redis container image version to use
                   type: string
+                init_container_image:
+                  description: Registry path to the init container to use
+                  type: string
+                init_container_image_version:
+                  description: Init container image version to use
+                  type: string
                 postgres_image:
                   description: Registry path to the PostgreSQL container to use
                   type: string
@@ -343,6 +349,9 @@ spec:
                   type: boolean
                 ldap_cacert_secret:
                   description: Secret where can be found the LDAP trusted Certificate Authority Bundle
+                  type: string
+                bundle_cacert_secret:
+                  description: Secret where can be found the trusted Certificate Authority Bundle
                   type: string
                 projects_persistence:
                   description: Whether or not the /var/lib/projects directory will be persistent

--- a/deploy/olm-catalog/awx-operator/manifests/awx.ansible.com_awxs_crd.yaml
+++ b/deploy/olm-catalog/awx-operator/manifests/awx.ansible.com_awxs_crd.yaml
@@ -35,6 +35,9 @@ spec:
               broadcast_websocket_secret:
                 description: Secret where the broadcast websocket secret can be found
                 type: string
+              bundle_cacert_secret:
+                description: Secret where can be found the trusted Certificate Authority Bundle
+                type: string
               ca_trust_bundle:
                 description: Path where the trusted CA bundle is available
                 type: string
@@ -148,6 +151,12 @@ spec:
                 - ingress
                 - Route
                 - route
+                type: string
+              init_container_image:
+                description: Registry path to the init container to use
+                type: string
+              init_container_image_version:
+                description: Initcontainer image version to use
                 type: string
               kind:
                 description: Kind of the deployment type

--- a/roles/installer/defaults/main.yml
+++ b/roles/installer/defaults/main.yml
@@ -111,6 +111,8 @@ redis_image: docker.io/redis
 redis_image_version: latest
 postgres_image: postgres
 postgres_image_version: 12
+init_container_image: quay.io/centos/centos
+init_container_image_version: 8
 image_pull_policy: IfNotPresent
 image_pull_secret: ''
 
@@ -205,6 +207,9 @@ ca_trust_bundle: "/etc/pki/tls/certs/ca-bundle.crt"
 # Secret to lookup that provides the LDAP CACert trusted bundle
 #
 ldap_cacert_secret: ''
+
+# Secret to lookup that provides the custom CA trusted bundle
+bundle_cacert_secret: ''
 
 # Whether secrets should be garbage collected
 # on teardown

--- a/roles/installer/tasks/load_bundle_cacert_secret.yml
+++ b/roles/installer/tasks/load_bundle_cacert_secret.yml
@@ -1,0 +1,12 @@
+---
+- name: Retrieve bundle Certificate Authority Secret
+  k8s_info:
+    kind: Secret
+    namespace: '{{ meta.namespace }}'
+    name: '{{ bundle_cacert_secret }}'
+  register: bundle_cacert
+
+- name: Load bundle Certificate Authority Secret content
+  set_fact:
+    bundle_ca_crt: '{{ bundle_cacert["resources"][0]["data"]["bundle-ca.crt"] | b64decode }}'
+  when: '"bundle-ca.crt" in bundle_cacert["resources"][0]["data"]'

--- a/roles/installer/tasks/main.yml
+++ b/roles/installer/tasks/main.yml
@@ -25,6 +25,11 @@
   when:
     - ldap_cacert_secret != ''
 
+- name: Load bundle certificate authority certificate
+  include_tasks: load_bundle_cacert_secret.yml
+  when:
+    - bundle_cacert_secret != ''
+
 - name: Include admin password configuration tasks
   include_tasks: admin_password_configuration.yml
 

--- a/roles/installer/templates/deployment.yaml.j2
+++ b/roles/installer/templates/deployment.yaml.j2
@@ -33,6 +33,25 @@ spec:
       imagePullSecrets:
         - name: {{ image_pull_secret }}
 {% endif %}
+{% if bundle_ca_crt %}
+      initContainers:
+        - name: init
+          image: '{{ init_container_image }}:{{ init_container_image_version }}'
+          imagePullPolicy: '{{ image_pull_policy }}'
+          command:
+            - /bin/sh
+            - -c
+            - |
+              mkdir -p /etc/pki/ca-trust/extracted/{java,pem,openssl,edk2}
+              update-ca-trust
+          volumeMounts:
+            - name: "ca-trust-extracted"
+              mountPath: "/etc/pki/ca-trust/extracted"
+            - name: "{{ meta.name }}-bundle-cacert"
+              mountPath: /etc/pki/ca-trust/source/anchors/bundle-ca.crt
+              subPath: bundle-ca.crt
+              readOnly: true
+{% endif %}
       containers:
         - image: '{{ redis_image }}:{{ redis_image_version }}'
           imagePullPolicy: '{{ image_pull_policy }}'
@@ -62,6 +81,14 @@ spec:
             - containerPort: 8053
 {% endif %}
           volumeMounts:
+{% if bundle_ca_crt %}
+            - name: "ca-trust-extracted"
+              mountPath: "/etc/pki/ca-trust/extracted"
+            - name: "{{ meta.name }}-bundle-cacert"
+              mountPath: /etc/pki/ca-trust/source/anchors/bundle-ca.crt
+              subPath: bundle-ca.crt
+              readOnly: true
+{% endif %}
             - name: "{{ meta.name }}-application-credentials"
               mountPath: "/etc/tower/conf.d/execution_environments.py"
               subPath: execution_environments.py
@@ -141,6 +168,14 @@ spec:
           args: {{ task_args }}
 {% endif %}
           volumeMounts:
+{% if bundle_ca_crt %}
+            - name: "ca-trust-extracted"
+              mountPath: "/etc/pki/ca-trust/extracted"
+            - name: "{{ meta.name }}-bundle-cacert"
+              mountPath: /etc/pki/ca-trust/source/anchors/bundle-ca.crt
+              subPath: bundle-ca.crt
+              readOnly: true
+{% endif %}
             - name: "{{ meta.name }}-application-credentials"
               mountPath: "/etc/tower/conf.d/execution_environments.py"
               subPath: execution_environments.py
@@ -211,6 +246,14 @@ spec:
           resources: {{ ee_resource_requirements }}
           args: ['receptor', '--config', '/etc/receptor.conf']
           volumeMounts:
+{% if bundle_ca_crt %}
+            - name: "ca-trust-extracted"
+              mountPath: "/etc/pki/ca-trust/extracted"
+            - name: "{{ meta.name }}-bundle-cacert"
+              mountPath: /etc/pki/ca-trust/source/anchors/bundle-ca.crt
+              subPath: bundle-ca.crt
+              readOnly: true
+{% endif %}
             - name: "{{ meta.name }}-receptor-config"
               mountPath: "/etc/receptor.conf"
               subPath: receptor.conf
@@ -241,6 +284,16 @@ spec:
         {{ tolerations | indent(width=8) }}
 {% endif %}
       volumes:
+{% if bundle_ca_crt %}
+        - name: "ca-trust-extracted"
+          emptyDir: {}
+        - name: "{{ meta.name }}-bundle-cacert"
+          secret:
+            secretName: "{{ bundle_cacert_secret }}"
+            items:
+              - key: bundle-ca.crt
+                path: 'bundle-ca.crt'
+{% endif %}
 {% if ingress_type | lower == 'route' and route_tls_termination_mechanism | lower == 'passthrough' %}
         - name: "{{ meta.name }}-nginx-certs"
           secret:

--- a/roles/installer/vars/main.yml
+++ b/roles/installer/vars/main.yml
@@ -2,4 +2,5 @@
 postgres_initdb_args: '--auth-host=scram-sha-256'
 postgres_host_auth_method: 'scram-sha-256'
 ldap_cacert_ca_crt: ''
+bundle_ca_crt: ''
 projects_existing_claim: ''


### PR DESCRIPTION
Fixes: https://github.com/ansible/awx-operator/issues/376

This PR introduces the `initContainer`  to prepare the RHEL PKI for the sub-containers used in AWX. This approach allows having the `update-trust-ca`  executed one instead for each container via `lifecycle`.  

See the https://github.com/ansible/awx-operator/issues/376 for the full testing report

Creating secret:
```sh
$ cat Toca_ROOT_CA.crt  Toca_Intermediate_CA.crt  > /tmp/bundle-ca.crt
$ kubectl create secret generic  awx-ssl-ca-custom  --from-file=bundle-ca.crt=/tmp/bundle-ca.crt
```

Modifying `awx` spec:

```yaml
apiVersion: awx.ansible.com/v1beta1
kind: AWX
....
spec:
  bundle_cacert_secret: awx-ssl-ca-custom
....
```

Result:
```sh
(py39) mdemello@storm ~> kubectl iexec awx /bin/bash                                                                                                                                                                                     00:53:40
Namespace: default | Pod: ✔ awx-ssl-ca-6cccf6577d-jzrk9
Container: ✔ awx-ssl-ca-task
bash-4.4$ ls -la /etc/pki/ca-trust/source/anchors/bundle-ca.crt 
-rw-r--r--. 1 root root 4086 Jun 11 04:51 /etc/pki/ca-trust/source/anchors/bundle-ca.crt
```