### PR TITLE
nodePort paramater missing when using service_type: nodeport

### DIFF
--- a/roles/installer/templates/service.yaml.j2
+++ b/roles/installer/templates/service.yaml.j2
@@ -44,6 +44,7 @@ spec:
       protocol: TCP
       targetPort: 8052
       name: http
+      nodePort: {{ nodeport_port }}
   type: NodePort
 {% endif %}
   selector:

--- a/roles/installer/templates/service.yaml.j2
+++ b/roles/installer/templates/service.yaml.j2
@@ -40,7 +40,7 @@ spec:
       targetPort: 8052
       name: http
 {% elif service_type | lower == "nodeport" %}
-    - port: {{ nodeport_port }}
+    - port: 8052
       protocol: TCP
       targetPort: 8052
       name: http


### PR DESCRIPTION

It seems that the "nodeport_port" is not actually setting nodeport to the desired static value, instead a random port is assigned. 
As per https://kubernetes.io/docs/concepts/services-networking/service/, a "nodePort" parameter must be provided for static nodeport_port, otherwise k8s will pick up a random port.
Just setting "port" and "targetPort" is not enough.