### PR TITLE
removes obsolete and confusing warning about project status

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,6 @@ An [Ansible AWX](https://github.com/ansible/awx) operator for Kubernetes built w
 
 This operator is meant to provide a more Kubernetes-native installation method for AWX via an AWX Custom Resource Definition (CRD).
 
-> :warning: The operator is not supported by Red Hat, and is in **alpha** status. For now, use it at your own risk!
-
 ## Usage
 
 ### Basic Install


### PR DESCRIPTION
This warning originated [two years ago](https://github.com/ansible/awx-operator/commit/6e6cd37ce671bd79e8d9ffe78f1e99c4ff39e67d#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R18).
The API is now at `v1beta1`, so it's probably not accurate to call it
"alpha" anymore.

Since AWX and awx-operator are both OSS upstream projects, there is
implicitly no vendor support from Red Hat. The warning about support can
lead to confusion, and potentially imply that some other part of AWX is
supported, as demonstrated in a recent [twitter
thread](https://twitter.com/vwbusguy/status/1470902780311212035). When this warning was written, the operator was self-described as an
"installation method for Ansible Tower or AWX". Since then, it appears
that the operator is focused only on upstream AWX, so that presumably
removes any need to clarify vendor support status.