### PR TITLE
Do not try to wait for Postgres on external db deployments

### DIFF
--- a/roles/installer/tasks/database_configuration.yml
+++ b/roles/installer/tasks/database_configuration.yml
@@ -138,7 +138,7 @@
     awx_postgres_sslmode: "{{ pg_config['resources'][0]['data']['sslmode'] |  default('prefer'|b64encode) | b64decode }}"
   no_log: true
 
-- name: Wait for Database to initialize
+- name: Wait for Database to initialize if managed DB
   k8s_info:
     kind: Pod
     namespace: '{{ ansible_operator_meta.namespace }}'
@@ -151,6 +151,7 @@
     - "postgres_pod['resources'][0]['status']['phase'] == 'Running'"
   delay: 5
   retries: 60
+  when: pg_config['resources'][0]['data']['type'] | default('') | b64decode == 'managed'
 
 - name: Look up details for this deployment
   k8s_info:


### PR DESCRIPTION
This check is not needed for deployments with external db's, if run, the install will fail because it keeps waiting for a postgres pod that will never run.  