### PR TITLE
Scale down app pod when database is unavailable

### DIFF
--- a/roles/installer/tasks/database_configuration.yml
+++ b/roles/installer/tasks/database_configuration.yml
@@ -99,6 +99,10 @@
         definition: "{{ lookup('template', 'postgres.yaml.j2') }}"
       register: create_statefulset_result
 
+    - name: Scale down Deployment for migration
+      include_tasks: scale_down_deployment.yml
+      when: create_statefulset_result.changed
+
   rescue:
     - name: Scale down Deployment for migration
       include_tasks: scale_down_deployment.yml


### PR DESCRIPTION
In some upgrade scenarios, the postgres StatefulSet will be changed, resulting in the postgres pod being terminated and re-created.  As a result, the database becomes unavailable temporarily, which causes the application to throw 500 errors and often will not recover even when the database is avialable again.  

To avoid this, the app pod deployment should be scaled down to 0 in cases where postgresql is expected to be unavailable.  In this case, whenever the postgres StatefulSet it changed, we can assume the postgres pod will be unavailable temporarily.  