### PR TITLE
added openshift api version

### DIFF
--- a/roles/installer/tasks/update_status.yml
+++ b/roles/installer/tasks/update_status.yml
@@ -75,6 +75,7 @@
 - block:
     - name: Retrieve route URL
       k8s_info:
+        api_version: 'route.openshift.io/v1'
         kind: Route
         namespace: '{{ meta.namespace }}'
         name: '{{ meta.name }}'


### PR DESCRIPTION
Adding the api version info enables the k8s_info module to retrieve the route information.

This fixes issue https://github.com/ansible/awx-operator/issues/452.