### PR TITLE
The OPERATOR_VERSION env var got lost in the sdk upgrade, adding it back

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -34,6 +34,8 @@ spec:
           env:
             - name: ANSIBLE_GATHERING
               value: explicit
+            - name: OPERATOR_VERSION
+              value: "0.13.0"
             - name: WATCH_NAMESPACE
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
This env var is used in labels for many resources created by the operator and is also expected downstream.  Thus, adding it back.  