### PR TITLE
Add topology constraints to AWX CRD

### DIFF
--- a/README.md
+++ b/README.md
@@ -537,16 +537,18 @@ spec:
 You can constrain the AWX pods created by the operator to run on a certain subset of nodes. `node_selector` and `postgres_selector` constrains
 the AWX pods to run only on the nodes that match all the specified key/value pairs. `tolerations` and `postgres_tolerations` allow the AWX
 pods to be scheduled onto nodes with matching taints.
+The ability to specify topologySpreadConstraints is also allowed through `topology_spread_constraints`  
 
 
-| Name                           | Description                 | Default |
-| -------------------------------| --------------------------- | ------- |
-| postgres_image                 | Path of the image to pull   | 12      |
-| postgres_image_version         | Image version to pull       | 12      |
-| node_selector                  | AWX pods' nodeSelector      | ''      |
-| tolerations                    | AWX pods' tolerations       | ''      |
-| postgres_selector              | Postgres pods' nodeSelector | ''      |
-| postgres_tolerations           | Postgres pods' tolerations  | ''      |
+| Name                           | Description                              | Default |
+| -------------------------------| ---------------------------------------- | ------- |
+| postgres_image                 | Path of the image to pull                | 12      |
+| postgres_image_version         | Image version to pull                    | 12      |
+| node_selector                  | AWX pods' nodeSelector                   | ''      |
+| topology_spread_constraints    | AWX pods' topologySpreadConstraints      | ''      |
+| tolerations                    | AWX pods' tolerations                    | ''      |
+| postgres_selector              | Postgres pods' nodeSelector              | ''      |
+| postgres_tolerations           | Postgres pods' tolerations               | ''      |
 
 Example of customization could be:
 
@@ -558,6 +560,13 @@ spec:
     disktype: ssd
     kubernetes.io/arch: amd64
     kubernetes.io/os: linux
+  topology_spread_constraints: |
+    - maxSkew: 100
+      topologyKey: "topology.kubernetes.io/zone"
+      whenUnsatisfiable: "ScheduleAnyway"
+      labelSelector:
+        matchLabels:
+          app.kubernetes.io/name: "<resourcename>"
   tolerations: |
     - key: "dedicated"
       operator: "Equal"

--- a/config/crd/bases/awx.ansible.com_awxs.yaml
+++ b/config/crd/bases/awx.ansible.com_awxs.yaml
@@ -134,6 +134,9 @@ spec:
                 node_selector:
                   description: nodeSelector for the pods
                   type: string
+                topology_spread_constraints:
+                  description: topology rule(s) for the pods
+                  type: string
                 service_labels:
                   description: Additional labels to apply to the service
                   type: string

--- a/config/manifests/bases/olm-parameters.yaml
+++ b/config/manifests/bases/olm-parameters.yaml
@@ -511,6 +511,11 @@
       x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:hidden
+    - displayName: Topology Spread Constraints
+      path: topology_spread_constraints
+      x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:hidden
     - displayName: Service Labels
       path: service_labels
       x-descriptors:

--- a/roles/installer/defaults/main.yml
+++ b/roles/installer/defaults/main.yml
@@ -64,6 +64,17 @@ hostname: ''
 #   kubernetes.io/os: linux
 node_selector: ''
 
+# Add a topologySpreadConstraints for the AWX pods.
+# Specify as literal block. E.g.:
+# topology_spread_constraints: |
+#   - maxSkew: 100
+#     topologyKey: "topology.kubernetes.io/zone"
+#     whenUnsatisfiable: "ScheduleAnyway"
+#     labelSelector:
+#       matchLabels:
+#         app.kubernetes.io/name: "<resourcename>"
+topology_spread_constraints: ''
+
 # Add node tolerations for the AWX pods. Specify as literal block. E.g.:
 # tolerations: |
 #   - key: "dedicated"

--- a/roles/installer/templates/deployment.yaml.j2
+++ b/roles/installer/templates/deployment.yaml.j2
@@ -306,6 +306,10 @@ spec:
       nodeSelector:
         {{ node_selector | indent(width=8) }}
 {% endif %}
+{% if topology_spread_constraints %}
+      topologySpreadConstraints:
+        {{ topology_spread_constraints | indent(width=8) }}
+{% endif %}
 {% if tolerations %}
       tolerations:
         {{ tolerations | indent(width=8) }}


### PR DESCRIPTION
# Description 

Add the ability to specify topologySpreadConstraints for AWX pods.  
  
Usefull for AWS EKS multi-AZ deployment using karpenter autoscaler.  
  
# Changes

- Added the section in the awxs.awx.ansible.com CRD
- Added the section in the deployment template
- Added the section in the olm-parameters
- Added the variable in defaults along with some documentation
- Added documentation in README