### PR TITLE
Preserve newlines in AWX spec

### DIFF
--- a/roles/backup/tasks/awx-cro.yml
+++ b/roles/backup/tasks/awx-cro.yml
@@ -10,11 +10,8 @@
 
 - name: Set AWX object
   set_fact:
-    _awx: "{{ _awx_cro['resources'][0] }}"
-
-- name: Set user specified spec
-  set_fact:
-    awx_spec: "{{ _awx['spec'] }}"
+    awx_spec:
+      spec: "{{ this_awx['resources'][0]['spec'] }}"
 
 - name: Set names of backed up secrets in the CR spec
   set_fact:
@@ -30,4 +27,4 @@
     namespace: "{{ backup_pvc_namespace }}"
     pod: "{{ meta.name }}-db-management"
     command: >-
-      bash -c 'echo "$0" > {{ backup_dir  }}/awx_object' {{ awx_spec | quote  }}
+      bash -c 'echo "$0" > {{ backup_dir  }}/awx_object' {{ awx_spec | to_yaml | quote  }}

--- a/roles/restore/tasks/deploy_awx.yml
+++ b/roles/restore/tasks/deploy_awx.yml
@@ -1,9 +1,5 @@
 ---
 
-- name: Save kind
-  set_fact:
-    _kind: "{{ kind }}"
-
 - name: Get AWX object definition from pvc
   k8s_exec:
     namespace: "{{ backup_pvc_namespace }}"
@@ -25,22 +21,13 @@
 
 - name: Include spec vars to save them as a dict
   include_vars: "{{ tmp_spec.path }}"
-  register: spec
-
-- name: Use include_vars to read in spec as a dict (because spec doesn't have quotes)
-  set_fact:
-    awx_spec: "{{ spec.ansible_facts }}"
-
-- name: Restore kind
-  set_fact:
-    kind: "{{ _kind }}"
 
 - name: Deploy AWX
   k8s:
     state: "{{ state | default('present') }}"
     namespace: "{{ meta.namespace }}"
     apply: yes
-    template: awx_object.yml.j2
+    definition: "{{ lookup('template', 'awx_object.yml.j2') }}"
     wait: true
     wait_condition:
       type: "Running"

--- a/roles/restore/templates/awx_object.yml.j2
+++ b/roles/restore/templates/awx_object.yml.j2
@@ -4,4 +4,5 @@ kind: AWX
 metadata:
   name: '{{ deployment_name }}'
   namespace: '{{ meta.namespace }}'
-spec: {{ awx_spec }}
+spec:
+  {{ spec | to_yaml | indent(2) }}


### PR DESCRIPTION
Issue & context: https://github.com/ansible/awx-operator/issues/370#issuecomment-868851991

This will preserve newlines in awx_spec vars.  Below is an example that was problematic that this fixes:

```
  spec:
    admin_email: admin@localhost
    admin_user: admin
    create_preload_data: true
    development_mode: false
    extra_volumes: |
      - name: myvolume
        persistentVolumeClaim:
          claimName: manual-claim
```

Previously, this would end up looking like this in the resulting awx object's spec:

```
    extra_volumes: '- name: myvolume\n  persistentVolumeClaim:\n    claimName: manual-claim\n'
```