### PR TITLE
Add pod_labels for custom pod labels

### DIFF
--- a/config/crd/bases/awx.ansible.com_awxs.yaml
+++ b/config/crd/bases/awx.ansible.com_awxs.yaml
@@ -134,6 +134,9 @@ spec:
                 node_selector:
                   description: nodeSelector for the pods
                   type: string
+                pod_labels:
+                  description: Additional labels to apply to the pod
+                  type: string
                 service_labels:
                   description: Additional labels to apply to the service
                   type: string

--- a/config/manifests/bases/olm-parameters.yaml
+++ b/config/manifests/bases/olm-parameters.yaml
@@ -511,6 +511,12 @@
       x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:hidden
+    - displayName: Pod Labels
+      path: pod_labels
+      x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:text
+        - urn:alm:descriptor:com.tectonic.ui:hidden
     - displayName: Service Labels
       path: service_labels
       x-descriptors:

--- a/roles/installer/defaults/main.yml
+++ b/roles/installer/defaults/main.yml
@@ -3,6 +3,12 @@ deployment_type: awx
 kind: '{{ deployment_type | upper }}'
 api_version: '{{ deployment_type }}.ansible.com/v1beta1'
 
+# Custom labels for the tower pod. Specify as literal block. E.g.:
+# pod_labels: |
+#   environment: non-production
+#   zone: internal
+pod_labels: ''
+
 database_name: "{{ deployment_type }}"
 database_username: "{{ deployment_type }}"
 

--- a/roles/installer/templates/deployment.yaml.j2
+++ b/roles/installer/templates/deployment.yaml.j2
@@ -27,6 +27,7 @@ spec:
         app.kubernetes.io/part-of: '{{ ansible_operator_meta.name }}'
         app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
         app.kubernetes.io/component: '{{ deployment_type }}'
+        {{ pod_labels | indent(width=8) }}
     spec:
       serviceAccountName: '{{ ansible_operator_meta.name }}'
 {% if image_pull_secret %}


### PR DESCRIPTION
Adding `pod_labels` option for templating custom labels into the pods. 

This could simply solve the #242 since users could add the `aadpodbinding` label and other use cases.

Signed-off-by: Loc Mai <lmai@axon.com>