### PR TITLE
Make receptor.conf path consistent between containers

### DIFF
--- a/roles/installer/templates/deployment.yaml.j2
+++ b/roles/installer/templates/deployment.yaml.j2
@@ -266,7 +266,7 @@ spec:
           name: '{{ meta.name }}-ee'
           imagePullPolicy: '{{ image_pull_policy }}'
           resources: {{ ee_resource_requirements }}
-          args: ['receptor', '--config', '/etc/receptor.conf']
+          args: ['receptor', '--config', '/etc/receptor/receptor.conf']
           volumeMounts:
 {% if bundle_ca_crt %}
             - name: "ca-trust-extracted"
@@ -277,7 +277,7 @@ spec:
               readOnly: true
 {% endif %}
             - name: "{{ meta.name }}-receptor-config"
-              mountPath: "/etc/receptor.conf"
+              mountPath: "/etc/receptor/receptor.conf"
               subPath: receptor.conf
               readOnly: true
             - name: receptor-socket


### PR DESCRIPTION
Follow-up PR for https://github.com/ansible/awx-operator/pull/529

@tchellomello pointed out that the receptor.conf paths are not consistent between the awx-task and the awx-ee containers.  This PR makes that the case.  

```
[chadams@chadams-work awx-operator]$ oc exec -it awx-56f7f6566d-jkmg5 -c awx-ee -- bash
bash-4.4$ stat /etc/receptor/receptor.conf 
  File: /etc/receptor/receptor.conf
  Size: 592       	Blocks: 8          IO Block: 4096   regular file
Device: 804h/2052d	Inode: 304578609   Links: 1
Access: (0644/-rw-r--r--)  Uid: (    0/    root)   Gid: (1000670000/ UNKNOWN)
Access: 2021-09-08 13:14:45.326561268 +0000
Modify: 2021-09-08 13:08:42.487926633 +0000
Change: 2021-09-08 13:14:45.326561268 +0000
 Birth: -
```

I deployed this with a fresh build of the awx/devel image and was able to run the demo JT successfully.  