### PR TITLE
Move to namespace-scoped operator for better security & isolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This is a list of high-level changes for each release of `awx-operator`. A full list of commits can be found at `https://github.com/ansible/awx-operator/releases/tag/<version>`.
 
+# 0.14.0 (TBA)
+
+- Starting with awx-operator 0.14.0, AWX can only be deployed in the namespace that the operator exists in. See [upgrade docs](#upgrading) for necessary cleanup actions. (Christian Adams) - 58c3ebf (breaking change)
+
 # 0.10.0 (Jun 1, 2021)
 
 - Make tower_ingress_type to respect ClusterIP definition (Marcelo Moreira de Mello) - e37c091 (breaking_change)

--- a/README.md
+++ b/README.md
@@ -795,6 +795,11 @@ To upgrade AWX, it is recommended to upgrade the awx-operator to the version tha
 Apply the awx-operator.yml for that release to upgrade the operator, and in turn also upgrade your AWX deployment.
 
 
+**Cluster-scope to Namespace-scope considerations**
+
+Starting with awx-operator 0.14.0, AWX can only be deployed in the namespace that the operator exists in. This is called a namespace-scoped operator. If you are upgrading from an earlier version, you will want to 
+delete your existing `awx-operator` service account, role and role binding.
+
 ## Contributing
 
 Please visit [our contributing guidelines](https://github.com/ansible/awx-operator/blob/devel/CONTRIBUTING.md).

--- a/ansible/deploy-operator.yml
+++ b/ansible/deploy-operator.yml
@@ -5,7 +5,7 @@
 - name: Deploy Operator
   hosts: localhost
   vars:
-    k8s_namespace: "default"
+    k8s_namespace: "{{ namespace | default('default') }}"
     obliterate: no
 
   collections:

--- a/ansible/templates/operator.yml.j2
+++ b/ansible/templates/operator.yml.j2
@@ -22,9 +22,11 @@ spec:
             - mountPath: /tmp/ansible-operator/runner
               name: runner
           env:
-            # Watch all namespaces (cluster-scoped).
+            # Watch one namespace (namespace-scoped).
             - name: WATCH_NAMESPACE
-              value: ""
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: POD_NAME
               valueFrom:
                 fieldRef:

--- a/ansible/templates/role.yml.j2
+++ b/ansible/templates/role.yml.j2
@@ -11,7 +11,13 @@ rules:
       - routes
       - routes/custom-host
     verbs:
-      - '*'
+      - get
+      - list
+      - create
+      - delete
+      - patch
+      - update
+      - watch
   - apiGroups:
       - ""
       - "rbac.authorization.k8s.io"
@@ -28,7 +34,13 @@ rules:
       - roles
       - rolebindings
     verbs:
-      - '*'
+      - get
+      - list
+      - create
+      - delete
+      - patch
+      - update
+      - watch
   - apiGroups:
       - apps
       - networking.k8s.io
@@ -39,7 +51,13 @@ rules:
       - statefulsets
       - ingresses
     verbs:
-      - '*'
+      - get
+      - list
+      - create
+      - delete
+      - patch
+      - update
+      - watch
   - apiGroups:
       - monitoring.coreos.com
     resources:
@@ -66,6 +84,8 @@ rules:
       - ""
     resources:
       - pods/exec
+      - pods/attach
+      - pods/log  # log & attach rules needed to be able to grant them to AWX service account
     verbs:
       - create
       - get
@@ -75,6 +95,8 @@ rules:
       - replicasets
     verbs:
       - get
+    verbs:
+      - create
   - apiGroups:
       - awx.ansible.com
     resources:

--- a/ansible/templates/role.yml.j2
+++ b/ansible/templates/role.yml.j2
@@ -1,6 +1,6 @@
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: Role
 metadata:
   creationTimestamp: null
   name: awx-operator
@@ -95,7 +95,6 @@ rules:
       - replicasets
     verbs:
       - get
-    verbs:
       - create
   - apiGroups:
       - awx.ansible.com

--- a/ansible/templates/role_binding.yml.j2
+++ b/ansible/templates/role_binding.yml.j2
@@ -1,13 +1,12 @@
 ---
-kind: ClusterRoleBinding
+kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: awx-operator
 subjects:
   - kind: ServiceAccount
     name: awx-operator
-    namespace: default
 roleRef:
-  kind: ClusterRole
+  kind: Role
   name: awx-operator
   apiGroup: rbac.authorization.k8s.io

--- a/ansible/templates/service_account.yml.j2
+++ b/ansible/templates/service_account.yml.j2
@@ -3,4 +3,3 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: awx-operator
-  namespace: default

--- a/deploy/awx-operator.yaml
+++ b/deploy/awx-operator.yaml
@@ -621,7 +621,13 @@ rules:
       - routes
       - routes/custom-host
     verbs:
-      - '*'
+      - get
+      - list
+      - create
+      - delete
+      - patch
+      - update
+      - watch
   - apiGroups:
       - ""
       - "rbac.authorization.k8s.io"
@@ -638,7 +644,13 @@ rules:
       - roles
       - rolebindings
     verbs:
-      - '*'
+      - get
+      - list
+      - create
+      - delete
+      - patch
+      - update
+      - watch
   - apiGroups:
       - apps
       - networking.k8s.io
@@ -649,7 +661,13 @@ rules:
       - statefulsets
       - ingresses
     verbs:
-      - '*'
+      - get
+      - list
+      - create
+      - delete
+      - patch
+      - update
+      - watch
   - apiGroups:
       - monitoring.coreos.com
     resources:
@@ -676,6 +694,8 @@ rules:
       - ""
     resources:
       - pods/exec
+      - pods/attach
+      - pods/log  # log & attach rules needed to be able to grant them to AWX service account
     verbs:
       - create
       - get
@@ -685,6 +705,8 @@ rules:
       - replicasets
     verbs:
       - get
+    verbs:
+      - create
   - apiGroups:
       - awx.ansible.com
     resources:

--- a/deploy/awx-operator.yaml
+++ b/deploy/awx-operator.yaml
@@ -610,7 +610,7 @@ spec:
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: Role
 metadata:
   creationTimestamp: null
   name: awx-operator
@@ -705,7 +705,6 @@ rules:
       - replicasets
     verbs:
       - get
-    verbs:
       - create
   - apiGroups:
       - awx.ansible.com
@@ -717,16 +716,15 @@ rules:
       - '*'
 
 ---
-kind: ClusterRoleBinding
+kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: awx-operator
 subjects:
   - kind: ServiceAccount
     name: awx-operator
-    namespace: default
 roleRef:
-  kind: ClusterRole
+  kind: Role
   name: awx-operator
   apiGroup: rbac.authorization.k8s.io
 
@@ -735,7 +733,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: awx-operator
-  namespace: default
 
 ---
 apiVersion: apps/v1
@@ -761,9 +758,11 @@ spec:
             - mountPath: /tmp/ansible-operator/runner
               name: runner
           env:
-            # Watch all namespaces (cluster-scoped).
+            # Watch one namespace (namespace-scoped).
             - name: WATCH_NAMESPACE
-              value: ""
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: POD_NAME
               valueFrom:
                 fieldRef:

--- a/deploy/olm-catalog/awx-operator/manifests/awx-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/awx-operator/manifests/awx-operator.clusterserviceversion.yaml
@@ -755,11 +755,11 @@ spec:
   installModes:
   - supported: true
     type: OwnNamespace
-  - supported: true
+  - supported: false
     type: SingleNamespace
   - supported: false
     type: MultiNamespace
-  - supported: true
+  - supported: false
     type: AllNamespaces
   keywords:
   - awx

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -26,4 +26,4 @@ provisioner:
   inventory:
     group_vars:
       all:
-        operator_namespace: ${TEST_NAMESPACE:-default}
+        operator_namespace: ${TEST_NAMESPACE:-example-awx}

--- a/molecule/test-minikube/molecule.yml
+++ b/molecule/test-minikube/molecule.yml
@@ -19,7 +19,7 @@ provisioner:
   inventory:
     group_vars:
       all:
-        operator_namespace: ${TEST_NAMESPACE:-default}
+        operator_namespace: ${TEST_NAMESPACE:-example-awx}
   env:
     ANSIBLE_ROLES_PATH: ${MOLECULE_PROJECT_DIRECTORY}/roles
 scenario:

--- a/scripts/okd-console.yaml
+++ b/scripts/okd-console.yaml
@@ -1,6 +1,6 @@
 ### Don't run this deployment in production
 ### The current configuration will run the
-### OKD console without any autentication!!!!
+### OKD console without any authentication!!!!
 ###
 ### A prerequisite is to install the OLM
 ### as instructed at https://olm.operatorframework.io/docs/getting-started/#install-released-olm


### PR DESCRIPTION
Be more intentional about what permissions the awx-operator service account has.  Restrict access where possible.  