### PR TITLE
Add redis_resource_requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,6 +442,7 @@ The resource requirements for both, the task and the web containers are configur
 | web_resource_requirements        | Web container resource requirements              | requests: {cpu: 1000m, memory: 2Gi} |
 | task_resource_requirements       | Task container resource requirements             | requests: {cpu: 500m, memory: 1Gi}  |
 | ee_resource_requirements         | EE control plane container resource requirements | requests: {cpu: 500m, memory: 1Gi}  |
+| redis_resource_requirements      | Redis container resource requirements            | requests: {cpu: 200m, memory: 256Mi}|
 
 Example of customization could be:
 
@@ -470,6 +471,13 @@ spec:
     limits:
       cpu: 1000m
       memory: 2Gi
+  redis_resource_requirements:
+    requests:
+      cpu: 200m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 1Gi
 ```
 
 #### Assigning AWX pods to specific nodes

--- a/ansible/templates/crd.yml.j2
+++ b/ansible/templates/crd.yml.j2
@@ -213,6 +213,28 @@ spec:
                           type: string
                       type: object
                   type: object
+                redis_resource_requirements:
+                  description: Resource requirements for the redis container
+                  properties:
+                    requests:
+                      properties:
+                        cpu:
+                          type: string
+                        memory:
+                          type: string
+                        storage:
+                          type: string
+                      type: object
+                    limits:
+                      properties:
+                        cpu:
+                          type: string
+                        memory:
+                          type: string
+                        storage:
+                          type: string
+                      type: object
+                  type: object
                 ee_resource_requirements:
                   description: Resource requirements for the ee container
                   properties:

--- a/deploy/awx-operator.yaml
+++ b/deploy/awx-operator.yaml
@@ -215,6 +215,28 @@ spec:
                           type: string
                       type: object
                   type: object
+                redis_resource_requirements:
+                  description: Resource requirements for the redis container
+                  properties:
+                    requests:
+                      properties:
+                        cpu:
+                          type: string
+                        memory:
+                          type: string
+                        storage:
+                          type: string
+                      type: object
+                    limits:
+                      properties:
+                        cpu:
+                          type: string
+                        memory:
+                          type: string
+                        storage:
+                          type: string
+                      type: object
+                  type: object
                 ee_resource_requirements:
                   description: Resource requirements for the ee container
                   properties:

--- a/deploy/crds/awx_v1beta1_crd.yaml
+++ b/deploy/crds/awx_v1beta1_crd.yaml
@@ -213,6 +213,28 @@ spec:
                           type: string
                       type: object
                   type: object
+                redis_resource_requirements:
+                  description: Resource requirements for the redis container
+                  properties:
+                    requests:
+                      properties:
+                        cpu:
+                          type: string
+                        memory:
+                          type: string
+                        storage:
+                          type: string
+                      type: object
+                    limits:
+                      properties:
+                        cpu:
+                          type: string
+                        memory:
+                          type: string
+                        storage:
+                          type: string
+                      type: object
+                  type: object
                 ee_resource_requirements:
                   description: Resource requirements for the ee container
                   properties:

--- a/deploy/crds/awx_v1beta1_molecule.yaml
+++ b/deploy/crds/awx_v1beta1_molecule.yaml
@@ -21,3 +21,7 @@ spec:
     requests:
       cpu: 200m
       memory: 64M
+  redis_resource_requirements:
+    requests:
+      cpu: 100m
+      memory: 128M

--- a/deploy/olm-catalog/awx-operator/manifests/awx-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/awx-operator/manifests/awx-operator.clusterserviceversion.yaml
@@ -292,6 +292,11 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
+      - displayName: Redis container resource requirements
+        path: redis_resource_requirements
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
       - displayName: PostgreSQL container resource requirements (when using a managed
           instance)
         path: postgres_resource_requirements

--- a/deploy/olm-catalog/awx-operator/manifests/awx.ansible.com_awxs_crd.yaml
+++ b/deploy/olm-catalog/awx-operator/manifests/awx.ansible.com_awxs_crd.yaml
@@ -400,6 +400,28 @@ spec:
                         type: string
                     type: object
                 type: object
+              redis_resource_requirements:
+                description: Resource requirements for the redis container
+                properties:
+                  limits:
+                    properties:
+                      cpu:
+                        type: string
+                      memory:
+                        type: string
+                      storage:
+                        type: string
+                    type: object
+                  requests:
+                    properties:
+                      cpu:
+                        type: string
+                      memory:
+                        type: string
+                      storage:
+                        type: string
+                    type: object
+                type: object
             type: object
           status:
             properties:

--- a/roles/installer/defaults/main.yml
+++ b/roles/installer/defaults/main.yml
@@ -163,6 +163,11 @@ ee_resource_requirements:
     cpu: 500m
     memory: 1Gi
 
+redis_resource_requirements:
+  requests:
+    cpu: 200m
+    memory: 256Mi
+
 # Add extra environment variables to the AWX task/web containers. Specify as
 # literal block. E.g.:
 # task_extra_env: |

--- a/roles/installer/templates/deployment.yaml.j2
+++ b/roles/installer/templates/deployment.yaml.j2
@@ -84,6 +84,7 @@ spec:
               mountPath: "/var/run/redis"
             - name: "{{ meta.name }}-redis-data"
               mountPath: "/data"
+          resources: {{ redis_resource_requirements }}
         - image: '{{ image }}:{{ image_version }}'
           name: '{{ meta.name }}-web'
 {% if web_command %}


### PR DESCRIPTION
In our OKD cluster all containers must have quotas.

The Redis container currently doesn't have resources configured.
I added the `redis_resource_requirements` variable.