### PR TITLE
Fix var so that generated secret names are added to spec backup

### DIFF
--- a/roles/backup/tasks/awx-cro.yml
+++ b/roles/backup/tasks/awx-cro.yml
@@ -10,17 +10,21 @@
 
 - name: Set AWX object
   set_fact:
-    awx_spec:
-      spec: "{{ this_awx['resources'][0]['spec'] }}"
+    _awx: "{{ this_awx['resources'][0]['spec'] }}"
 
 - name: Set names of backed up secrets in the CR spec
   set_fact:
-    awx_spec: "{{ awx_spec | combine ({ item.key : item.value }) }}"
+    _awx: "{{ _awx | combine ({ item.key : item.value }) }}"
   with_items:
     - {"key": "secret_key_secret", "value": "{{ this_awx['resources'][0]['status']['secretKeySecret'] }}"}
     - {"key": "admin_password_secret", "value": "{{ this_awx['resources'][0]['status']['adminPasswordSecret'] }}"}
     - {"key": "broadcast_websocket_secret", "value": "{{ this_awx['resources'][0]['status']['broadcastWebsocketSecret'] }}"}
     - {"key": "postgres_configuration_secret", "value": "{{ this_awx['resources'][0]['status']['postgresConfigurationSecret'] }}"}
+
+- name: Set AWX object
+  set_fact:
+    awx_spec:
+      spec: "{{ _awx }}"
 
 - name: Write awx object to pvc
   k8s_exec:

--- a/roles/restore/tasks/postgres.yml
+++ b/roles/restore/tasks/postgres.yml
@@ -1,5 +1,9 @@
 ---
 
+- name: Set Postgres Configuration Secret name
+  set_fact:
+    postgres_configuration_secret: "{{ spec['postgres_configuration_secret'] | default(postgres_configuration_secret) }}"
+
 - name: Check for specified PostgreSQL configuration
   k8s_info:
     kind: Secret


### PR DESCRIPTION
Issue: https://github.com/ansible/tower/issues/5185

The generated secret names were not getting added to the awx_spec at backup time.  As a result, at restore time, the postgres configuration secret was not known to the AWX object.  

After the fix:

```
root@debug-db-management:/backups/tower-openshift-backup-2021-06-30-09:50:30# ls
awx_object  secrets.yml  tower.db
root@debug-db-management:/backups/tower-openshift-backup-2021-06-30-09:50:30# cat awx_object 
spec: {admin_email: admin@localhost, admin_password_secret: awx-admin-password, admin_user: admin,
  broadcast_websocket_secret: awx-broadcast-websocket, create_preload_data: true,
  development_mode: false, garbage_collect_secrets: false, image_pull_policy: Always,
  ingress_type: Route, loadbalancer_port: 80, loadbalancer_protocol: http, postgres_configuration_secret: awx-postgres-configuration,
  projects_persistence: false, projects_storage_access_mode: ReadWriteMany, projects_storage_size: 8Gi,
  replicas: 1, route_tls_termination_mechanism: Edge, secret_key_secret: awx-secret-key,
  service_type: clusterip, task_privileged: false}
```