### PR TITLE
backup: Ensure colon are preserved in awx spec

### DIFF
--- a/roles/backup/tasks/awx-cro.yml
+++ b/roles/backup/tasks/awx-cro.yml
@@ -21,4 +21,4 @@
     namespace: "{{ backup_pvc_namespace }}"
     pod: "{{ meta.name }}-db-management"
     command: >-
-      bash -c "echo '{{ awx_spec }}' > {{ backup_dir }}/awx_object"
+      bash -c 'echo "$0" > {{ backup_dir  }}/awx_object' {{ awx_spec | quote  }}


### PR DESCRIPTION
Due to the way the command is run, the field with a colon in it will
generate a broken yaml serialization. This commit aims to keep it
accurate.

Proof of working as expected:


```
---
- hosts: localhost
  gather_facts: false
  vars:
    awx_spec:
      foo: bar
      tmp: 'foo: bar'
      task_extra_env: |
        - name: http_proxy
          value: "http://proxy.domain.tld:3128"
  tasks:
    - debug:
        var: '{{ awx_spec | to_nice_yaml | quote }}'

    - name: Store spec definition
      # command: bash -c "echo '{{ awx_spec }}' > awx_object"
      command: bash -c 'echo "$0" > awx_object' {{ awx_spec | quote  }}

    - name: Load spec definition
      command: bash -c "cat awx_object"
      register: awx_object

    - name: Create temp file for spec dict
      tempfile:
        state: file
      register: tmp_spec

    - name: Write spec vars to temp file
      copy:
        content: "{{ awx_object.stdout }}"
        dest: "{{ tmp_spec.path }}"
        mode: '0644'

    - name: Include spec vars to save them as a dict
      include_vars: "{{ tmp_spec.path }}"
      register: spec

    - name: Use include_vars to read in spec as a dict (because spec doesn't have quotes)
      set_fact:
        awx_spec: "{{ spec.ansible_facts }}"

    - debug:
        var: awx_spec
```

With the fix on (above snipped) output is:

```
TASK [debug] ***********************************************************************************************************************************************************************************
ok: [localhost] => 
  awx_spec:
    foo: bar
    task_extra_env: |-
      - name: http_proxy
        value: "http://proxy.domain.tld:3128"
    tmp: 'foo: bar'
```

Without it, the playbook run would crash

```
TASK [Include spec vars to save them as a dict] ************************************************************************************************************************************************
fatal: [localhost]: FAILED! => changed=false 
  ansible_facts: {}
  ansible_included_var_files: []
  message: |-
    We were unable to read either as JSON nor YAML, these are the errors we got from each:
    JSON: Expecting property name enclosed in double quotes: line 1 column 2 (char 1)
  
    Syntax Error while loading YAML.
      did not find expected ',' or '}'
  
    The error appears to be in '/tmp/ansible.ea5z_u_z': line 1, column 20, but may
    be elsewhere in the file depending on the exact syntax problem.
  
    The offending line appears to be:
  
  
    {foo: bar, tmp: foo: bar, task_extra_env: - name: http_proxyn value: http://proxy.domain.tld:3128n}
                       ^ here
```

Fixes: https://github.com/ansible/awx-operator/issues/370