### PR TITLE
Add in ansible debug logs env var

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -34,6 +34,8 @@ spec:
           env:
             - name: ANSIBLE_GATHERING
               value: explicit
+            - name: ANSIBLE_DEBUG_LOGS
+              value: 'false'
             - name: WATCH_NAMESPACE
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
Another small detail lost when we did the operator-sdk upgrade

  * This will be added to the CSV automatically when make bundle is run

Signed-off-by: Christian M. Adams <chadams@redhat.com>