### PR TITLE
Use fsGroup and handles NFS shares

### DIFF
--- a/README.md
+++ b/README.md
@@ -572,59 +572,19 @@ spec:
 
 In a scenario where custom volumes and volume mounts are required to either overwrite defaults or mount configuration files.
 
-| Name                           | Description                                              | Default |
-| ------------------------------ | -------------------------------------------------------- | ------- |
-| extra_volumes                  | Specify extra volumes to add to the application pod      | ''      |
-| web_extra_volume_mounts        | Specify volume mounts to be added to Web container       | ''      |
-| task_extra_volume_mounts       | Specify volume mounts to be added to Task container      | ''      |
-| ee_extra_volume_mounts         | Specify volume mounts to be added to Execution container | ''      |
+| Name                              | Description                                              | Default |
+| --------------------------------- | -------------------------------------------------------- | ------- |
+| extra_volumes                     | Specify extra volumes to add to the application pod      | ''      |
+| web_extra_volume_mounts           | Specify volume mounts to be added to Web container       | ''      |
+| task_extra_volume_mounts          | Specify volume mounts to be added to Task container      | ''      |
+| ee_extra_volume_mounts            | Specify volume mounts to be added to Execution container | ''      |
+| init_container_extra_volume_mounts| Specify volume mounts to be added to Init container      | ''      |
+| init_container_extra_commands     | Specify additional commands for Init container           | ''      |
+
 
 > :warning: The `ee_extra_volume_mounts` and `extra_volumes` will only take effect to the globally available Execution Environments. For custom `ee`, please [customize the Pod spec](https://docs.ansible.com/ansible-tower/latest/html/administration/external_execution_envs.html#customize-the-pod-spec).
 
 Example configuration for ConfigMap
-
-#### Default execution environments from private registries
-
-In order to register default execution environments from private registries, the Custom Resource needs to know about the pull credentials. Those credentials should be stored as a secret and specified as `ee_pull_credentials_secret` at the CR spec level. Instance initialization will register a `Container registry` type credential on the deployed instance and assign it to the registered default execution environments.
-
-The secret should be formated as follows:
-
-```yaml
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: my-ee-pull-credentials
-  namespace: <target namespace>
-stringData:
-  url: <registry url. i.e. quay.io>
-  username: <username to connect as>
-  password: <password to connect with>
-  ssl_verify: <Optional attribute. Whether verify ssl connection or not. Accepted values "True" (default), "False" >
-type: Opaque
-```
-
-##### Control plane EE from private registry
-The images listed in "ee_images" will be added as globally available Execution Environments. The "control_plane_ee_image" will be used to run project updates. In order to use a private image for any of these you'll need to use `image_pull_secret` to provide a k8s pull secret to access it. Currently the same secret is used for any of these images supplied at install time. 
-
-You can create `image_pull_secret`
-```
-kubectl create secret <resoucename>-cp-pull-credentials regcred --docker-server=<your-registry-server> --docker-username=<your-name> --docker-password=<your-pword> --docker-email=<your-email>
-```
-If you need more control (for example, to set a namespace or a label on the new secret) then you can customise the Secret before storing it
-
-```yaml
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: <resoucename>-cp-pull-credentials
-  namespace: <target namespace>
-data:
-  .dockerconfigjson: <base64 docker config>
-type: kubernetes.io/dockerconfigjson
-```
-Example spec file extra-config
 
 ```yaml
 ---
@@ -649,16 +609,6 @@ Example spec file for volumes and volume mounts
 ---
     spec:
     ...
-      ee_extra_volume_mounts: |
-        - name: ansible-cfg
-          mountPath: /etc/ansible/ansible.cfg
-          subPath: ansible.cfg
-
-      task_extra_volume_mounts: |
-        - name: custom-py
-          mountPath: /etc/tower/conf.d/custom.py
-          subPath: custom.py
-
       extra_volumes: |
         - name: ansible-cfg
           configMap:
@@ -674,10 +624,77 @@ Example spec file for volumes and volume mounts
               - key: custom.py
                 path: custom.py
             name: <resourcename>-extra-config
+        - name: shared-volume
+          persistentVolumeClaim:
+            claimName: my-external-volume-claim
 
+      init_container_extra_volume_mounts: |
+        - name: shared-volume
+          mountPath: /shared
+
+      init_container_extra_commands: |
+        # set proper permissions (rwx) for the awx user
+        chmod 775 /shared
+        chgrp 1000 /shared
+
+      ee_extra_volume_mounts: |
+        - name: ansible-cfg
+          mountPath: /etc/ansible/ansible.cfg
+          subPath: ansible.cfg
+
+      task_extra_volume_mounts: |
+        - name: custom-py
+          mountPath: /etc/tower/conf.d/custom.py
+          subPath: custom.py
+        - name: shared-volume
+          mountPath: /shared
 ```
 
 > :warning: **Volume and VolumeMount names cannot contain underscores(_)**
+
+#### Default execution environments from private registries
+
+In order to register default execution environments from private registries, the Custom Resource needs to know about the pull credentials. Those credentials should be stored as a secret and either specified as `ee_pull_credentials_secret` at the CR spec level, or simply be present on the namespace under the name `<resourcename>-ee-pull-credentials` . Instance initialization will register a `Container registry` type credential on the deployed instance and assign it to the registered default execution environments.
+
+The secret should be formated as follows:
+
+```yaml
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: <resourcename>-ee-pull-credentials
+  namespace: <target namespace>
+stringData:
+  url: <registry url. i.e. quay.io>
+  username: <username to connect as>
+  password: <password to connect with>
+  ssl_verify: <Optional attribute. Whether verify ssl connection or not. Accepted values "True" (default), "False" >
+type: Opaque
+```
+
+##### Control plane ee from private registry
+The images listed in "ee_images" will be added as globally available Execution Environments. The "control_plane_ee_image" will be used to run project updates. In order to use a private image for any of these you'll need to use `image_pull_secret` to provide a k8s pull secret to access it. Currently the same secret is used for any of these images supplied at install time.
+
+You can create `image_pull_secret`
+```
+kubectl create secret <resoucename>-cp-pull-credentials regcred --docker-server=<your-registry-server> --docker-username=<your-name> --docker-password=<your-pword> --docker-email=<your-email>
+```
+If you need more control (for example, to set a namespace or a label on the new secret) then you can customise the Secret before storing it
+
+Example spec file extra-config
+
+```yaml
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: <resoucename>-cp-pull-credentials
+  namespace: <target namespace>
+data:
+  .dockerconfigjson: <base64 docker config>
+type: kubernetes.io/dockerconfigjson
+```
 
 #### Exporting Environment Variables to Containers
 

--- a/ansible/templates/crd.yml.j2
+++ b/ansible/templates/crd.yml.j2
@@ -291,6 +291,12 @@ spec:
                 init_container_image_version:
                   description: Init container image version to use
                   type: string
+                init_container_extra_commands:
+                  description: Extra commands for the init container
+                  type: string
+                init_container_extra_volume_mounts:
+                  description: Specify volume mounts to be added to the init container
+                  type: string
                 postgres_image:
                   description: Registry path to the PostgreSQL container to use
                   type: string

--- a/deploy/awx-operator.yaml
+++ b/deploy/awx-operator.yaml
@@ -293,6 +293,12 @@ spec:
                 init_container_image_version:
                   description: Init container image version to use
                   type: string
+                init_container_extra_commands:
+                  description: Extra commands for the init container
+                  type: string
+                init_container_extra_volume_mounts:
+                  description: Specify volume mounts to be added to the init container
+                  type: string
                 postgres_image:
                   description: Registry path to the PostgreSQL container to use
                   type: string

--- a/deploy/crds/awx_v1beta1_crd.yaml
+++ b/deploy/crds/awx_v1beta1_crd.yaml
@@ -291,6 +291,12 @@ spec:
                 init_container_image_version:
                   description: Init container image version to use
                   type: string
+                init_container_extra_commands:
+                  description: Extra commands for the init container
+                  type: string
+                init_container_extra_volume_mounts:
+                  description: Specify volume mounts to be added to the init container
+                  type: string
                 postgres_image:
                   description: Registry path to the PostgreSQL container to use
                   type: string

--- a/deploy/olm-catalog/awx-operator/manifests/awx-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/awx-operator/manifests/awx-operator.clusterserviceversion.yaml
@@ -565,6 +565,18 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Specify Extra commands for the Init container
+        displayName: Init Container Extra Commands
+        path: init_container_extra_commands
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Specify volume mounts to be added to Init container
+        displayName: Init Container Extra Volume Mounts
+        path: init_container_extra_volume_mounts
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:hidden
       - description: Secret where can be found the trusted Certificate Authority Bundle
         path: bundle_cacert_secret
         x-descriptors:

--- a/deploy/olm-catalog/awx-operator/manifests/awx.ansible.com_awxs_crd.yaml
+++ b/deploy/olm-catalog/awx-operator/manifests/awx.ansible.com_awxs_crd.yaml
@@ -158,6 +158,12 @@ spec:
               init_container_image_version:
                 description: Init container image version to use
                 type: string
+              init_container_extra_commands:
+                description: Extra commands for the init container
+                type: string
+              init_container_extra_volume_mounts:
+                description: Specify volume mounts to be added to the init container
+                type: string
               kind:
                 description: Kind of the deployment type
                 type: string

--- a/roles/installer/defaults/main.yml
+++ b/roles/installer/defaults/main.yml
@@ -116,6 +116,22 @@ init_container_image_version: 8
 image_pull_policy: IfNotPresent
 image_pull_secret: ''
 
+# Extra commands which will be appended to the initContainer
+# Make sure that each command entered return an exit code 0
+# otherwise the initContainer will fail
+# init_container_extra_commands: |
+#   date >> /var/lib/awx/projects/timestamp
+#   chgrp 1000 /shared
+#   chmod 775 /shared
+init_container_extra_commands: ''
+
+# Mount extra volumes on the initContainer.
+# The volume used must be defined as an `extra_volumes` resource
+# init_container_extra_volume_mounts: |
+#   - name: shared-vol
+#     mountPath: /shared
+init_container_extra_volume_mounts: ''
+
 ee_images:
   - name: AWX EE 0.5.0
     image: quay.io/ansible/awx-ee:0.5.0

--- a/roles/installer/templates/deployment.yaml.j2
+++ b/roles/installer/templates/deployment.yaml.j2
@@ -33,7 +33,7 @@ spec:
       imagePullSecrets:
         - name: {{ image_pull_secret }}
 {% endif %}
-{% if bundle_ca_crt %}
+{% if bundle_ca_crt or projects_persistence|bool or init_container_extra_commands %}
       initContainers:
         - name: init
           image: '{{ init_container_image }}:{{ init_container_image_version }}'
@@ -42,15 +42,33 @@ spec:
             - /bin/sh
             - -c
             - |
+{% if bundle_ca_crt  %}
               mkdir -p /etc/pki/ca-trust/extracted/{java,pem,openssl,edk2}
               update-ca-trust
+{% endif %}
+{% if projects_persistence|bool %}
+              chmod 775 /var/lib/awx/projects
+              chgrp 1000 /var/lib/awx/projects
+{% endif %}
+{% if init_container_extra_commands %}
+              {{ init_container_extra_commands | indent(width=14) }}
+{% endif %}
           volumeMounts:
+{% if bundle_ca_crt  %}
             - name: "ca-trust-extracted"
               mountPath: "/etc/pki/ca-trust/extracted"
             - name: "{{ meta.name }}-bundle-cacert"
               mountPath: /etc/pki/ca-trust/source/anchors/bundle-ca.crt
               subPath: bundle-ca.crt
               readOnly: true
+{% endif %}
+{% if projects_persistence|bool %}
+            - name: "{{ meta.name }}-projects"
+              mountPath: "/var/lib/awx/projects"
+{% endif %}
+{% if init_container_extra_volume_mounts -%}
+            {{ init_container_extra_volume_mounts | indent(width=12, indentfirst=True) }}
+{% endif %}
 {% endif %}
       containers:
         - image: '{{ redis_image }}:{{ redis_image_version }}'
@@ -282,6 +300,10 @@ spec:
 {% if tolerations %}
       tolerations:
         {{ tolerations | indent(width=8) }}
+{% endif %}
+{% if projects_persistence|bool %}
+      securityContext:
+        fsGroup: 1000
 {% endif %}
       volumes:
 {% if bundle_ca_crt %}


### PR DESCRIPTION
Fixes: https://github.com/ansible/awx-operator/issues/395
Fixes: https://github.com/ansible/awx-operator/issues/357


This PR accomplishes a couple of things based on different environments. 

When using the `projects_persistence` with a `projects_existing_claim`, depending on the storage provide a `block` device or `filesystem` device will present to the AWX instance writable only by the `root` user.  This introduces a problem as the `awx` user is unable to write under `/var/lib/awx/projects` therefore not being able to sync projects. 

Using the `fsGroup` address the issue for `block` and `fs` mounts so the volume will be mounted allowing the `awx` user to write on it. However, `fsGroup` does not work for `NFS` shares as noted here: https://github.com/kubernetes/examples/issues/260

To work around this issue, we can use the `initContainer` approach to change the permissions and privileges for the mounted volume. 

Please refer to https://github.com/ansible/awx-operator/issues/395#issuecomment-864453580 and https://github.com/ansible/awx-operator/issues/357#issuecomment-863732211 for a full write-up while troubleshooting this issue. 

Another important addition is the ability to the user specify extra volumes as mentioned at https://github.com/ansible/awx-operator/issues/395#issuecomment-864659530

For example:

```yaml

spec:
  replicas: 1 
  ingress_type: none
  service_type: loadbalancer
  projects_existing_claim: awx-testing-nfs-claim
  projects_persistence: true
  extra_volumes: |
    - name: shared-volume
      persistentVolumeClaim:
        claimName: awx-testing-nfs-claim2
  init_container_extra_volume_mounts: |
    - name: shared-volume
      mountPath: /shared
  init_container_extra_commands: |
    # this will ensure the awx user can write on this volume
    chmod 775 /shared
    chgrp 1000 /shared
    date >> /var/lib/awx/projects/been_here
  task_extra_volume_mounts: |
    - name: shared-volume
      mountPath: /shared
```


**TL;DR**

**Before with nfs**
```sh
kubectl iexec awx /bin/bash                                                               15:08:49
Namespace: default | Pod: ✔ awx-nfs-596f6cf8b7-lb4xq
Container: ✔ awx-nfs-web
bash-4.4$ ls -lahd /var/lib/awx/projects
d---------. 1 root root 14 Jun 19 18:43 /var/lib/awx/projects
bash-4.4$ df -h /var/lib/awx/projects
Filesystem                        Size  Used Avail Use% Mounted on
192.168.111.46:/volume1/test-nfs-share  3.5T  1.3T  2.3T  36% /var/lib/awx/projects
bash-4.4$ whoami
awx
bash-4.4$ id awx
uid=1000(awx) gid=0(root) groups=0(root)
bash-4.4$ touch /var/lib/awx/projects/testing
touch: cannot touch '/var/lib/awx/projects/testing': Permission denied
```
**Before with block**
```sh
(py39) mdemello@storm ~/d/P/a/reproducer-357 (devel)> kubectl iexec awx-az /bin/bash                                       22:39:54
Namespace: default | Pod: ✔ awx-az-84dd57946f-855mn
Container: ✔ awx-az-web
bash-4.4$ df -h /var/lib/awx/projects/
Filesystem      Size  Used Avail Use% Mounted on
/dev/sdc        9.8G   37M  9.8G   1% /var/lib/awx/projects
bash-4.4$ ls -lah /var/lib/awx/projects/
total 24K
drwxr-xr-x 3 root root 4.0K Jun 18 02:26 .
drwxrwxr-x 1 root root 4.0K Jun 18 02:39 ..
drwx------ 2 root root  16K Jun 18 02:26 lost+found
bash-4.4$ id awx
uid=1000(awx) gid=0(root) groups=0(root)
bash-4.4$ whoami 
awx
bash-4.4$ touch /var/lib/awx/projects/test
touch: cannot touch '/var/lib/awx/projects/test': Permission denied
```


**After with nfs**
```sh
$ kubectl iexec awx /bin/bash                                                                   15:27:14
Namespace: default | Pod: ✔ awx-nfs-696dd649f5-zlqc4
Container: ✔ awx-nfs-web
bash-4.4$ df -h /var/lib/awx/projects/
Filesystem                        Size  Used Avail Use% Mounted on
192.168.111.46:/volume1/test-nfs-share  3.5T  1.3T  2.3T  36% /var/lib/awx/projects
bash-4.4$ whoami 
awx
bash-4.4$ id
uid=1000(awx) gid=0(root) groups=0(root),1000
bash-4.4$ touch /var/lib/awx/projects/testing-works-now
bash-4.4$ ls -la /var/lib/awx/projects/testing-works-now
-rw-rw-rw-. 1 awx root 0 Jun 19 19:23 /var/lib/awx/projects/testing-works-now
```
**After with block**

```sh
$ kubectl iexec awx-az /bin/bash                                                                            23:39:31
Namespace: default | Pod: ✔ awx-az-5fc5dd5767-lc48z
Container: ✔ awx-az-web
bash-4.4$ ls -lad /var/lib/awx/projects/
drwxrwsr-x 5 root 1000 4096 Jun 18 03:09 /var/lib/awx/projects/
bash-4.4$ df -h /var/lib/awx/projects/
Filesystem      Size  Used Avail Use% Mounted on
/dev/sdc        9.8G   37M  9.8G   1% /var/lib/awx/projects
bash-4.4$ touch /var/lib/awx/projects/test_works && echo $?
0
```

TODO:
* [ ] Tested @ AWS
* [ ] Tested @ OCP
* [x] Tested @ Azure :heavy_check_mark: 
* [x] Tested @ vanilla k8s with `hostPath` 
* [x] Tested @ vanilla k8s
* [x] Tested @ vanilla k8s with NFS provisioner  