### PR TITLE
Rename operator image name to make it unique from resource & pulp

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -21,7 +21,7 @@ spec:
             - containerPort: 8443
               protocol: TCP
               name: https
-        - name: manager
+        - name: awx-manager
           args:
             - "--health-probe-bind-address=:6789"
             - "--metrics-bind-address=127.0.0.1:8080"

--- a/config/default/manager_config_patch.yaml
+++ b/config/default/manager_config_patch.yaml
@@ -8,14 +8,14 @@ spec:
   template:
     spec:
       containers:
-        - name: manager
+        - name: awx-manager
           args:
             - "--config=controller_manager_config.yaml"
           volumeMounts:
-            - name: manager-config
+            - name: awx-manager-config
               mountPath: /controller_manager_config.yaml
               subPath: controller_manager_config.yaml
       volumes:
-        - name: manager-config
+        - name: awx-manager-config
           configMap:
-            name: manager-config
+            name: awx-manager-config

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,7 +5,7 @@ generatorOptions:
 configMapGenerator:
 - files:
   - controller_manager_config.yaml
-  name: manager-config
+  name: awx-manager-config
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -30,7 +30,7 @@ spec:
             - --leader-elect
             - --leader-election-id=awx-operator
           image: controller:latest
-          name: manager
+          name: awx-manager
           env:
             - name: ANSIBLE_GATHERING
               value: explicit

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   creationTimestamp: null
-  name: manager-role
+  name: awx-manager-role
 rules:
   - apiGroups:
       - route.openshift.io

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -2,11 +2,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: manager-rolebinding
+  name: awx-manager-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: manager-role
+  name: awx-manager-role
 subjects:
   - kind: ServiceAccount
     name: controller-manager

--- a/config/testing/debug_logs_patch.yaml
+++ b/config/testing/debug_logs_patch.yaml
@@ -8,7 +8,7 @@ spec:
   template:
     spec:
       containers:
-        - name: manager
+        - name: awx-manager
           env:
             - name: ANSIBLE_DEBUG_LOGS
               value: "TRUE"

--- a/config/testing/manager_image.yaml
+++ b/config/testing/manager_image.yaml
@@ -8,5 +8,5 @@ spec:
   template:
     spec:
       containers:
-        - name: manager
+        - name: awx-manager
           image: testing

--- a/config/testing/pull_policy/Always.yaml
+++ b/config/testing/pull_policy/Always.yaml
@@ -8,5 +8,5 @@ spec:
   template:
     spec:
       containers:
-        - name: manager
+        - name: awx-manager
           imagePullPolicy: Always

--- a/config/testing/pull_policy/IfNotPresent.yaml
+++ b/config/testing/pull_policy/IfNotPresent.yaml
@@ -8,5 +8,5 @@ spec:
   template:
     spec:
       containers:
-        - name: manager
+        - name: awx-manager
           imagePullPolicy: IfNotPresent

--- a/config/testing/pull_policy/Never.yaml
+++ b/config/testing/pull_policy/Never.yaml
@@ -8,5 +8,5 @@ spec:
   template:
     spec:
       containers:
-        - name: manager
+        - name: awx-manager
           imagePullPolicy: Never


### PR DESCRIPTION
When building these operators together in a bundle, the operator image names need to be unique.  

I updated the other manager references for consistency, but the only required changes are related to the image name.  