### PR TITLE
pgsql uses initContainer to address FS permissions

### DIFF
--- a/roles/installer/tasks/database_configuration.yml
+++ b/roles/installer/tasks/database_configuration.yml
@@ -80,8 +80,9 @@
 - block:
     - name: Create Database if no database is specified
       k8s:
-        apply: true
+        apply: yes
         definition: "{{ lookup('template', 'postgres.yaml.j2') }}"
+        wait: yes
       register: create_statefulset_result
 
   rescue:

--- a/roles/installer/templates/postgres.yaml.j2
+++ b/roles/installer/templates/postgres.yaml.j2
@@ -37,6 +37,21 @@ spec:
       imagePullSecrets:
         - name: {{ image_pull_secret }}
 {% endif %}
+      initContainers:
+        - name: init-chmod-data
+          image: '{{ postgres_image }}:{{ postgres_image_version }}'
+          imagePullPolicy: '{{ image_pull_policy }}'
+          command:
+            - /bin/sh
+            - -c
+            - |
+              if [ ! -f {{ postgres_data_path }}/PG_VERSION ]; then
+                chown postgres:root {{ postgres_data_path | dirname }}
+              fi
+          volumeMounts:
+            - name: postgres
+              mountPath: '{{ postgres_data_path | dirname }}'
+              subPath: '{{ postgres_data_path | dirname | basename }}'
       containers:
         - image: '{{ postgres_image }}:{{ postgres_image_version }}'
           imagePullPolicy: '{{ image_pull_policy }}'

--- a/roles/installer/templates/postgres.yaml.j2
+++ b/roles/installer/templates/postgres.yaml.j2
@@ -56,6 +56,8 @@ spec:
         - image: '{{ postgres_image }}:{{ postgres_image_version }}'
           imagePullPolicy: '{{ image_pull_policy }}'
           name: postgres
+          securityContext:
+            fsGroup: 999
           env:
             # For postgres_image based on rhel8/postgresql-12
             - name: POSTGRESQL_DATABASE


### PR DESCRIPTION
When using `local-path-provisioner` driver it might occur of the `postgresql` user to be unable to write on the `pvc` mounted at `{{ postgres_data_path }}`. 

To address this, we can use a `initContainer` which will be called only the first time the PostgreSQL statefulset gets created to address the directory to be writable by the `postgresql` user. 

This approach worked well when using the `postgres:12 ` image, however, we need to test using the `rhel8/postgresql-12` as well. 

### TODO
- [ ] - Test using the `rhel8/postgresql-12` image on OCP *cc*: @rooftopcellist 
- [x] - Test using a `k3s` with `local-path-provisioner`  with `postgres:12` image 

Fixes: #483
Fixes: #475

```sh
$ kubectl get pvc                                                                                                                                                00:45:39
NAME                      STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
awx-projects-claim        Bound    pvc-33b08fb9-2af1-4352-b805-49c9686ddfbc   2Gi        RWO            local-path     27m
postgres-awx-postgres-0   Bound    pvc-786afed3-6a14-4bc0-9c54-e39015b481f2   3Gi        RWO            local-path     20m


$ kubectl get pods -w                              00:38:58
NAME                            READY   STATUS    RESTARTS   AGE
awx-operator-5bc776b4d4-d9ww2   1/1     Running   0          4m41s
awx-postgres-0                  1/1     Running   0          4m3s
awx-d67898cd9-k6jrc             4/4     Running   0          3m48s

$ kubectl iexec awx-postgres-0 /bin/bash 
root@awx-postgres-0:/# namei  -xmolv /var/lib/postgresql/data/pgdata/
f: /var/lib/postgresql/data/pgdata/
Drwxr-xr-x root     root     /
drwxr-xr-x root     root     var
drwxr-xr-x root     root     lib
drwxr-xr-x postgres postgres postgresql
Drwx------ postgres root     data
drwx------ postgres root     pgdata
