### PR TITLE
LDAPSearch Module is missing

### DIFF
--- a/roles/installer/templates/config.yaml.j2
+++ b/roles/installer/templates/config.yaml.j2
@@ -18,6 +18,7 @@ data:
   settings: |
     import os
     import socket
+    from django_auth_ldap.config import LDAPSearch
     
     def get_secret():
         if os.path.exists("/etc/tower/SECRET_KEY"):


### PR DESCRIPTION
Since LDAPSearch Module is missing LDAP authentication is not working if you configure the LDAP configuration via extra_settings.