### PR TITLE
Note for wrapping pg password in quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,6 +378,8 @@ stringData:
 type: Opaque
 ```
 
+> Please ensure that the value for the variable "password" is wrapped in quotes if the password contains any special characters.
+
 > It is possible to set a specific username, password, port, or database, but still have the database managed by the operator. In this case, when creating the postgres-configuration secret, the `type: managed` field should be added.
 
 **Note**: The variable `sslmode` is valid for `external` databases only. The allowed values are: `prefer`, `disable`, `allow`, `require`, `verify-ca`, `verify-full`.


### PR DESCRIPTION
- Add a note suggesting the password for postgres stringData be wrapped in quotes especially for passwords with special characters.
- Filed based on feedback from #565 