### PR TITLE
Add Ingress path type option

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,7 @@ The following variables are customizable when `ingress_type=ingress`. The `ingre
 | ingress_tls_secret         | Secret that contains the TLS information | Empty string                 |
 | hostname                   | Define the FQDN                          | {{ meta.name }}.example.com  |
 | ingress_path               | Define the ingress path to the service   | /                            |
+| ingress_path_type          | Define the type of the path (for LBs)    | Prefix                       |
 
 ```yaml
 ---

--- a/config/crd/bases/awx.ansible.com_awxs.yaml
+++ b/config/crd/bases/awx.ansible.com_awxs.yaml
@@ -89,6 +89,9 @@ spec:
                 ingress_path:
                   description: The ingress path used to reach the deployed service
                   type: string
+                ingress_path_type:
+                  description: The ingress path type for the deployed service
+                  type: string
                 ingress_annotations:
                   description: Annotations to add to the Ingress Controller
                   type: string

--- a/roles/installer/defaults/main.yml
+++ b/roles/installer/defaults/main.yml
@@ -10,6 +10,7 @@ task_privileged: false
 service_type: ClusterIP
 ingress_type: none
 ingress_path: '/'
+ingress_path_type: 'Prefix'
 # Add annotations to the service account. Specify as literal block. E.g.:
 # service_account_annotations: |
 #   eks.amazonaws.com/role-arn: arn:aws:iam::<ACCOUNT_ID>:role/<IAM_ROLE_NAME>

--- a/roles/installer/templates/ingress.yaml.j2
+++ b/roles/installer/templates/ingress.yaml.j2
@@ -20,7 +20,7 @@ spec:
     - http:
         paths:
           - path: '{{ ingress_path }}'
-            pathType: Prefix
+            pathType: '{{ ingress_path_type }}'
             backend:
               service:
                 name: '{{ ansible_operator_meta.name }}-service'


### PR DESCRIPTION
This change makes `ingress_path_type` an option (defaulting to `Prefix`). This is necessary behind HTTP load balancers in GKE, which require the `ImplementationSpecific` `pathType`.

Edit: This solves https://github.com/ansible/awx-operator/issues/580