### PR TITLE
Set no_log on all tasks that could leak secrets in logs

### DIFF
--- a/roles/backup/tasks/dump_generated_secret.yml
+++ b/roles/backup/tasks/dump_generated_secret.yml
@@ -25,12 +25,15 @@
       namespace: '{{ meta.namespace }}'
       name: "{{ _name }}"
   register: _secret
+  no_log: true
 
 - name: Set secret data
   set_fact:
       _data: "{{ _secret['resources'][0]['data'] }}"
       _type: "{{ _secret['resources'][0]['type'] }}"
+  no_log: true
 
 - name: Create and Add secret names and data to dictionary
   set_fact:
       secret_dict: "{{ secret_dict | default({}) | combine({ item: {'name': _name, 'data': _data, 'type': _type }}) }}"
+  no_log: true

--- a/roles/backup/tasks/dump_secret.yml
+++ b/roles/backup/tasks/dump_secret.yml
@@ -4,7 +4,7 @@
   set_fact:
       _name: "{{ awx_spec.spec[item] | default('') }}"
 
-- name: Skip if secret name not defined
+- name: Backup secret if defined
   block:
       - name: Get secret
         k8s_info:
@@ -13,13 +13,16 @@
             namespace: '{{ meta.namespace }}'
             name: "{{ _name }}"
         register: _secret
+        no_log: true
 
       - name: Set secret key
         set_fact:
             _data: "{{ _secret['resources'][0]['data'] }}"
             _type: "{{ _secret['resources'][0]['type'] }}"
+        no_log: true
 
       - name: Create and Add secret names and data to dictionary
         set_fact:
             secret_dict: "{{ secret_dict | default({}) | combine({item: { 'name': _name, 'data': _data, 'type': _type }}) }}"
+        no_log: true
   when: _name != ''

--- a/roles/backup/tasks/postgres.yml
+++ b/roles/backup/tasks/postgres.yml
@@ -6,6 +6,7 @@
     namespace: '{{ meta.namespace }}'
     name: "{{ this_awx['resources'][0]['status']['postgresConfigurationSecret'] }}"
   register: pg_config
+  no_log: true
 
 - name: Fail if postgres configuration secret status does not exist
   fail:
@@ -20,6 +21,7 @@
     awx_postgres_port: "{{ pg_config['resources'][0]['data']['port'] | b64decode }}"
     awx_postgres_host: "{{ pg_config['resources'][0]['data']['host'] | b64decode }}"
     awx_postgres_type: "{{ pg_config['resources'][0]['data']['type'] | default('unmanaged'|b64encode) | b64decode }}"
+  no_log: true
 
 - block:
     - name: Delete pod to reload a resource configuration
@@ -77,6 +79,7 @@
 - name: Set full resolvable host name for postgres pod
   set_fact:
     resolvable_db_host: '{{ (awx_postgres_type == "managed") | ternary(awx_postgres_host + "." + meta.namespace + ".svc.cluster.local", awx_postgres_host) }}'  # noqa 204
+  no_log: true
 
 - name: Set pg_dump command
   set_fact:
@@ -87,6 +90,7 @@
       -d {{ awx_postgres_database }}
       -p {{ awx_postgres_port }}
       -F custom
+  no_log: true
 
 - name: Write pg_dump to backup on PVC
   k8s_exec:
