### PR TITLE
Fix deploy target for the devel branch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,9 @@ gen-resources: kustomize ## Generate resources for controller and print to stdou
 	@$(KUSTOMIZE) build config/default
 
 deploy: kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
-	$(MAKE) gen-resources | kubectl apply -f -
+	@cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
+	@cd config/default && $(KUSTOMIZE) edit set namespace ${NAMESPACE}
+	@$(KUSTOMIZE) build config/default | kubectl apply -f -
 
 undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config.
 	$(KUSTOMIZE) build config/default | kubectl delete -f -


### PR DESCRIPTION
Related Issue: https://github.com/ansible/awx-operator/issues/667

  * piping a make target within another target causes issues

When running `make deploy` on the devel branch, I get the following error.  This fixes it, though it isn't DRY..
```
$ VERSION=0.15.0 NAMESPACE=ca-awx IMG=quay.io/chadams/awx-operator:dev make deploy
make gen-resources | kubectl apply -f -
error: error validating "STDIN": error validating data: ValidationError(Namespace): unknown field "make[1]" in io.k8s.api.core.v1.Namespace; if you choose to ignore these errors, turn validation off with --validate=false
make: *** [Makefile:87: deploy] Error 1
```

Signed-off-by: Christian M. Adams <chadams@redhat.com>