### PR TITLE
Update README.md - fix status command

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ awx.awx.ansible.com/awx-demo created
 After a few minutes, the new AWX instance will be deployed. You can look at the operator pod logs in order to know where the installation process is at:
 
 ```
-$ kubectl logs -f deployments/awx-operator-controller-manager -c awx-manager
+$ kubectl logs -f deployments/awx-operator-controller-manager -c manager
 ```
 
 After a few seconds, you should see the operator begin to create new resources:


### PR DESCRIPTION
one command is mentioned wrong in the readme and results this:
```
root@awx:~# kubectl logs -f deployments/awx-operator-controller-manager -c awx-manager
error: container awx-manager is not valid for pod awx-operator-controller-manager-68d787cfbd-lgrm8
```
proper container name is `manager`  (not `awx-manager`)