@@ -99,4 +103,5 @@
       echo 'Successful'
       """
   register: data_migration
+  no_log: true
   failed_when: "'Successful' not in data_migration.stdout"

--- a/roles/backup/tasks/secrets.yml
+++ b/roles/backup/tasks/secrets.yml
@@ -27,6 +27,7 @@
 - name: Nest secrets under a single variable
   set_fact:
     secrets: {"secrets": '{{ secret_dict }}'}
+  no_log: true
 
 - name: Write postgres configuration to pvc
   k8s_exec:
@@ -34,3 +35,4 @@
     pod: "{{ meta.name }}-db-management"
     command: >-
       bash -c "echo '{{ secrets | to_yaml }}' > {{ backup_dir }}/secrets.yml"
+  no_log: true

--- a/roles/installer/tasks/admin_password_configuration.yml
+++ b/roles/installer/tasks/admin_password_configuration.yml
@@ -5,6 +5,7 @@
     namespace: '{{ meta.namespace }}'
     name: '{{ admin_password_secret }}'
   register: _custom_admin_password
+  no_log: true
   when: admin_password_secret | length
 
 - name: Check for default admin password configuration
@@ -13,16 +14,19 @@
     namespace: '{{ meta.namespace }}'
     name: '{{ meta.name }}-admin-password'
   register: _default_admin_password
+  no_log: true
 
 - name: Set admin password secret
   set_fact:
     _admin_password_secret: '{{ _custom_admin_password["resources"] | default([]) | length | ternary(_custom_admin_password, _default_admin_password) }}'
+  no_log: true
 
 - block:
     - name: Create admin password secret
       k8s:
         apply: true
         definition: "{{ lookup('template', 'admin_password_secret.yaml.j2') }}"
+      no_log: true
 
     - name: Read admin password secret
       k8s_info:
@@ -30,13 +34,16 @@
         namespace: '{{ meta.namespace }}'
         name: '{{ meta.name }}-admin-password'
       register: _generated_admin_password
+      no_log: true
 
   when: not _admin_password_secret['resources'] | default([]) | length
 
 - name: Set admin password secret
   set_fact:
     __admin_password_secret: '{{ _generated_admin_password["resources"] | default([]) | length | ternary(_generated_admin_password, _admin_password_secret) }}'
+  no_log: true
 
 - name: Store admin password
   set_fact:
     admin_password: "{{ __admin_password_secret['resources'][0]['data']['password'] | b64decode }}"
+  no_log: true

--- a/roles/installer/tasks/broadcast_websocket_configuration.yml
+++ b/roles/installer/tasks/broadcast_websocket_configuration.yml
@@ -5,6 +5,7 @@
     namespace: '{{ meta.namespace }}'
     name: '{{ broadcast_websocket_secret }}'
   register: _custom_broadcast_websocket
+  no_log: true
   when: broadcast_websocket_secret | length
 
 - name: Check for default broadcast websocket secret configuration
@@ -13,17 +14,20 @@
     namespace: '{{ meta.namespace }}'
     name: '{{ meta.name }}-broadcast-websocket'
   register: _default_broadcast_websocket
+  no_log: true
 
 - name: Set broadcast websocket secret
   set_fact:
     # yamllint disable-line rule:line-length
     _broadcast_websocket_secret: '{{ _custom_broadcast_websocket["resources"] | default([]) | length | ternary(_custom_broadcast_websocket, _default_broadcast_websocket) }}'  # noqa 204
+  no_log: true
 
 - block:
     - name: Create broadcast websocket secret
       k8s:
         apply: true
         definition: "{{ lookup('template', 'broadcast_websocket_secret.yaml.j2') }}"
+      no_log: true
 
     - name: Read broadcast websocket secret
       k8s_info:
@@ -31,6 +35,7 @@
         namespace: '{{ meta.namespace }}'
         name: '{{ meta.name }}-broadcast-websocket'
       register: _generated_broadcast_websocket
+      no_log: true
 
   when: not _broadcast_websocket_secret['resources'] | default([]) | length
 
@@ -38,7 +43,9 @@
   set_fact:
     # yamllint disable-line rule:line-length
     __broadcast_websocket_secret: '{{ _generated_broadcast_websocket["resources"] | default([]) | length | ternary(_generated_broadcast_websocket, _broadcast_websocket_secret)  }}'  # noqa 204
+  no_log: true
 
 - name: Store broadcast websocket secret name
   set_fact:
     broadcast_websocket_secret_value: "{{ __broadcast_websocket_secret['resources'][0]['data']['secret'] | b64decode }}"
+  no_log: true

--- a/roles/installer/tasks/cleanup.yml
+++ b/roles/installer/tasks/cleanup.yml
@@ -23,5 +23,6 @@
         - '{{ _secret_key }}'
         - '{{ _postgres_configuration }}'
         - '{{ _broadcast_websocket_secret }}'
+      no_log: true
 
   when: not garbage_collect_secrets | bool

--- a/roles/installer/tasks/database_configuration.yml
+++ b/roles/installer/tasks/database_configuration.yml
@@ -6,6 +6,7 @@
     name: '{{ postgres_configuration_secret }}'
   register: _custom_pg_config_resources
   when: postgres_configuration_secret | length
+  no_log: true
 
 - name: Check for default PostgreSQL configuration
   k8s_info:
@@ -13,6 +14,7 @@
     namespace: '{{ meta.namespace }}'
     name: '{{ meta.name }}-postgres-configuration'
   register: _default_pg_config_resources
+  no_log: true
 
 - name: Check for specified old PostgreSQL configuration secret
   k8s_info:
@@ -21,6 +23,7 @@
     name: '{{ old_postgres_configuration_secret }}'
   register: _custom_old_pg_config_resources
   when: old_postgres_configuration_secret | length
+  no_log: true
 
 - name: Check for default old PostgreSQL configuration
   k8s_info:
@@ -28,6 +31,7 @@
     namespace: '{{ meta.namespace }}'
     name: '{{ meta.name }}-old-postgres-configuration'
   register: _default_old_pg_config_resources
+  no_log: true
 
 - name: Set old PostgreSQL configuration
   set_fact:
@@ -41,16 +45,19 @@
   when:
     - old_pg_config['resources'] is defined
     - old_pg_config['resources'] | length
+  no_log: true
 
 - name: Set PostgreSQL configuration
   set_fact:
     _pg_config: '{{ _custom_pg_config_resources["resources"] | default([]) | length | ternary(_custom_pg_config_resources, _default_pg_config_resources) }}'
+  no_log: true
 
 - block:
     - name: Create Database configuration
       k8s:
         apply: true
         definition: "{{ lookup('template', 'postgres_secret.yaml.j2') }}"
+      no_log: true
 
     - name: Read Database Configuration
       k8s_info:
@@ -58,11 +65,13 @@
         namespace: '{{ meta.namespace }}'
         name: '{{ meta.name }}-postgres-configuration'
       register: _generated_pg_config_resources
+      no_log: true
   when: not _pg_config['resources'] | default([]) | length
 
 - name: Set PostgreSQL Configuration
   set_fact:
     pg_config: '{{ _generated_pg_config_resources["resources"] | default([]) | length | ternary(_generated_pg_config_resources, _pg_config) }}'
+  no_log: true
 
 - name: Set actual postgres configuration secret used
   set_fact:
@@ -112,6 +121,7 @@
     awx_postgres_port: "{{ pg_config['resources'][0]['data']['port'] | b64decode }}"
     awx_postgres_host: "{{ pg_config['resources'][0]['data']['host'] | b64decode }}"
     awx_postgres_sslmode: "{{ pg_config['resources'][0]['data']['sslmode'] |  default('prefer'|b64encode) | b64decode }}"
+  no_log: true
 
 - name: Look up details for this deployment
   k8s_info:

--- a/roles/installer/tasks/initialize_django.yml
+++ b/roles/installer/tasks/initialize_django.yml
@@ -22,6 +22,7 @@
       bash -c "awx-manage update_password --username '{{ admin_user }}' --password '{{ admin_password }}'"
   register: update_pw_result
   changed_when: users_result.stdout == 'Password not updated'
+  no_log: true
   when: users_result.return_code == 0
 
 - name: Create super user via Django if it doesn't exist.
@@ -33,6 +34,7 @@
       bash -c "echo \"from django.contrib.auth.models import User;
       User.objects.create_superuser('{{ admin_user }}', '{{ admin_email }}', '{{ admin_password }}')\"
       | awx-manage shell"
+  no_log: true
   when: users_result.return_code > 0
 
 - name: Create preload data if necessary.  # noqa 305
@@ -78,6 +80,7 @@
     _execution_environments_pull_credentials: >-
       {{ _custom_execution_environments_pull_credentials["resources"] | default([]) | length
       | ternary(_custom_execution_environments_pull_credentials, []) }}
+  no_log: true
 
 - name: Register default execution environments (without authentication)
   k8s_exec:
@@ -98,6 +101,8 @@
         default_execution_environment_pull_credentials_url: "{{ _execution_environments_pull_credentials['resources'][0]['data']['url'] | b64decode }}"
         default_execution_environment_pull_credentials_url_verify: >-
           {{ _execution_environments_pull_credentials['resources'][0]['data']['ssl_verify'] | default("True"|b64encode) | b64decode }}
+      no_log: true
+
     - name: Register default execution environments (with authentication)
       k8s_exec:
         namespace: "{{ meta.namespace }}"
@@ -111,4 +116,5 @@
           --verify-ssl='{{ default_execution_environment_pull_credentials_url_verify }}'"
       register: ree
       changed_when: "'changed: True' in ree.stdout"
+      no_log: true
   when: _execution_environments_pull_credentials['resources'] | default([]) | length

--- a/roles/installer/tasks/load_bundle_cacert_secret.yml
+++ b/roles/installer/tasks/load_bundle_cacert_secret.yml
@@ -5,8 +5,10 @@
     namespace: '{{ meta.namespace }}'
     name: '{{ bundle_cacert_secret }}'
   register: bundle_cacert
+  no_log: true
 
 - name: Load bundle Certificate Authority Secret content
   set_fact:
     bundle_ca_crt: '{{ bundle_cacert["resources"][0]["data"]["bundle-ca.crt"] | b64decode }}'
+  no_log: true
   when: '"bundle-ca.crt" in bundle_cacert["resources"][0]["data"]'

--- a/roles/installer/tasks/load_ldap_cacert_secret.yml
+++ b/roles/installer/tasks/load_ldap_cacert_secret.yml
@@ -5,8 +5,10 @@
     namespace: '{{ meta.namespace }}'
     name: '{{ ldap_cacert_secret }}'
   register: ldap_cacert
+  no_log: true
 
 - name: Load LDAP CA Certificate Secret content
   set_fact:
     ldap_cacert_ca_crt: '{{ ldap_cacert["resources"][0]["data"]["ldap-ca.crt"] | b64decode }}'
+  no_log: true
   when: '"ldap-ca.crt" in ldap_cacert["resources"][0]["data"]'

--- a/roles/installer/tasks/load_route_tls_secret.yml
+++ b/roles/installer/tasks/load_route_tls_secret.yml
@@ -5,13 +5,16 @@
     namespace: '{{ meta.namespace }}'
     name: '{{ route_tls_secret }}'
   register: route_tls
+  no_log: true
 
 - name: Load Route TLS Secret content
   set_fact:
     route_tls_key: '{{ route_tls["resources"][0]["data"]["tls.key"] | b64decode }}'
     route_tls_crt: '{{ route_tls["resources"][0]["data"]["tls.crt"] | b64decode }}'
+  no_log: true
 
 - name: Load Route TLS Secret content
   set_fact:
     route_ca_crt: '{{ route_tls["resources"][0]["data"]["ca.crt"] | b64decode }}'
+  no_log: true
   when: '"ca.crt" in route_tls["resources"][0]["data"]'

--- a/roles/installer/tasks/migrate_data.yml
+++ b/roles/installer/tasks/migrate_data.yml
@@ -11,6 +11,7 @@
     awx_old_postgres_database: "{{ old_pg_config['resources'][0]['data']['database'] | b64decode }}"
     awx_old_postgres_port: "{{ old_pg_config['resources'][0]['data']['port'] | b64decode }}"
     awx_old_postgres_host: "{{ old_pg_config['resources'][0]['data']['host'] | b64decode }}"
+  no_log: true
 
 - name: Default label selector to custom resource generated postgres
   set_fact:
@@ -47,6 +48,7 @@
       -d {{ awx_old_postgres_database }}
       -p {{ awx_old_postgres_port }}
       -F custom
+  no_log: true
 
 - name: Set pg_restore command
   set_fact:
@@ -54,6 +56,7 @@
       pg_restore --clean --if-exists
       -U {{ database_username }}
       -d {{ database_name }}
+  no_log: true
 
 - name: Stream backup from pg_dump to the new postgresql container
   k8s_exec:
@@ -65,6 +68,7 @@
       PGPASSWORD={{ awx_old_postgres_pass }} {{ pgdump }} | PGPASSWORD={{ awx_postgres_pass }} {{ pg_restore }}
       echo 'Successful'
       """
