### PR TITLE
only set mem/cpu setting if limit is set

### DIFF
--- a/roles/installer/templates/config.yaml.j2
+++ b/roles/installer/templates/config.yaml.j2
@@ -34,13 +34,13 @@ data:
 
     # Set memory available based off of resource request/limit for the task pod
     memory_limit = '{{ task_resource_requirements["limits"]["memory"] if "limits" in task_resource_requirements and "memory" in task_resource_requirements["limits"] }}'
-    memory_request = '{{ task_resource_requirements["requests"]["memory"] if "requests" in task_resource_requirements and "memory" in task_resource_requirements["requests"] }}'
-    SYSTEM_TASK_ABS_MEM = memory_limit if memory_limit else memory_request
+    if memory_limit:
+        SYSTEM_TASK_ABS_MEM = memory_limit
 
     # Set cpu available based off of resource request/limit for the task pod
     cpu_limit = '{{ task_resource_requirements["limits"]["cpu"] if "limits" in task_resource_requirements and "cpu" in task_resource_requirements["limits"] }}'
-    cpu_request = '{{ task_resource_requirements["requests"]["cpu"] if "requests" in task_resource_requirements and "cpu" in task_resource_requirements["requests"] }}'
-    SYSTEM_TASK_ABS_CPU = cpu_limit if cpu_limit else cpu_request
+    if cpu_limit:
+        SYSTEM_TASK_ABS_CPU = cpu_limit
 
     SECRET_KEY = get_secret()
     


### PR DESCRIPTION
Otherwise, we get the too-low setting of the request, which
will be a rough experience for folks who have been using the operator
and are used to the experience of having entire underlying node capacity

Users can still set the setting via extra_settings to get the experience
of having each pod with a individualized capacity, or set a limit.

This will hopefully fix the PR check that sets really low requests.