### PR TITLE
Add an option to specify container capabilities for the redis container

### DIFF
--- a/README.md
+++ b/README.md
@@ -458,6 +458,20 @@ spec:
 
 **Note**: The `image` and `image_version` are intended for local mirroring scenarios. Please note that using a version of AWX other than the one bundled with the `awx-operator` is **not** supported. For the default values, check the [main.yml](https://github.com/ansible/awx-operator/blob/devel/roles/installer/defaults/main.yml) file.
 
+#### Redis container capabilities
+
+Depending on your kubernetes cluster and settings you might need to grant some capabilities to the redis container so it can start. Set the `redis_capabilities` option so the capabilities are added in the deployment.
+
+```yaml
+---
+spec:
+  ...
+  redis_capabilities:
+    - CHOWN
+    - SETUID
+    - SETGID
+```
+
 #### Privileged Tasks
 
 Depending on the type of tasks that you'll be running, you may find that you need the task pod to run as `privileged`. This can open yourself up to a variety of security concerns, so you should be aware (and verify that you have the privileges) to do this if necessary. In order to toggle this feature, you can add the following to your custom resource:

--- a/config/crd/bases/awx.ansible.com_awxs.yaml
+++ b/config/crd/bases/awx.ansible.com_awxs.yaml
@@ -292,6 +292,11 @@ spec:
                 redis_image_version:
                   description: Redis container image version to use
                   type: string
+                redis_capabilities:
+                  description: Redis container capabilities
+                  type: array
+                  items:
+                    type: string
                 init_container_image:
                   description: Registry path to the init container to use
                   type: string

--- a/roles/installer/templates/deployment.yaml.j2
+++ b/roles/installer/templates/deployment.yaml.j2
@@ -74,6 +74,11 @@ spec:
         - image: '{{ redis_image }}:{{ redis_image_version }}'
           imagePullPolicy: '{{ image_pull_policy }}'
           name: redis
+{% if redis_capabilities is defined and redis_capabilities %}
+          securityContext:
+            capabilities:
+              add: {{ redis_capabilities }}
+{% endif %}
           args: ["redis-server", "/etc/redis.conf"]
           volumeMounts:
             - name: {{ ansible_operator_meta.name }}-redis-config


### PR DESCRIPTION
With some kubernetes cluster and settings, you might need to specify some capabilities so the container can start.
For example, the CHOWN, SETUID and SETGID capabilties.
Setting the redis_capabilities option will add the capabilities in the deployment.