### PR TITLE
Set default images, but use them as a last resort

### DIFF
--- a/roles/backup/tasks/init.yml
+++ b/roles/backup/tasks/init.yml
@@ -63,6 +63,10 @@
   when:
     - backup_pvc == '' or backup_pvc is not defined
 
+- name: Set default postgres image
+  set_fact:
+    _default_postgres_image: "{{ _postgres_image }}:{{_postgres_image_version }}"
+
 - name: Set user provided postgres image
   set_fact:
     _custom_postgres_image: "{{ postgres_image }}:{{ postgres_image_version }}"
@@ -72,7 +76,7 @@
 
 - name: Set Postgres image URL
   set_fact:
-    _postgres_image: "{{ _custom_postgres_image | default(lookup('env', 'RELATED_IMAGE_AWX_POSTGRES')) }}"
+    _postgres_image: "{{ _custom_postgres_image | default(lookup('env', 'RELATED_IMAGE_AWX_POSTGRES')) | default(_default_postgres_image) }}"
 
 - name: Create management pod from templated deployment config
   k8s:

--- a/roles/backup/vars/main.yml
+++ b/roles/backup/vars/main.yml
@@ -1,6 +1,6 @@
 ---
 deployment_type: "awx"
-postgres_image: postgres
-postgres_image_version: 12
+_postgres_image: postgres
+_postgres_image_version: 12
 backup_complete: false
 database_type: "unmanaged"

--- a/roles/installer/defaults/main.yml
+++ b/roles/installer/defaults/main.yml
@@ -107,14 +107,14 @@ extra_volumes: ''
 
 # Use these image versions for Ansible AWX.
 
-image: quay.io/ansible/awx
-image_version: "{{ lookup('env', 'DEFAULT_AWX_VERSION') or 'latest' }}"
-redis_image: docker.io/redis
-redis_image_version: latest
-postgres_image: postgres
-postgres_image_version: 12
-init_container_image: quay.io/centos/centos
-init_container_image_version: 8
+_image: quay.io/ansible/awx
+_image_version: "{{ lookup('env', 'DEFAULT_AWX_VERSION') or 'latest' }}"
+_redis_image: docker.io/redis
+_redis_image_version: latest
+_postgres_image: postgres
+_postgres_image_version: 12
+_init_container_image: quay.io/centos/centos
+_init_container_image_version: 8
 image_pull_policy: IfNotPresent
 image_pull_secret: ''
 

--- a/roles/installer/tasks/database_configuration.yml
+++ b/roles/installer/tasks/database_configuration.yml
@@ -47,6 +47,10 @@
     - old_pg_config['resources'] | length
   no_log: true
 
+- name: Set default postgres image
+  set_fact:
+    _default_postgres_image: "{{ _postgres_image }}:{{_postgres_image_version }}"
+
 - name: Set PostgreSQL configuration
   set_fact:
     _pg_config: '{{ _custom_pg_config_resources["resources"] | default([]) | length | ternary(_custom_pg_config_resources, _default_pg_config_resources) }}'
@@ -61,7 +65,7 @@
 
 - name: Set Postgres image URL
   set_fact:
-    _postgres_image: "{{ _custom_postgres_image | default(lookup('env', 'RELATED_IMAGE_AWX_POSTGRES')) }}"
+    _postgres_image: "{{ _custom_postgres_image | default(lookup('env', 'RELATED_IMAGE_AWX_POSTGRES')) | default(_default_postgres_image) }}"
 
 - block:
     - name: Create Database configuration

--- a/roles/installer/tasks/resources_configuration.yml
+++ b/roles/installer/tasks/resources_configuration.yml
@@ -32,6 +32,10 @@
     - 'ingress'
   no_log: true
 
+- name: Set default awx app image
+  set_fact:
+    _default_image: "{{ _image }}:{{ _image_version }}"
+
 - name: Set user provided awx app image
   set_fact:
     _custom_image: "{{ image }}:{{ image_version }}"
@@ -39,11 +43,15 @@
     - image | default([]) | length
     - image_version is defined or image_version != ''
 
-- name: Set AWX App image URL
+- name: Set AWX app image URL
   set_fact:
-    _image: "{{ _custom_image | default(lookup('env', 'RELATED_IMAGE_AWX')) }}"
+    _image: "{{ _custom_image | default(lookup('env', 'RELATED_IMAGE_AWX')) | default(_default_image) }}"
 
-- name: Set user provided controller init image
+- name: Set default awx init container image
+  set_fact:
+    _default_init_container_image: "{{ _init_container_image }}:{{ _init_container_image_version }}"
+
+- name: Set user provided awx init image
   set_fact:
     _custom_init_container_image: "{{ init_container_image }}:{{ init_container_image_version }}"
   when:
