### PR TITLE
Always run database-check initContainer

### DIFF
--- a/roles/installer/tasks/database_configuration.yml
+++ b/roles/installer/tasks/database_configuration.yml
@@ -157,6 +157,10 @@
   retries: 60
   when: pg_config['resources'][0]['data']['type'] | default('') | b64decode == 'managed'
 
+- name: Set database as managed
+  set_fact:
+    managed_database: "{{ pg_config['resources'][0]['data']['type'] | default('') | b64decode == 'managed' }}"
+
 - name: Look up details for this deployment
   k8s_info:
     api_version: "{{ api_version }}"

--- a/roles/installer/templates/deployment.yaml.j2
+++ b/roles/installer/templates/deployment.yaml.j2
@@ -34,6 +34,7 @@ spec:
         - name: {{ image_pull_secret }}
 {% endif %}
       initContainers:
+{% if managed_database %}
         - name: database-check
           image: '{{ _init_container_image }}'
           imagePullPolicy: '{{ image_pull_policy }}'
@@ -41,15 +42,12 @@ spec:
             - /bin/sh
             - -c
             - |
-              [[ -d /check-db/pgsql/data ]] && rm -rf /check-db/data; mv /check-db/pgsql/data/ /check-db/data/ && rm -rf /check-db/pgsql
+              [[ -d /check-db/pgsql/data ]] && rm -rf /check-db/data && mv /check-db/pgsql/data/ /check-db/data/ && rm -rf /check-db/pgsql || true
           volumeMounts:
             - name: check-db-pvc
               mountPath: /check-db
               subPath: ''
-            volumes:
-            - name: check-db-pvc
-            persistentVolumeClaim:
-              claimName: postgres-{{ ansible_operator_meta.name }}-postgres-0
+{% endif %}
 {% if bundle_ca_crt or projects_persistence|bool or init_container_extra_commands %}
         - name: init
           image: '{{ _init_container_image }}'
@@ -340,6 +338,11 @@ spec:
 {% endif %}
 {% endif %}
       volumes:
+{% if managed_database %}
+        - name: check-db-pvc
+          persistentVolumeClaim:
+            claimName: postgres-{{ ansible_operator_meta.name }}-postgres-0
+{% endif %}
 {% if bundle_ca_crt %}
         - name: "ca-trust-extracted"
           emptyDir: {}

--- a/roles/installer/templates/deployment.yaml.j2
+++ b/roles/installer/templates/deployment.yaml.j2
@@ -33,7 +33,6 @@ spec:
       imagePullSecrets:
         - name: {{ image_pull_secret }}
 {% endif %}
-{% if bundle_ca_crt or projects_persistence|bool or init_container_extra_commands %}
       initContainers:
         - name: database-check
           image: '{{ _init_container_image }}'
@@ -51,6 +50,7 @@ spec:
             - name: check-db-pvc
             persistentVolumeClaim:
               claimName: postgres-{{ ansible_operator_meta.name }}-postgres-0
+{% if bundle_ca_crt or projects_persistence|bool or init_container_extra_commands %}
         - name: init
           image: '{{ _init_container_image }}'
           imagePullPolicy: '{{ image_pull_policy }}'


### PR DESCRIPTION
Follow-up for https://github.com/ansible/awx-operator/pull/755

The init container was only being called in certain cases, this change will ensure that it happens every time.  