+  no_log: true
   register: data_migration
   failed_when: "'Successful' not in data_migration.stdout"
 

--- a/roles/installer/tasks/resources_configuration.yml
+++ b/roles/installer/tasks/resources_configuration.yml
@@ -30,6 +30,7 @@
     - 'persistent'
     - 'service'
     - 'ingress'
+  no_log: true
 
 - name: Apply deployment resources
   k8s:

--- a/roles/installer/tasks/secret_key_configuration.yml
+++ b/roles/installer/tasks/secret_key_configuration.yml
@@ -5,6 +5,7 @@
     namespace: '{{ meta.namespace }}'
     name: '{{ secret_key_secret }}'
   register: _custom_secret_key
+  no_log: true
   when: secret_key_secret | length
 
 - name: Check for default secret key configuration
@@ -13,16 +14,19 @@
     namespace: '{{ meta.namespace }}'
     name: '{{ meta.name }}-secret-key'
   register: _default_secret_key
+  no_log: true
 
 - name: Set secret key secret
   set_fact:
     _secret_key_secret: '{{ _custom_secret_key["resources"] | default([]) | length | ternary(_custom_secret_key, _default_secret_key) }}'
+  no_log: true
 
 - block:
     - name: Create secret key secret
       k8s:
         apply: true
         definition: "{{ lookup('template', 'secret_key.yaml.j2') }}"
