### PR TITLE
Allow pass the security contexts to the Redis container

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,6 +460,19 @@ spec:
 
 **Note**: The `image` and `image_version` are intended for local mirroring scenarios. Please note that using a version of AWX other than the one bundled with the `awx-operator` is **not** supported. For the default values, check the [main.yml](https://github.com/ansible/awx-operator/blob/devel/roles/installer/defaults/main.yml) file.
 
+#### Redis container security contexts
+
+Depending on your kubernetes cluster and settings you might need to set the security contexts to the redis container so it can start. Set the `redis_security_contexts` option so the security contexts are added in the deployment.
+
+```yaml
+---
+spec:
+  ...
+  redis_security_contexts:
+    runAsUser: 999
+    runAsGroup: 999
+```
+
 #### Redis container capabilities
 
 Depending on your kubernetes cluster and settings you might need to grant some capabilities to the redis container so it can start. Set the `redis_capabilities` option so the capabilities are added in the deployment.

--- a/config/crd/bases/awx.ansible.com_awxs.yaml
+++ b/config/crd/bases/awx.ansible.com_awxs.yaml
@@ -298,6 +298,10 @@ spec:
                 redis_image_version:
                   description: Redis container image version to use
                   type: string
+                redis_security_contexts:
+                  description: Key/values that will be set under the Redis container security contexts
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
                 redis_capabilities:
                   description: Redis container capabilities
                   type: array

--- a/roles/installer/templates/deployment.yaml.j2
+++ b/roles/installer/templates/deployment.yaml.j2
@@ -90,10 +90,15 @@ spec:
         - image: '{{ _redis_image }}'
           imagePullPolicy: '{{ image_pull_policy }}'
           name: redis
-{% if redis_capabilities is defined and redis_capabilities %}
+{% if redis_capabilities is defined or redis_security_contexts is defined %}
           securityContext:
+{% if redis_security_contexts|length %}
+            {{ redis_security_contexts | to_nice_yaml | indent(12) }}
+{% endif %}
+{% if redis_capabilities is defined %}
             capabilities:
               add: {{ redis_capabilities }}
+{% endif %}
 {% endif %}
           args: ["redis-server", "/etc/redis.conf"]
           volumeMounts:


### PR DESCRIPTION
Manage the security contexts by AWX Operator. Unlike open PR ([https://github.com/ansible/awx-operator/pull/348](https://github.com/ansible/awx-operator/pull/348)), these changes allow to control the uid and the gid with which to execute the container.