### PR TITLE
Namespace not required

### DIFF
--- a/deploy/olm-catalog/awx-operator/manifests/awx-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/awx-operator/manifests/awx-operator.clusterserviceversion.yaml
@@ -114,21 +114,19 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
         - urn:alm:descriptor:com.tectonic.ui:fieldDependency:backup_source:CR
-      - displayName: Deployment name
+      - displayName: Name of newly restored deployment
         path: deployment_name
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
-        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:backup_source:PVC
       - displayName: Backup persistent volume claim
         path: backup_pvc
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
         - urn:alm:descriptor:com.tectonic.ui:fieldDependency:backup_source:PVC
-      - displayName: Backup persistent volume claim namespace
+      - displayName: Backup namespace
         path: backup_pvc_namespace
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
-        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:backup_source:PVC
       - displayName: Backup directory in the persistent volume claim
         path: backup_dir
         x-descriptors:

--- a/roles/restore/defaults/main.yml
+++ b/roles/restore/defaults/main.yml
@@ -6,7 +6,7 @@ api_version: '{{ deployment_type }}.ansible.com/v1beta1'
 
 # Required: specify a pre-created PVC (name) to restore from
 backup_pvc: ''
-backup_pvc_namespace: ''
+backup_pvc_namespace: '{{ meta.namespace }}'
 
 # Required: backup name, found on the awxbackup object
 backup_dir: ''


### PR DESCRIPTION
Missing namespace field in the catalog.  

Now this is fixed.  If the CR enum is selected:
![image](https://user-images.githubusercontent.com/11698892/124161276-36c26f00-da6b-11eb-8eff-3784e4341bef.png)

If the PVC enum is selected:
![image](https://user-images.githubusercontent.com/11698892/124161120-067ad080-da6b-11eb-8da2-c6858c628c90.png)