@@ -52,7 +60,11 @@
 
 - name: Set Init image URL
   set_fact:
-    _init_container_image: "{{ _custom_init_container_image | default(lookup('env', 'RELATED_IMAGE_AWX_INIT_CONTAINER')) }}"
+    _init_container_image: "{{ _custom_init_container_image | default(lookup('env', 'RELATED_IMAGE_AWX_INIT_CONTAINER')) | default(_default_init_container_image) }}"
+
+- name: Set default redis image
+  set_fact:
+    _default_redis_image: "{{ _redis_image }}:{{ _redis_image_version }}"
 
 - name: Set user provided redis image
   set_fact:
@@ -63,17 +75,17 @@
 
 - name: Set Redis image URL
   set_fact:
-    _redis_image: "{{ _custom_redis_image | default(lookup('env', 'RELATED_IMAGE_AWX_REDIS')) }}"
+    _redis_image: "{{ _custom_redis_image | default(lookup('env', 'RELATED_IMAGE_AWX_REDIS')) | default(_default_redis_image) }}"
 
 - name: Set user provided control plane ee image
   set_fact:
-    _custom_control_plane_ee_image: "{{ control_plane_ee_image}}"
+    _custom_control_plane_ee_image: "{{ control_plane_ee_image }}"
   when:
     - control_plane_ee_image | default([]) | length
 
 - name: Set Control Plane EE image URL
   set_fact:
-    _control_plane_ee_image: "{{ _custom_control_plane_ee_image | default(lookup('env', 'RELATED_IMAGE_CONTROL_PLANE_EE')) }}"
+    _control_plane_ee_image: "{{ _custom_control_plane_ee_image | default(lookup('env', 'RELATED_IMAGE_CONTROL_PLANE_EE')) | default(_control_plane_ee_image) }}"
 
 - name: Apply deployment resources
   k8s:

--- a/roles/installer/templates/deployment.yaml.j2
+++ b/roles/installer/templates/deployment.yaml.j2
@@ -7,7 +7,7 @@ metadata:
   namespace: '{{ ansible_operator_meta.namespace }}'
   labels:
     app.kubernetes.io/name: '{{ ansible_operator_meta.name }}'
-    app.kubernetes.io/version: '{{ image_version }}'
+    app.kubernetes.io/version: '{{ _image_version }}'
     app.kubernetes.io/part-of: '{{ ansible_operator_meta.name }}'
     app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
     app.kubernetes.io/component: '{{ deployment_type }}'
@@ -23,7 +23,7 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: '{{ ansible_operator_meta.name }}'
-        app.kubernetes.io/version: '{{ image_version }}'
+        app.kubernetes.io/version: '{{ _image_version }}'
         app.kubernetes.io/part-of: '{{ ansible_operator_meta.name }}'
         app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
         app.kubernetes.io/component: '{{ deployment_type }}'

--- a/roles/restore/tasks/init.yml
+++ b/roles/restore/tasks/init.yml
@@ -71,6 +71,10 @@
     force: true
     wait: true
 
+- name: Set default postgres image
+  set_fact:
+    _default_postgres_image: "{{ _postgres_image }}:{{_postgres_image_version }}"
+
 - name: Set user provided postgres image
   set_fact:
     _custom_postgres_image: "{{ postgres_image }}:{{ postgres_image_version }}"
@@ -80,7 +84,7 @@
 
 - name: Set Postgres image URL
   set_fact:
-    _postgres_image: "{{ _custom_postgres_image | default(lookup('env', 'RELATED_IMAGE_AWX_POSTGRES')) }}"
+    _postgres_image: "{{ _custom_postgres_image | default(lookup('env', 'RELATED_IMAGE_AWX_POSTGRES'))  | default(_default_postgres_image) }}"
 
 - name: Create management pod from templated deployment config
   k8s:

--- a/roles/restore/vars/main.yml
+++ b/roles/restore/vars/main.yml
@@ -1,8 +1,8 @@
 ---
 
 deployment_type: "awx"
-postgres_image: postgres
-postgres_image_version: 12
+_postgres_image: postgres
+_postgres_image_version: 12
 
 backup_api_version: '{{ deployment_type }}.ansible.com/v1beta1'
 backup_kind: 'AWXBackup'


### PR DESCRIPTION
  * Only use them if user did not set an image, or RELATED_IMAGES_ var
    is not set

Signed-off-by: Christian M. Adams <chadams@redhat.com>

Part of the rationale for adding this in instead of just removing the defaults is that it it prevents someone from accidentally breaking disconnected deployment support by adding in default image values later on.  