### PR TITLE
Do not check for default ee-pull-cred secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -577,7 +577,7 @@ Example configuration for ConfigMap
 
 #### Default execution environments from private registries
 
-In order to register default execution environments from private registries, the Custom Resource needs to know about the pull credentials. Those credentials should be stored as a secret and either specified as `ee_pull_credentials_secret` at the CR spec level, or simply be present on the namespace under the name `<resourcename>-ee-pull-credentials` . Instance initialization will register a `Container registry` type credential on the deployed instance and assign it to the registered default execution environments.
+In order to register default execution environments from private registries, the Custom Resource needs to know about the pull credentials. Those credentials should be stored as a secret and specified as `ee_pull_credentials_secret` at the CR spec level. Instance initialization will register a `Container registry` type credential on the deployed instance and assign it to the registered default execution environments.
 
 The secret should be formated as follows:
 
@@ -586,7 +586,7 @@ The secret should be formated as follows:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: <resourcename>-ee-pull-credentials
+  name: my-ee-pull-credentials
   namespace: <target namespace>
 stringData:
   url: <registry url. i.e. quay.io>
@@ -596,7 +596,7 @@ stringData:
 type: Opaque
 ```
 
-##### Control plane ee from private registry
+##### Control plane EE from private registry
 The images listed in "ee_images" will be added as globally available Execution Environments. The "control_plane_ee_image" will be used to run project updates. In order to use a private image for any of these you'll need to use `image_pull_secret` to provide a k8s pull secret to access it. Currently the same secret is used for any of these images supplied at install time. 
 
 You can create `image_pull_secret`

--- a/roles/backup/tasks/dump_secret.yml
+++ b/roles/backup/tasks/dump_secret.yml
@@ -2,7 +2,7 @@
 
 - name: Get Secret Name
   set_fact:
-      _name: "{{ awx_spec[item] | default('') }}"
+      _name: "{{ awx_spec.spec[item] | default('') }}"
 
 - name: Skip if secret name not defined
   block:

--- a/roles/installer/tasks/initialize_django.yml
+++ b/roles/installer/tasks/initialize_django.yml
@@ -73,18 +73,12 @@
   register: _custom_execution_environments_pull_credentials
   when: ee_pull_credentials_secret | length
 
-- name: Check for default execution environment pull credentials
-  k8s_info:
-    kind: Secret
-    namespace: '{{ meta.namespace }}'
-    name: '{{ meta.name }}-ee-pull-credentials'
-  register: _default_execution_environments_pull_credentials
-
-- name: Set admin password secret
+- name: Set execution environment pull credential secret
   set_fact:
     _execution_environments_pull_credentials: >-
       {{ _custom_execution_environments_pull_credentials["resources"] | default([]) | length
-      | ternary(_custom_execution_environments_pull_credentials, _default_execution_environments_pull_credentials) }}
+      | ternary(_custom_execution_environments_pull_credentials, []) }}
+
 - name: Register default execution environments (without authentication)
   k8s_exec:
     namespace: "{{ meta.namespace }}"


### PR DESCRIPTION
To stay consistent with other non-generated secrets, we should not check for a default secret name because this would require us to also add it as a status on the AWX object to properly back it up.  

For the other secrets (ee_pull_credentials_secret, image_pull_secret, route_tls_secret), they were not being added because a variable name got changed in this PR: https://github.com/ansible/awx-operator/pull/435/files#diff-3ced427495f8e83eeeefcf8bf0228eb0c2b7f0398758d64a46b49954d05528bcR13-R14

This now correctly backs up the secrets to `secrets.yml`

```
root@awx-db-management:/backups/tower-openshift-backup-2021-07-01-11:10:03# cat secrets.yml 
secrets:
  adminPasswordSecret:
    data: {password: dW5NWXdFREtTaGlwdzNwaWhqSW9SSXZ3YzdoandKeGU=}
    name: awx-admin-password
  broadcastWebsocketSecret:
    data: {secret: cGsxV2E2RUt3MXM5NWx3UGF5VmFRREl6TWpubjdQM1E=}
    name: awx-broadcast-websocket
  ee_pull_credentials_secret:
    data: {password: Q0dNM0hMWElKNzZUME43Wk5MVFNaRlQ4Qkk4WDdWSjk1MFk0MFAwN1NBOUhSSFdLUjlQVlJNQUdRMkxBTlRVOA==,
      url: cXVheS5pbw==, username: Y2hhZGFtcyt0ZXN0Ym90}
    name: custom-ee-pull-secret
  image_pull_secret:
    data: {password: Q0dNM0hMWElKNzZUME43Wk5MVFNaRlQ4Qkk4WDdWSjk1MFk0MFAwN1NBOUhSSFdLUjlQVlJNQUdRMkxBTlRVOA==,
      username: Y2hhZGFtcyt0ZXN0Ym90}
    name: custom-pull-secret
  postgresConfigurationSecret:
    data: {database: dG93ZXI=, host: YXd4LXBvc3RncmVz, password: bXlwYXNzd29yZA==,
      port: NTQzMg==, type: bWFuYWdlZA==, username: dG93ZXI=}
    name: custom-postgres-configuration
  route_tls_secret:
    data: {ca.crt: b3B0aW9uYWwtY2EtY2VydFxudGVzdA==, tls.crt: Y2VydC12YWx1ZVxudGVzdA==,
      tls.key: a2V5LXZhbHVlXG50ZXN0}
    name: custom-route-tls
  secretKeySecret:
    data: {secret_key: aERNOXN5enVuTFRvWUZabndlVHpUUE5pYW50ZG9JR0I=}
    name: awx-secret-key
```