### PR TITLE
Add OLM params for postgres_extra_vars

### DIFF
--- a/config/manifests/bases/olm-parameters.yaml
+++ b/config/manifests/bases/olm-parameters.yaml
@@ -375,6 +375,11 @@
       x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:hidden
+    - displayName: Postgres Extra Arguments
+      path: postgres_extra_args
+      x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:hidden
     - displayName: Certificate Authorirty Trust Bundle
       path: ca_trust_bundle
       x-descriptors:


### PR DESCRIPTION
Follow-up for https://github.com/ansible/awx-operator/pull/753

The postgres_extra_args needed to be added to the OLM parameters.  