### PR TITLE
Add ability to configure extra args for postgres

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,6 +422,9 @@ spec:
     limits:
       storage: 50Gi
   postgres_storage_class: fast-ssd
+  postgres_extra_args:
+    - '-c'
+    - 'max_connections=1000'
 ```
 
 **Note**: If `postgres_storage_class` is not defined, Postgres will store it's data on a volume using the default storage class for your cluster.

--- a/config/crd/bases/awx.ansible.com_awxs.yaml
+++ b/config/crd/bases/awx.ansible.com_awxs.yaml
@@ -362,6 +362,10 @@ spec:
                 postgres_data_path:
                   description: Path where the PostgreSQL data are located
                   type: string
+                postgres_extra_args:
+                  type: array
+                  items:
+                    type: string
                 ca_trust_bundle:
                   description: Path where the trusted CA bundle is available
                   type: string

--- a/roles/installer/defaults/main.yml
+++ b/roles/installer/defaults/main.yml
@@ -215,6 +215,9 @@ projects_persistence: false
 # Define an existing PersistentVolumeClaim to use
 projects_existing_claim: ''
 #
+# Define postgres configuration arguments to use
+postgres_extra_args: ''
+
 # Define the storage_class, size and access_mode
 # when not using an existing claim
 projects_storage_size: 8Gi

--- a/roles/installer/templates/postgres.yaml.j2
+++ b/roles/installer/templates/postgres.yaml.j2
@@ -41,6 +41,9 @@ spec:
         - image: '{{ _postgres_image }}'
           imagePullPolicy: '{{ image_pull_policy }}'
           name: postgres
+{% if postgres_extra_args %}
+          args: {{ postgres_extra_args }}
+{% endif %}
           env:
             # For postgres_image based on rhel8/postgresql-12
             - name: POSTGRESQL_DATABASE


### PR DESCRIPTION
## Summary

To get https://github.com/ansible/awx-operator/pull/600 merged, our CI needed a new commit hash in order to get retriggered.  I cherry-picked over @chris93111's commits, the squashed them in this PR.   

* add default extra args postgres
* add postgres_extra_args option to readme

## Info from original message

allow change settings for postgresql with extra args in deployment

fix https://github.com/ansible/awx-operator/issues/538

```
postgres_extra_args:
  - '-c'
  - 'max_connections=1000'
```