### PR TITLE
Update API versions removed from kubes 1.22

### DIFF
--- a/ansible/templates/role.yml.j2
+++ b/ansible/templates/role.yml.j2
@@ -37,6 +37,11 @@ rules:
       - daemonsets
       - replicasets
       - statefulsets
+    verbs:
+      - '*'
+  - apiGroups:
+      - networking.k8s.io
+    resources:
       - ingresses
     verbs:
       - '*'

--- a/deploy/awx-operator.yaml
+++ b/deploy/awx-operator.yaml
@@ -643,6 +643,11 @@ rules:
       - daemonsets
       - replicasets
       - statefulsets
+    verbs:
+      - '*'
+  - apiGroups:
+      - networking.k8s.io
+    resources:
       - ingresses
     verbs:
       - '*'

--- a/roles/installer/templates/ingress.yaml.j2
+++ b/roles/installer/templates/ingress.yaml.j2
@@ -1,6 +1,6 @@
 {% if ingress_type|lower == "ingress" %}
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: '{{ meta.name }}-ingress'
@@ -21,9 +21,12 @@ spec:
       http:
         paths:
           - path: '{{ ingress_path }}'
+            pathType: 'ImplementationSpecific'
             backend:
-              serviceName: '{{ meta.name }}-service'
-              servicePort: 80
+              service:
+                name: '{{ meta.name }}-service'
+                port:
+                  number: 80
 {% if ingress_tls_secret %}
   tls:
     - hosts:

--- a/roles/installer/templates/service_account.yaml.j2
+++ b/roles/installer/templates/service_account.yaml.j2
@@ -36,7 +36,7 @@ rules:
 
 ---
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: '{{ meta.name }}'
   namespace: '{{ meta.namespace }}'


### PR DESCRIPTION
The ingress change will lock out versions <1.19, if desired I can add a `ingress_api_version` or something similar.