+      no_log: true
 
     - name: Read secret key secret
       k8s_info:
@@ -30,13 +34,16 @@
         namespace: '{{ meta.namespace }}'
         name: '{{ meta.name }}-secret-key'
       register: _generated_secret_key
+      no_log: true
 
   when: not _secret_key_secret['resources'] | default([]) | length
 
 - name: Set secret key secret
   set_fact:
     __secret_key_secret: '{{ _generated_secret_key["resources"] | default([]) | length | ternary(_generated_secret_key, _secret_key_secret)  }}'
+  no_log: true
 
 - name: Store secret key secret name
   set_fact:
     secret_key_secret_name: "{{ __secret_key_secret['resources'][0]['metadata']['name'] }}"
+  no_log: true

--- a/roles/restore/tasks/cleanup.yml
+++ b/roles/restore/tasks/cleanup.yml
@@ -22,6 +22,7 @@
     - '{{ admin_password_secret }}'
     - '{{ broadcast_websocket_secret }}'
     - '{{ postgres_configuration_secret }}'
+  no_log: true
 
 - name: Cleanup temp spec file
   file:

--- a/roles/restore/tasks/postgres.yml
+++ b/roles/restore/tasks/postgres.yml
@@ -10,6 +10,7 @@
     namespace: '{{ meta.namespace }}'
     name: '{{ postgres_configuration_secret }}'
   register: pg_config
