### PR TITLE
Add some loop control for ansible warnings

### DIFF
--- a/molecule/default/tasks/awx_test.yml
+++ b/molecule/default/tasks/awx_test.yml
@@ -55,7 +55,7 @@
   rescue:
     - name: Get list of project updates and jobs
       uri:
-        url: "http://localhost/api/v2/{{ item }}/"
+        url: "http://localhost/api/v2/{{ resource }}/"
         user: admin
         password: "{{ admin_pw_secret.resources[0].data.password | b64decode }}"
         force_basic_auth: yes
@@ -63,15 +63,19 @@
       loop:
         - project_updates
         - jobs
+      loop_control:
+        loop_var: resource
 
     - name: Get all job and project details
       uri:
-        url: "http://localhost{{ item }}"
+        url: "http://localhost{{ endpoint }}"
         user: admin
         password: "{{ admin_pw_secret.resources[0].data.password | b64decode }}"
         force_basic_auth: yes
       loop: |
         {{ job_lists.results | map(attribute='json') | map(attribute='results') | flatten | map(attribute='url') }}
+      loop_control:
+        loop_var: endpoint
 
     - name: Re-emit failure
       vars:


### PR DESCRIPTION
addresses warnings

```
  TASK [Get list of project updates and jobs] ************************************
  Warning: : The loop variable 'item' is already in use. You should set the
  `loop_var` value in the `loop_control` option for the task to something else to
  avoid variable collisions and unexpected behavior.
  ok: [localhost] => (item=project_updates)
  ok: [localhost] => (item=jobs)
  Warning: : Module did not set no_log for password
  
  TASK [Get all job and project details] *****************************************
  Warning: : The loop variable 'item' is already in use. You should set the
  `loop_var` value in the `loop_control` option for the task to something else to
  avoid variable collisions and unexpected behavior.
  ok: [localhost] => (item=/api/v2/project_updates/1/)
```

but I want to see that checks pass first