### PR TITLE
added capability to set the redis container resources

### DIFF
--- a/config/crd/bases/awx.ansible.com_awxs.yaml
+++ b/config/crd/bases/awx.ansible.com_awxs.yaml
@@ -242,6 +242,28 @@ spec:
                           type: string
                       type: object
                   type: object
+                redis_resource_requirements:
+                  description: Resource requirements for the redis container
+                  properties:
+                    requests:
+                      properties:
+                        cpu:
+                          type: string
+                        memory:
+                          type: string
+                        storage:
+                          type: string
+                      type: object
+                    limits:
+                      properties:
+                        cpu:
+                          type: string
+                        memory:
+                          type: string
+                        storage:
+                          type: string
+                      type: object
+                  type: object
                 service_account_annotations:
                   description: ServiceAccount annotations
                   type: string

--- a/config/manifests/bases/olm-parameters.yaml
+++ b/config/manifests/bases/olm-parameters.yaml
@@ -261,6 +261,11 @@
       x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
+    - displayName: Redis container resource requirements
+      path: redis_resource_requirements
+      x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
     - displayName: PostgreSQL container resource requirements (when using a managed
         instance)
       path: postgres_resource_requirements

--- a/roles/installer/defaults/main.yml
+++ b/roles/installer/defaults/main.yml
@@ -165,6 +165,10 @@ ee_resource_requirements:
     cpu: 500m
     memory: 1Gi
 
+redis_resource_requirements:
+  requests:
+    cpu: 500m
+    memory: 250Mi
 # Add extra environment variables to the AWX task/web containers. Specify as
 # literal block. E.g.:
 # task_extra_env: |

--- a/roles/installer/templates/deployment.yaml.j2
+++ b/roles/installer/templates/deployment.yaml.j2
@@ -89,6 +89,7 @@ spec:
               mountPath: "/var/run/redis"
             - name: "{{ ansible_operator_meta.name }}-redis-data"
               mountPath: "/data"
+          resources: {{ redis_resource_requirements }}
         - image: '{{ _image }}'
           name: '{{ ansible_operator_meta.name }}-web'
 {% if web_command %}


### PR DESCRIPTION
## Description
Added the capability to setup the resources requirements to the redis container (part of awx pod) 

## changes

- Added the section in the awxs.awx.ansible.com CRD
- Added the section in the appropriate location in deployment template
- Added the variable in defaults

## Tests
Tested in my own env