### PR TITLE
Truncate image version label so that it avoids the 63 char k8s limit

### DIFF
--- a/roles/installer/templates/deployment.yaml.j2
+++ b/roles/installer/templates/deployment.yaml.j2
@@ -7,7 +7,7 @@ metadata:
   namespace: '{{ ansible_operator_meta.namespace }}'
   labels:
     app.kubernetes.io/name: '{{ ansible_operator_meta.name }}'
-    app.kubernetes.io/version: '{{ _image_version }}'
+    app.kubernetes.io/version: '{{ _image.split(':')[-1] | truncate(63, True, '') }}'
     app.kubernetes.io/part-of: '{{ ansible_operator_meta.name }}'
     app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
     app.kubernetes.io/component: '{{ deployment_type }}'
@@ -23,7 +23,7 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: '{{ ansible_operator_meta.name }}'
-        app.kubernetes.io/version: '{{ _image_version }}'
+        app.kubernetes.io/version: '{{ _image.split(':')[-1] | truncate(63, True, '') }}'
         app.kubernetes.io/part-of: '{{ ansible_operator_meta.name }}'
         app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
         app.kubernetes.io/component: '{{ deployment_type }}'


### PR DESCRIPTION
If the image tag specified is longer than 63 characters, then k8s throws an error when adding the version label to the deployment object (which we get from the image tag).  While looking at this issue, I noticed that the version being set as the label is not always set correctly depending on where the image and image_version is set.  This PR fixes that as well.  

In my spec, I included an 70+ character tag for image_version
```
            image_version: 2.1.0-toasttoasttoastfordays-toast-is-the-best-snack-i-ever-had-coffee-and-toast-for-life
```

With these changes, I no longer see an error when the deployment config is applied, and the correct version is displayed.

```
$ oc get deployment awx -o yaml| grep app.kubernetes.io/version:
    app.kubernetes.io/version: 2.1.0-toasttoasttoastfordays-toast-is-the-best-snack-i-ever-had
```
