### PR TITLE
Allow service annotations not only for LoadBalancer type

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,12 +241,15 @@ The following variables are customizable for any `service_type`
 | Name                                  | Description                                   | Default                           |
 | ------------------------------------- | --------------------------------------------- | --------------------------------- |
 | service_labels                  | Add custom labels                             | Empty string                      |
+| service_annotations             | Add service annotations                 | Empty string  |
 
 ```yaml
 ---
 spec:
   ...
   service_type: ClusterIP
+  service_annotations: |
+    environment: testing
   service_labels: |
     environment: testing
 ```
@@ -257,7 +260,6 @@ The following variables are customizable only when `service_type=LoadBalancer`
 
 | Name                           | Description                              | Default       |
 | ------------------------------ | ---------------------------------------- | ------------- |
-| loadbalancer_annotations | LoadBalancer annotations                 | Empty string  |
 | loadbalancer_protocol    | Protocol to use for Loadbalancer ingress | http          |
 | loadbalancer_port        | Port used for Loadbalancer ingress       | 80            |
 
@@ -268,7 +270,7 @@ spec:
   service_type: LoadBalancer
   loadbalancer_protocol: https
   loadbalancer_port: 443
-  loadbalancer_annotations: |
+  service_annotations: |
     environment: testing
   service_labels: |
     environment: testing

--- a/config/crd/bases/awx.ansible.com_awxs.yaml
+++ b/config/crd/bases/awx.ansible.com_awxs.yaml
@@ -67,6 +67,9 @@ spec:
                 extra_volumes:
                   description: Specify extra volumes to add to the application pod
                   type: string
+                service_annotations:
+                  description: Annotations to add to the service
+                  type: string
                 service_type:
                   description: The service type to be used on the deployed instance
                   type: string
@@ -97,9 +100,6 @@ spec:
                   type: string
                 ingress_tls_secret:
                   description: Secret where the Ingress TLS secret can be found
-                  type: string
-                loadbalancer_annotations:
-                  description: Annotations to add to the loadbalancer
                   type: string
                 loadbalancer_protocol:
                   description: Protocol to use for the loadbalancer

--- a/config/manifests/bases/olm-parameters.yaml
+++ b/config/manifests/bases/olm-parameters.yaml
@@ -199,7 +199,7 @@
         - urn:alm:descriptor:io.kubernetes:Secret
         - urn:alm:descriptor:com.tectonic.ui:fieldDependency:ingress_type:Ingress
     - displayName: Tower LoadBalancer Annotations
-      path: loadbalancer_annotations
+      path: service_annotations
       x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:text

--- a/roles/installer/defaults/main.yml
+++ b/roles/installer/defaults/main.yml
@@ -36,7 +36,7 @@ ingress_tls_secret: ''
 
 loadbalancer_protocol: 'http'
 loadbalancer_port: '80'
-loadbalancer_annotations: ''
+service_annotations: ''
 
 nodeport_port: '30080'
 # The TLS termination mechanism to use to access

--- a/roles/installer/templates/service.yaml.j2
+++ b/roles/installer/templates/service.yaml.j2
@@ -11,9 +11,9 @@ metadata:
     app.kubernetes.io/component: '{{ deployment_type }}'
     app.kubernetes.io/operator-version: '{{ lookup("env", "OPERATOR_VERSION") }}'
     {{ service_labels | indent(width=4) }}
-{% if service_type | lower == 'loadbalancer' and loadbalancer_annotations %}
+{% if service_annotations %}
   annotations:
-    {{ loadbalancer_annotations | indent(width=4) }}
+    {{ service_annotations | indent(width=4) }}
 {% endif %}
 spec:
   ports:


### PR DESCRIPTION
By example, to configure NEG's or set a backendconfig we need to annotate de service but there is no reason for use a LoadBalancer for this, NodePort should be ok.