### PR TITLE
Added nodeport port properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ The following variables are customizable only when `service_type=NodePort`
 
 | Name                           | Description                              | Default       |
 | ------------------------------ | ---------------------------------------- | ------------- |
-| nodeport_port            | Port used for NodePort       | 80            |
+| nodeport_port            | Port used for NodePort       | 30080            |
 
 ```yaml
 ---

--- a/README.md
+++ b/README.md
@@ -252,6 +252,21 @@ When setting up a Load Balancer for HTTPS you will be required to set the `loadb
 
 The HTTPS Load Balancer also uses SSL termination at the Load Balancer level and will offload traffic to AWX over HTTP.
 
+  * NodePort
+
+The following variables are customizable only when `service_type=NodePort`
+
+| Name                           | Description                              | Default       |
+| ------------------------------ | ---------------------------------------- | ------------- |
+| nodeport_port            | Port used for NodePort       | 80            |
+
+```yaml
+---
+spec:
+  ...
+  service_type: NodePort
+  nodeport_port: 30080
+```
 #### Ingress Type
 
 By default, the AWX operator is not opinionated and won't force a specific ingress type on you. So, when the `ingress_type` is not specified, it will default to `none` and nothing ingress-wise will be created.

--- a/ansible/templates/crd.yml.j2
+++ b/ansible/templates/crd.yml.j2
@@ -109,6 +109,10 @@ spec:
                   description: Port to use for the loadbalancer
                   type: integer
                   default: 80
+                nodeport_port:
+                  description: Port to use for the nodeport
+                  type: integer
+                  default: 30080
                 route_host:
                   description: The DNS to use to points to the instance
                   type: string

--- a/deploy/awx-operator.yaml
+++ b/deploy/awx-operator.yaml
@@ -126,6 +126,10 @@ spec:
                 route_tls_secret:
                   description: Secret where the TLS related credentials are stored
                   type: string
+                nodeport_port:
+                  description: Port to use for the nodeport
+                  type: integer
+                  default: 30080
                 node_selector:
                   description: nodeSelector for the pods
                   type: string

--- a/deploy/crds/awx_v1beta1_crd.yaml
+++ b/deploy/crds/awx_v1beta1_crd.yaml
@@ -124,6 +124,10 @@ spec:
                 route_tls_secret:
                   description: Secret where the TLS related credentials are stored
                   type: string
+                nodeport_port:
+                  description: Port to use for the nodeport
+                  type: integer
+                  default: 30080
                 node_selector:
                   description: nodeSelector for the pods
                   type: string

--- a/deploy/olm-catalog/awx-operator/manifests/awx-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/awx-operator/manifests/awx-operator.clusterserviceversion.yaml
@@ -248,6 +248,12 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:number
         - urn:alm:descriptor:com.tectonic.ui:fieldDependency:service_type:LoadBalancer
+      - displayName: Tower NodePort Port
+        path: nodeport_port
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:number
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:service_type:NodePort
       - displayName: Route DNS host
         path: route_host
         x-descriptors:

--- a/deploy/olm-catalog/awx-operator/manifests/awx.ansible.com_awxs_crd.yaml
+++ b/deploy/olm-catalog/awx-operator/manifests/awx.ansible.com_awxs_crd.yaml
@@ -189,6 +189,10 @@ spec:
                 - http
                 - https
                 type: string
+              nodeport_port:
+                default: 30080
+                description: Port to use for the nodeport
+                type: integer
               node_selector:
                 description: nodeSelector for the pods
                 type: string

--- a/roles/installer/defaults/main.yml
+++ b/roles/installer/defaults/main.yml
@@ -37,6 +37,7 @@ loadbalancer_protocol: 'http'
 loadbalancer_port: '80'
 loadbalancer_annotations: ''
 
+nodeport_port: '30080'
 # The TLS termination mechanism to use to access
 # the services. Supported mechanism are: edge, passthrough
 #

--- a/roles/installer/templates/service.yaml.j2
+++ b/roles/installer/templates/service.yaml.j2
@@ -39,6 +39,12 @@ spec:
       protocol: TCP
       targetPort: 8052
       name: http
+{% elif service_type | lower == "nodeport" %}
+    - port: {{ nodeport_port }}
+      protocol: TCP
+      targetPort: 8052
+      name: http
+  type: NodePort
 {% endif %}
   selector:
     app.kubernetes.io/name: '{{ meta.name }}'
@@ -46,8 +52,6 @@ spec:
     app.kubernetes.io/component: '{{ deployment_type }}'
 {% if service_type | lower == "loadbalancer" %}
   type: LoadBalancer
-{% elif service_type | lower == "nodeport" %}
-  type: NodePort
 {% else %}
   type: ClusterIP
 {% endif %}


### PR DESCRIPTION
This PR is in to help close issue #291 

The goal is to just allow the user to specify the nodeport port they're like to use instead of just auto-generating

```yaml
---
spec:
  ...
  service_type: NodePort
  nodeport_port: 30080
```