### PR TITLE
Enable setting a list of image_pull_secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,7 +438,7 @@ There are a few variables that are customizable for awx the image management.
 | image                     | Path of the image to pull  |
 | image_version             | Image version to pull      |
 | image_pull_policy         | The pull policy to adopt   |
-| image_pull_secret         | The pull secret to use     |
+| image_pull_secrets        | The pull secrets to use    |
 | ee_images                 | A list of EEs to register  |
 | redis_image               | Path of the image to pull  |
 | redis_image_version       | Image version to pull      |
@@ -452,7 +452,8 @@ spec:
   image: myorg/my-custom-awx
   image_version: latest
   image_pull_policy: Always
-  image_pull_secret: pull_secret_name
+  image_pull_secrets:
+    - pull_secret_name
   ee_images:
     - name: my-custom-awx-ee
       image: myorg/my-custom-awx-ee
@@ -745,7 +746,7 @@ type: Opaque
 ```
 
 ##### Control plane ee from private registry
-The images listed in "ee_images" will be added as globally available Execution Environments. The "control_plane_ee_image" will be used to run project updates. In order to use a private image for any of these you'll need to use `image_pull_secret` to provide a k8s pull secret to access it. Currently the same secret is used for any of these images supplied at install time.
+The images listed in "ee_images" will be added as globally available Execution Environments. The "control_plane_ee_image" will be used to run project updates. In order to use a private image for any of these you'll need to use `image_pull_secrets` to provide a list of k8s pull secrets to access it. Currently the same secret is used for any of these images supplied at install time.
 
 You can create `image_pull_secret`
 ```

--- a/config/crd/bases/awx.ansible.com_awxs.yaml
+++ b/config/crd/bases/awx.ansible.com_awxs.yaml
@@ -176,9 +176,11 @@ spec:
                     - never
                     - IfNotPresent
                     - ifnotpresent
-                image_pull_secret:
-                  description: The image pull secret
-                  type: string
+                image_pull_secrets:
+                  description: The image pull secrets
+                  type: array
+                  items:
+                    type: string
                 task_resource_requirements:
                   description: Resource requirements for the task container
                   properties:

--- a/config/manifests/bases/olm-parameters.yaml
+++ b/config/manifests/bases/olm-parameters.yaml
@@ -241,8 +241,8 @@
       x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:imagePullPolicy
-    - displayName: Image Pull Secret
-      path: image_pull_secret
+    - displayName: Image Pull Secrets
+      path: image_pull_secrets
       x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:io.kubernetes:Secret

--- a/roles/backup/tasks/secrets.yml
+++ b/roles/backup/tasks/secrets.yml
@@ -21,8 +21,18 @@
     - ingress_tls_secret
     - ldap_cacert_secret
     - bundle_cacert_secret
-    - image_pull_secret
     - ee_pull_credentials_secret
+
+# image_pull_secret is deprecated in favor of image_pull_secrets
+- name: Dump image_pull_secret into file
+  include_tasks: dump_secret.yml
+  loop:
+    - image_pull_secret
+  when: image_pull_secret is defined
+
+- name: Dump image_pull_secrets into file
+  include_tasks: dump_secret.yml
+  loop: "{{ awx_spec.spec[image_pull_secrets] }}"
 
 - name: Nest secrets under a single variable
   set_fact:

--- a/roles/installer/defaults/main.yml
+++ b/roles/installer/defaults/main.yml
@@ -127,7 +127,7 @@ _postgres_image_version: 12
 _init_container_image: quay.io/centos/centos
 _init_container_image_version: 8
 image_pull_policy: IfNotPresent
-image_pull_secret: ''
+image_pull_secrets: []
 
 # Extra commands which will be appended to the initContainer
 # Make sure that each command entered return an exit code 0

--- a/roles/installer/templates/deployment.yaml.j2
+++ b/roles/installer/templates/deployment.yaml.j2
@@ -29,9 +29,14 @@ spec:
         app.kubernetes.io/component: '{{ deployment_type }}'
     spec:
       serviceAccountName: '{{ ansible_operator_meta.name }}'
-{% if image_pull_secret %}
+{% if image_pull_secret is defined %}
       imagePullSecrets:
         - name: {{ image_pull_secret }}
+{% elif image_pull_secrets | length > 0 %}
+      imagePullSecrets:
+{% for secret in image_pull_secrets %}
+        - name: {{ secret }}
+{% endfor %}
 {% endif %}
 {% if bundle_ca_crt or projects_persistence|bool or init_container_extra_commands %}
       initContainers:

--- a/roles/installer/templates/postgres.yaml.j2
+++ b/roles/installer/templates/postgres.yaml.j2
@@ -33,9 +33,14 @@ spec:
         app.kubernetes.io/part-of: '{{ ansible_operator_meta.name }}'
         app.kubernetes.io/managed-by: '{{ deployment_type }}-operator' 
     spec:
-{% if image_pull_secret %}
+{% if image_pull_secret is defined %}
       imagePullSecrets:
         - name: {{ image_pull_secret }}
+{% elif image_pull_secrets | length > 0 %}
+      imagePullSecrets:
+{% for secret in image_pull_secrets %}
+        - name: {{ secret }}
+{% endfor %}
 {% endif %}
       containers:
         - image: '{{ _postgres_image }}'


### PR DESCRIPTION
When there are e.g. multiple authenticated container registries used
we need to be able to add multiple imagePullSecrets to the k8s resource

NOTE: I haven't run any tests so far to confirm that it works