### PR TITLE
add image_pull_secret to postgres install

### DIFF
--- a/roles/installer/templates/postgres.yaml.j2
+++ b/roles/installer/templates/postgres.yaml.j2
@@ -33,6 +33,10 @@ spec:
         app.kubernetes.io/part-of: '{{ meta.name }}'
         app.kubernetes.io/managed-by: '{{ deployment_type }}-operator' 
     spec:
+{% if image_pull_secret %}
+      imagePullSecrets:
+        - name: {{ image_pull_secret }}
+{% endif %}
       containers:
         - image: '{{ postgres_image }}:{{ postgres_image_version }}'
           imagePullPolicy: '{{ image_pull_policy }}'


### PR DESCRIPTION
Hi,

Postgres image can be override.
But if you use a private repository with an authentification, postgres deployment don't use the image_pull_secret

So i propose to use the same value as deployment of AWX