### PR TITLE
Use v1 extensions because v1beta1 is being removed

### DIFF
--- a/ansible/templates/role.yml.j2
+++ b/ansible/templates/role.yml.j2
@@ -31,7 +31,7 @@ rules:
       - '*'
   - apiGroups:
       - apps
-      - extensions
+      - networking.k8s.io
     resources:
       - deployments
       - daemonsets

--- a/deploy/awx-operator.yaml
+++ b/deploy/awx-operator.yaml
@@ -637,7 +637,7 @@ rules:
       - '*'
   - apiGroups:
       - apps
-      - extensions
+      - networking.k8s.io
     resources:
       - deployments
       - daemonsets

--- a/deploy/olm-catalog/awx-operator/manifests/awx-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/awx-operator/manifests/awx-operator.clusterserviceversion.yaml
@@ -644,7 +644,7 @@ spec:
           - '*'
         - apiGroups:
           - apps
-          - extensions
+          - networking.k8s.io
           resources:
           - deployments
           - daemonsets

--- a/roles/installer/templates/ingress.yaml.j2
+++ b/roles/installer/templates/ingress.yaml.j2
@@ -1,6 +1,6 @@
 {% if ingress_type|lower == "ingress" %}
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: '{{ meta.name }}-ingress'
@@ -21,9 +21,12 @@ spec:
       http:
         paths:
           - path: '{{ ingress_path }}'
+            pathType: Prefix
             backend:
-              serviceName: '{{ meta.name }}-service'
-              servicePort: 80
+              service:
+                name: '{{ meta.name }}-service'
+                port:
+                  number: 80
 {% if ingress_tls_secret %}
   tls:
     - hosts:

--- a/roles/installer/templates/service_account.yaml.j2
+++ b/roles/installer/templates/service_account.yaml.j2
@@ -36,7 +36,7 @@ rules:
 
 ---
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: '{{ meta.name }}'
   namespace: '{{ meta.namespace }}'

--- a/scripts/okd-console.yaml
+++ b/scripts/okd-console.yaml
@@ -32,7 +32,7 @@ metadata:
   name: okd-console
   namespace: okd-console
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: okd-console


### PR DESCRIPTION
To remain compatible with Kubernetes 1.22 and Openshift 4.9, we need to start using the `extensions/v1` API as the `extensions/v1beta1` is being removed.  


> All beta Ingress APIs (the extensions/v1beta1 and networking.k8s.io/v1beta1 API versions)

>The beta CustomResourceDefinition API (apiextensions.k8s.io/v1beta1)

Context: https://kubernetes.io/blog/2021/07/14/upcoming-changes-in-kubernetes-1-22/