### PR TITLE
Mount receptor config in awx-task container

### DIFF
--- a/roles/installer/templates/deployment.yaml.j2
+++ b/roles/installer/templates/deployment.yaml.j2
@@ -222,6 +222,10 @@ spec:
               mountPath: "/var/run/awx-rsyslog"
             - name: rsyslog-dir
               mountPath: "/var/lib/awx/rsyslog"
+            - name: "{{ meta.name }}-receptor-config"
+              mountPath: "/etc/receptor/receptor.conf"
+              subPath: receptor.conf
+              readOnly: true
             - name: receptor-socket
               mountPath: "/var/run/receptor"
             - name: "{{ meta.name }}-projects"


### PR DESCRIPTION
When deploying an AWX app image from awx/devel with the awx-operator, the containers deployed and run, but after migrations run I am see this in the awx-task logs:

```
FileNotFoundError: [Errno 2] No such file or directory: '/etc/receptor/receptor.conf'
```

This PR mounts the receptor.conf where the awx app expects it.  Now, when deploying a fresh image built from awx/devel with the awx-operator, I no longer see the errors in the task container and can log in and run jobs. 