### PR TITLE
Define ingress path as variable for deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,7 @@ The following variables are customizable when `ingress_type=ingress`. The `ingre
 | ingress_annotations        | Ingress annotations                      | Empty string                 |
 | ingress_tls_secret         | Secret that contains the TLS information | Empty string                 |
 | hostname                   | Define the FQDN                          | {{ meta.name }}.example.com  |
+| ingress_path               | Define the ingress path to the service   | /                            |
 
 ```yaml
 ---

--- a/ansible/templates/crd.yml.j2
+++ b/ansible/templates/crd.yml.j2
@@ -86,6 +86,9 @@ spec:
                     - ingress
                     - Route
                     - route
+                ingress_path:
+                  description: The ingress path used to reach the deployed service
+                  type: string
                 ingress_annotations:
                   description: Annotations to add to the Ingress Controller
                   type: string

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -6,9 +6,9 @@ LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=awx-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=alpha
 LABEL operators.operatorframework.io.bundle.channel.default.v1=alpha
-LABEL operators.operatorframework.io.metrics.project_layout=ansible
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v0.19.4
+LABEL operators.operatorframework.io.metrics.project_layout=ansible
 
 COPY deploy/olm-catalog/awx-operator/manifests /manifests/
 COPY deploy/olm-catalog/awx-operator/metadata /metadata/

--- a/deploy/awx-operator.yaml
+++ b/deploy/awx-operator.yaml
@@ -88,6 +88,9 @@ spec:
                     - ingress
                     - Route
                     - route
+                ingress_path:
+                  description: The ingress path used to reach the deployed service
+                  type: string
                 ingress_annotations:
                   description: Annotations to add to the Ingress Controller
                   type: string

--- a/deploy/crds/awx_v1beta1_crd.yaml
+++ b/deploy/crds/awx_v1beta1_crd.yaml
@@ -86,6 +86,9 @@ spec:
                     - ingress
                     - Route
                     - route
+                ingress_path:
+                  description: The ingress path used to reach the deployed service
+                  type: string
                 ingress_annotations:
                   description: Annotations to add to the Ingress Controller
                   type: string

--- a/deploy/olm-catalog/awx-operator/manifests/awx.ansible.com_awxs_crd.yaml
+++ b/deploy/olm-catalog/awx-operator/manifests/awx.ansible.com_awxs_crd.yaml
@@ -36,7 +36,8 @@ spec:
                 description: Secret where the broadcast websocket secret can be found
                 type: string
               bundle_cacert_secret:
-                description: Secret where can be found the trusted Certificate Authority Bundle
+                description: Secret where can be found the trusted Certificate Authority
+                  Bundle
                 type: string
               ca_trust_bundle:
                 description: Path where the trusted CA bundle is available
@@ -140,6 +141,9 @@ spec:
               ingress_annotations:
                 description: Annotations to add to the Ingress Controller
                 type: string
+              ingress_path:
+                description: The ingress path used to reach the deployed service
+                type: string
               ingress_tls_secret:
                 description: Secret where the Ingress TLS secret can be found
                 type: string
@@ -152,9 +156,6 @@ spec:
                 - Route
                 - route
                 type: string
-              ingress_path:
-                  description: The ingress path used to reach the deployed service
-                  type: string
               init_container_image:
                 description: Registry path to the init container to use
                 type: string

--- a/deploy/olm-catalog/awx-operator/manifests/awx.ansible.com_awxs_crd.yaml
+++ b/deploy/olm-catalog/awx-operator/manifests/awx.ansible.com_awxs_crd.yaml
@@ -152,6 +152,9 @@ spec:
                 - Route
                 - route
                 type: string
+              ingress_path:
+                  description: The ingress path used to reach the deployed service
+                  type: string
               init_container_image:
                 description: Registry path to the init container to use
                 type: string

--- a/roles/installer/defaults/main.yml
+++ b/roles/installer/defaults/main.yml
@@ -9,7 +9,7 @@ database_username: "{{ deployment_type }}"
 task_privileged: false
 service_type: ClusterIP
 ingress_type: none
-
+ingress_path: '/'
 # Add annotations to the service account. Specify as literal block. E.g.:
 # service_account_annotations: |
 #   eks.amazonaws.com/role-arn: arn:aws:iam::<ACCOUNT_ID>:role/<IAM_ROLE_NAME>

--- a/roles/installer/templates/ingress.yaml.j2
+++ b/roles/installer/templates/ingress.yaml.j2
@@ -20,7 +20,7 @@ spec:
     - host: '{{ hostname }}'
       http:
         paths:
-          - path: /
+          - path: '{{ ingress_path }}'
             backend:
               serviceName: '{{ meta.name }}-service'
               servicePort: 80


### PR DESCRIPTION
This PR provides the ingress path on ingress deployment as a variable that defaults to '/'. By overriding this value, custom ingress can be applied for running on cloud-providers using external LoadBalancers.

For the issue, please see: https://github.com/ansible/awx-operator/issues/455.

Fixes: https://github.com/ansible/awx-operator/issues/455

Updates the defaults for the installer role, the crd's and the documentation. Tested build against local Kubernetes by updating the ingress_path to be '' and '/'.