### PR TITLE
Running as user nobody if task_privilage is false

### DIFF
--- a/roles/installer/templates/deployment.yaml.j2
+++ b/roles/installer/templates/deployment.yaml.j2
@@ -178,6 +178,9 @@ spec:
 {% if task_privileged == true %}
           securityContext:
             privileged: true
+{% else %}
+          securityContext:
+            runAsUser: 65534
 {% endif %}
 {% if task_command %}
           command: {{ task_command }}


### PR DESCRIPTION
If the `task_privileged` is `false`, then the container should not run as root, this will open security vulnerabilities in the Kubernetes cluster. If the user sets the value of `task_privileged` to `false`, then the container should run as user `nobody`. 

This will enhance the Kubernetes cluster security and the variable needs to set explicitly to `true`,  if the user wants to run awx as root.