### PR TITLE
Support running AWX at non-root path

### DIFF
--- a/roles/installer/templates/config.yaml.j2
+++ b/roles/installer/templates/config.yaml.j2
@@ -25,6 +25,7 @@ data:
     
     ADMINS = ()
     STATIC_ROOT = '/var/lib/awx/public/static'
+    STATIC_URL = '{{ (ingress_path + '/static/').replace('//', '/') }}'
     PROJECTS_ROOT = '/var/lib/awx/projects'
     JOBOUTPUT_ROOT = '/var/lib/awx/job_status'
 
@@ -172,15 +173,15 @@ data:
                 deny all;
             }
     
-            location /static/ {
+            location {{ (ingress_path + '/static').replace('//', '/') }} {
                 alias /var/lib/awx/public/static/;
             }
     
-            location /favicon.ico {
+            location {{ (ingress_path + '/favicon.ico').replace('//', '/') }} {
                 alias /var/lib/awx/public/static/media/favicon.ico;
             }
     
-            location /websocket {
+            location {{ (ingress_path + '/websocket').replace('//', '/') }} {
                 # Pass request to the upstream alias
                 proxy_pass http://daphne;
                 # Require http version 1.1 to allow for upgrade requests
@@ -202,7 +203,7 @@ data:
                 proxy_set_header Connection $connection_upgrade;
             }
     
-            location / {
+            location {{ ingress_path }} {
                 # Add trailing / if missing
                 rewrite ^(.*)$http_host(.*[^/])$ $1$http_host$2/ permanent;
                 uwsgi_read_timeout 120s;

--- a/roles/installer/templates/deployment.yaml.j2
+++ b/roles/installer/templates/deployment.yaml.j2
@@ -169,6 +169,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: UWSGI_MOUNT_PATH
+              value: "{{ ingress_path }}"
 {% if development_mode | bool %}
             - name: AWX_KUBE_DEVEL
               value: "1"


### PR DESCRIPTION
This PR uses the existing `ingress_path` variable and passes it through so the application is aware of where it is running.

The other half of this is at https://github.com/ansible/awx/pull/11342

---

#### Testing

If you would like to test this and don't have your own workflow, you can try this (it reuses tooling from our tests).

```
$ make kustomize
$ KUSTOMIZE_PATH=$(readlink -f bin/kustomize) molecule test -s kind --destroy=never
```

To watch the progress of the deployment:

```
$ export KUBECONFIG=$HOME/.cache/molecule/awx-operator/kind/kubeconfig
$ kubectl config set-context --current --namespace=osdk-test
$ kubectl logs -f deployment/osdk-controller-manager -c awx-manager
```

Once the deployment is complete verify AWX is up on port 80:

```
$ curl localhost/api/
{"description":"AWX REST API","current_version":"/api/v2/","available_versions":{"v2":"/api/v2/"},"oauth2":"/api/o/","custom_logo":"","custom_login_info":"","login_redirect_override":""}
```

Now patch the deployment to test this feature. Running this command should pop open your `$EDITOR`:

```
$ kubectl edit awx example-awx
```

Add these values to the custom resource:

```yaml
image: quay.io/shanemcd/awx # or build your own
image_version: latest
ingress_path: /myprefix
```

Wait a couple minutes for the operator to reconcile and then verify you can reach AWX at the prefixed path:

```
$ curl localhost/myprefix/api/
{"description":"AWX REST API","current_version":"/myprefix/api/v2/","available_versions":{"v2":"/myprefix/api/v2/"},"oauth2":"/myprefix/api/o/","custom_logo":"","custom_login_info":"","login_redirect_override":""}
```

Note how the URLs in the API response are properly prefixed. Yay!