### PR TITLE
Add an option to specify affinity rules for the awx pod

### DIFF
--- a/README.md
+++ b/README.md
@@ -557,6 +557,7 @@ You can constrain the AWX pods created by the operator to run on a certain subse
 the AWX pods to run only on the nodes that match all the specified key/value pairs. `tolerations` and `postgres_tolerations` allow the AWX
 pods to be scheduled onto nodes with matching taints.
 The ability to specify topologySpreadConstraints is also allowed through `topology_spread_constraints`  
+If you want to use affinity rules for your AWX pod you can use the `node_affinity` option.
 
 
 | Name                           | Description                              | Default |
@@ -565,6 +566,7 @@ The ability to specify topologySpreadConstraints is also allowed through `topolo
 | postgres_image_version         | Image version to pull                    | 12      |
 | node_selector                  | AWX pods' nodeSelector                   | ''      |
 | topology_spread_constraints    | AWX pods' topologySpreadConstraints      | ''      |
+| node_affinity                  | AWX pods' affinity rules    | ''      |
 | tolerations                    | AWX pods' tolerations                    | ''      |
 | postgres_selector              | Postgres pods' nodeSelector              | ''      |
 | postgres_tolerations           | Postgres pods' tolerations               | ''      |
@@ -600,6 +602,16 @@ spec:
       operator: "Equal"
       value: "AWX"
       effect: "NoSchedule"
+  affinity:
+    nodeAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 1
+        preference:
+          matchExpressions:
+          - key: another-node-label-key
+            operator: In
+            values:
+            - another-node-label-value
 ```
 
 #### Trusting a Custom Certificate Authority

--- a/config/crd/bases/awx.ansible.com_awxs.yaml
+++ b/config/crd/bases/awx.ansible.com_awxs.yaml
@@ -137,6 +137,10 @@ spec:
                 topology_spread_constraints:
                   description: topology rule(s) for the pods
                   type: string
+                node_affinity:
+                  description: affinity rule(s) for the pods
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
                 service_labels:
                   description: Additional labels to apply to the service
                   type: string

--- a/roles/installer/templates/deployment.yaml.j2
+++ b/roles/installer/templates/deployment.yaml.j2
@@ -326,6 +326,10 @@ spec:
       topologySpreadConstraints:
         {{ topology_spread_constraints | indent(width=8) }}
 {% endif %}
+{% if node_affinity %}
+      affinity:
+        {{ node_affinity | to_yaml | indent(width=8) }}
+{% endif %}
 {% if tolerations %}
       tolerations:
         {{ tolerations | indent(width=8) }}


### PR DESCRIPTION
In some cases, you may want to use affinity rules instead of a
 node selector so you can have more flexbility. For example if you want
to have "soft" rules i.e. run my pod on this node if possible otherwise
run it anywhere