+  no_log: true
 
 - name: Store Database Configuration
   set_fact:
@@ -19,6 +20,7 @@
     awx_postgres_port: "{{ pg_config['resources'][0]['data']['port'] | b64decode }}"
     awx_postgres_host: "{{ pg_config['resources'][0]['data']['host'] | b64decode }}"
     awx_postgres_type: "{{ pg_config['resources'][0]['data']['type'] | b64decode | default('unmanaged') }}"
+  no_log: true
 
 - name: Default label selector to custom resource generated postgres
   set_fact:
@@ -63,6 +65,7 @@
 - name: Set full resolvable host name for postgres pod
   set_fact:
     resolvable_db_host: "{{ awx_postgres_host }}.{{ meta.namespace }}.svc.cluster.local"
+  no_log: true
   when: awx_postgres_type == 'managed'
 
 - name: Set pg_restore command
@@ -74,6 +77,7 @@
       -U {{ awx_postgres_user }}
       -d {{ awx_postgres_database }}
       -p {{ awx_postgres_port }}
+  no_log: true
 
 - name: Restore database dump to the new postgresql container
   k8s_exec:
@@ -86,4 +90,5 @@
       echo 'Successful'
       """
   register: data_migration
+  no_log: true
   failed_when: "'Successful' not in data_migration.stdout"

--- a/roles/restore/tasks/secrets.yml
+++ b/roles/restore/tasks/secrets.yml
@@ -7,6 +7,7 @@
     command: >-
       bash -c "cat '{{ backup_dir }}/secrets.yml'"
   register: _secrets
+  no_log: true
 
 - name: Create Temporary secrets file
   tempfile:
@@ -19,31 +20,38 @@
     dest: "{{ tmp_secrets.path }}"
     content: "{{ _secrets.stdout }}"
     mode: 0640
+  no_log: true
 
 - name: Include secret vars from backup
   include_vars: "{{ tmp_secrets.path }}"
+  no_log: true
 
 - name: If deployment is managed, set the database_host in the pg config secret
   block:
     - name: Set new database host
       set_fact:
         database_host: "{{ deployment_name }}-postgres"
+      no_log: true
 
     - name: Set tmp postgres secret dict
       set_fact:
         _pg_secret: "{{ secrets['postgresConfigurationSecret'] }}"
+      no_log: true
 
     - name: Change postgres host value
       set_fact:
         _pg_data: "{{ _pg_secret['data'] | combine({'host': database_host | b64encode }) }}"
+      no_log: true
 
     - name: Create a postgres secret with the new host value
       set_fact:
         _pg_secret: "{{ _pg_secret | combine({'data': _pg_data}) }}"
+      no_log: true
 
     - name: Create a new dict of secrets with the new postgres secret
       set_fact:
         secrets: "{{ secrets | combine({'postgresConfigurationSecret': _pg_secret}) }}"
+      no_log: true
   when: secrets['postgresConfigurationSecret']['data']['type'] | b64decode == 'managed'
 
 - name: Apply secret
@@ -53,6 +61,7 @@
     apply: yes
     wait: yes
     template: "secrets.yml.j2"
+  no_log: true
 
 - name: Remove ownerReference on restored secrets
   k8s:
@@ -64,3 +73,4 @@
         namespace: '{{ meta.namespace }}'
         ownerReferences: null
   loop: "{{ secrets | dict2items }}"
+  no_log: true


### PR DESCRIPTION
Related to https://github.com/pulp/pulp-operator/pull/160/files

This adds `no_log: true` to all tasks that could potentially leak secret values or database credentials.  