### PR TITLE
[Do Not Merge Yet] Use pgsql subPath directory inside volume to remain consistent

### DIFF
--- a/roles/installer/templates/postgres.yaml.j2
+++ b/roles/installer/templates/postgres.yaml.j2
@@ -87,7 +87,7 @@ spec:
           volumeMounts:
             - name: postgres
               mountPath: '{{ postgres_data_path | dirname }}'
-              subPath: '{{ postgres_data_path | dirname | basename }}'
+              subPath: '{{ postgres_data_path | dirname | dirname | basename }}'
           resources: {{ postgres_resource_requirements }}
 {% if postgres_selector %}
       nodeSelector:


### PR DESCRIPTION
Use pgsql subPath directory inside volume to remain consistent with past versions

  * data will not persist when upgrading if the subPath is different.
    The data is not lost, but the wrong directory in the volume is
mounted, which results in a new db getting initialized.

Now that the default value for postgres_data_dir is `/var/lib/pgsql/data/userdata`, this change is needed so that the subPath remains pgsql.  

Signed-off-by: Christian M. Adams <chadams@redhat.com>