### PR TITLE
Wait for Postgres to initialize before starting containers

### DIFF
--- a/roles/installer/tasks/database_configuration.yml
+++ b/roles/installer/tasks/database_configuration.yml
@@ -138,6 +138,20 @@
     awx_postgres_sslmode: "{{ pg_config['resources'][0]['data']['sslmode'] |  default('prefer'|b64encode) | b64decode }}"
   no_log: true
 
+- name: Wait for Database to initialize
+  k8s_info:
+    kind: Pod
+    namespace: '{{ ansible_operator_meta.namespace }}'
+    name: '{{ ansible_operator_meta.name }}-postgres-0'  # using name to keep compatibility
+    field_selectors:
+      - status.phase=Running
+  register: postgres_pod
+  until:
+    - "postgres_pod['resources'] | length"
+    - "postgres_pod['resources'][0]['status']['phase'] == 'Running'"
+  delay: 5
+  retries: 60
+
 - name: Look up details for this deployment
   k8s_info:
     api_version: "{{ api_version }}"


### PR DESCRIPTION
To avoid a bad state that can occur if the app containers come online before the postgres pod is up, we should add the following task to wait for Postgres to initialize.  

This used to exist in the launch_awx.sh script, but was removed as ansible is no longer available in the task container at that point. 

The ascii video below demonstrates that the wait task is honored.  
![postgres-wait](https://user-images.githubusercontent.com/11698892/145117324-d984a088-d81f-49e0-b9c4-665eb561c5f5.gif)
