### PR TITLE
Add support for arbitrary pod-level securityContext settings

### DIFF
--- a/config/crd/bases/awx.ansible.com_awxs.yaml
+++ b/config/crd/bases/awx.ansible.com_awxs.yaml
@@ -408,6 +408,10 @@ spec:
                         x-kubernetes-preserve-unknown-fields: true
                     type: object
                   type: array
+                security_context_settings:
+                  description: Key/values that will be set under the pod-level securityContext field
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
               type: object
             status:
               properties:

--- a/roles/installer/defaults/main.yml
+++ b/roles/installer/defaults/main.yml
@@ -235,3 +235,5 @@ bundle_cacert_secret: ''
 garbage_collect_secrets: false
 
 development_mode: false
+
+security_context_settings: {}

--- a/roles/installer/templates/deployment.yaml.j2
+++ b/roles/installer/templates/deployment.yaml.j2
@@ -310,9 +310,14 @@ spec:
       tolerations:
         {{ tolerations | indent(width=8) }}
 {% endif %}
-{% if projects_persistence|bool %}
+{% if projects_persistence|bool or (security_context_settings|length) %}
       securityContext:
+{% if projects_persistence|bool %}
         fsGroup: 1000
+{% endif %}
+{% if security_context_settings|length %}
+        {{ security_context_settings | to_nice_yaml | indent(8) }}
+{% endif %}
 {% endif %}
       volumes:
 {% if bundle_ca_crt %}

--- a/watches.yaml
+++ b/watches.yaml
@@ -4,14 +4,17 @@
   group: awx.ansible.com
   kind: AWX
   role: installer
+  snakeCaseParameters: False
 
 - version: v1beta1
   group: awx.ansible.com
   kind: AWXBackup
   role: backup
+  snakeCaseParameters: False
 
 - version: v1beta1
   group: awx.ansible.com
   kind: AWXRestore
   role: restore
+  snakeCaseParameters: False
 # +kubebuilder:scaffold:watch


### PR DESCRIPTION
This allows for doing stuff like this on the custom resource:

```
security_context_settings:
  runAsUser: 1000
  runAsGroup: 0
```

I added `snakeCaseParameters: False` because without it, variables like `runAsUser` become `run_as_user`... and that doesnt work.