### PR TITLE
Run database-check initContainer on postgres sts instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,13 +419,14 @@ If you don't have access to an external PostgreSQL service, the AWX operator can
 
 The following variables are customizable for the managed PostgreSQL service
 
-| Name                                 | Description                                | Default                           |
-| ------------------------------------ | ------------------------------------------ | --------------------------------- |
-| postgres_image                       | Path of the image to pull                  | postgres:12                       |
-| postgres_resource_requirements       | PostgreSQL container resource requirements | Empty object                      |
-| postgres_storage_requirements        | PostgreSQL container storage requirements  | requests: {storage: 8Gi}          |
-| postgres_storage_class               | PostgreSQL PV storage class                | Empty string                      |
-| postgres_data_path                   | PostgreSQL data path                       | `/var/lib/postgresql/data/pgdata` |
+| Name                                          | Description                                   | Default                           |
+| --------------------------------------------- | --------------------------------------------- | --------------------------------- |
+| postgres_image                                | Path of the image to pull                     | postgres:12                       |
+| postgres_init_container_resource_requirements | Database init container resource requirements | requests: {}                      |
+| postgres_resource_requirements                | PostgreSQL container resource requirements    | requests: {}                      |
+| postgres_storage_requirements                 | PostgreSQL container storage requirements     | requests: {storage: 8Gi}          |
+| postgres_storage_class                        | PostgreSQL PV storage class                   | Empty string                      |
+| postgres_data_path                            | PostgreSQL data path                          | `/var/lib/postgresql/data/pgdata` |
 
 Example of customization could be:
 

--- a/config/crd/bases/awx.ansible.com_awxs.yaml
+++ b/config/crd/bases/awx.ansible.com_awxs.yaml
@@ -245,6 +245,28 @@ spec:
                           type: string
                       type: object
                   type: object
+                postgres_init_container_resource_requirements:
+                  description: Resource requirements for the postgres init container
+                  properties:
+                    requests:
+                      properties:
+                        cpu:
+                          type: string
+                        memory:
+                          type: string
+                        storage:
+                          type: string
+                      type: object
+                    limits:
+                      properties:
+                        cpu:
+                          type: string
+                        memory:
+                          type: string
+                        storage:
+                          type: string
+                      type: object
+                  type: object
                 service_account_annotations:
                   description: ServiceAccount annotations
                   type: string

--- a/config/manifests/bases/olm-parameters.yaml
+++ b/config/manifests/bases/olm-parameters.yaml
@@ -261,14 +261,17 @@
       x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
-    - displayName: PostgreSQL container resource requirements (when using a managed
-        instance)
+    - displayName: PostgreSQL init container resource requirements (when using a managed instance)
+      path: postgres_init_container_resource_requirements
+      x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
+    - displayName: PostgreSQL container resource requirements (when using a managed instance)
       path: postgres_resource_requirements
       x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
-    - displayName: PostgreSQL container storage requirements (when using a managed
-        instance)
+    - displayName: PostgreSQL container storage requirements (when using a managed instance)
       path: postgres_storage_requirements
       x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced

--- a/roles/installer/defaults/main.yml
+++ b/roles/installer/defaults/main.yml
@@ -216,6 +216,7 @@ postgres_tolerations: ''
 postgres_storage_requirements:
   requests:
     storage: 8Gi
+postgres_init_container_resource_requirements: {}
 postgres_resource_requirements: {}
 postgres_data_path: '/var/lib/postgresql/data/pgdata'
 

--- a/roles/installer/tasks/main.yml
+++ b/roles/installer/tasks/main.yml
@@ -36,6 +36,9 @@
 - name: Include broadcast websocket configuration tasks
   include_tasks: broadcast_websocket_configuration.yml
 
+- name: Include set_images tasks
+  include_tasks: set_images.yml
+
 - name: Include database configuration tasks
   include_tasks: database_configuration.yml
 

--- a/roles/installer/tasks/resources_configuration.yml
+++ b/roles/installer/tasks/resources_configuration.yml
@@ -47,24 +47,6 @@
   set_fact:
     _image: "{{ _custom_image | default(lookup('env', 'RELATED_IMAGE_AWX')) | default(_default_image, true) }}"
 
-- name: Set default awx init container image
-  set_fact:
-    _default_init_container_image: "{{ _init_container_image }}:{{ _init_container_image_version }}"
-
-- name: Set user provided awx init image
-  set_fact:
-    _custom_init_container_image: "{{ init_container_image }}:{{ init_container_image_version }}"
-  when:
-    - init_container_image | default([]) | length
-    - init_container_image_version is defined or init_container_image_version != ''
-
-- name: Set Init image URL
-  set_fact:
-    _init_container_image: >-
-      {{ _custom_init_container_image |
-         default(lookup('env', 'RELATED_IMAGE_AWX_INIT_CONTAINER')) |
-         default(_default_init_container_image, true) }}
-
 - name: Set default redis image
   set_fact:
     _default_redis_image: "{{ _redis_image }}:{{ _redis_image_version }}"

--- a/roles/installer/tasks/set_images.yml
+++ b/roles/installer/tasks/set_images.yml
@@ -1,0 +1,19 @@
+# For disconnected environments, images must be set based on the values of `RELATED_IMAGE_` variables
+---
+- name: Set default awx init container image
+  set_fact:
+    _default_init_container_image: "{{ _init_container_image }}:{{ _init_container_image_version }}"
+
+- name: Set user provided awx init image
+  set_fact:
+    _custom_init_container_image: "{{ init_container_image }}:{{ init_container_image_version }}"
+  when:
+    - init_container_image | default([]) | length
+    - init_container_image_version is defined or init_container_image_version != ''
+
+- name: Set Init image URL
+  set_fact:
+    _init_container_image: >-
+      {{ _custom_init_container_image |
+         default(lookup('env', 'RELATED_IMAGE_AWX_INIT_CONTAINER')) |
+         default(_default_init_container_image, true) }}

--- a/roles/installer/templates/deployment.yaml.j2
+++ b/roles/installer/templates/deployment.yaml.j2
@@ -34,20 +34,6 @@ spec:
         - name: {{ image_pull_secret }}
 {% endif %}
       initContainers:
-{% if managed_database %}
-        - name: database-check
-          image: '{{ _init_container_image }}'
-          imagePullPolicy: '{{ image_pull_policy }}'
-          command:
-            - /bin/sh
-            - -c
-            - |
-              [[ -d /check-db/pgsql/data ]] && rm -rf /check-db/data && mv /check-db/pgsql/data/ /check-db/data/ && rm -rf /check-db/pgsql || true
-          volumeMounts:
-            - name: check-db-pvc
-              mountPath: /check-db
-              subPath: ''
-{% endif %}
 {% if bundle_ca_crt or projects_persistence|bool or init_container_extra_commands %}
         - name: init
           image: '{{ _init_container_image }}'
@@ -340,11 +326,6 @@ spec:
 {% endif %}
 {% endif %}
       volumes:
-{% if managed_database %}
-        - name: check-db-pvc
-          persistentVolumeClaim:
-            claimName: postgres-{{ ansible_operator_meta.name }}-postgres-0
-{% endif %}
 {% if bundle_ca_crt %}
         - name: "ca-trust-extracted"
           emptyDir: {}

--- a/roles/installer/templates/postgres.yaml.j2
+++ b/roles/installer/templates/postgres.yaml.j2
@@ -40,13 +40,7 @@ spec:
       initContainers:
         - name: database-check
           image: '{{ _init_container_image }}'
-          resources:
-            requests:
-              memory: "64Mi"
-              cpu: "250m"
-            limits:
-              memory: "256Mi"
-              cpu: "1000m"
+          resources: {{ postgres_init_container_resource_requirements }}
           imagePullPolicy: '{{ image_pull_policy }}'
           command:
             - /bin/sh

--- a/roles/installer/templates/postgres.yaml.j2
+++ b/roles/installer/templates/postgres.yaml.j2
@@ -37,6 +37,26 @@ spec:
       imagePullSecrets:
         - name: {{ image_pull_secret }}
 {% endif %}
+      initContainers:
+        - name: database-check
+          image: '{{ _init_container_image }}'
+          resources:
+            requests:
+              memory: "64Mi"
+              cpu: "250m"
+            limits:
+              memory: "256Mi"
+              cpu: "1000m"
+          imagePullPolicy: '{{ image_pull_policy }}'
+          command:
+            - /bin/sh
+            - -c
+            - |
+              [[ -d /check-db/pgsql/data ]] && rm -rf /check-db/data && mv /check-db/pgsql/data/ /check-db/data/ && rm -rf /check-db/pgsql || exit 0
+          volumeMounts:
+            - name: postgres
+              mountPath: /check-db
+              subPath: ''
       containers:
         - image: '{{ _postgres_image }}'
           imagePullPolicy: '{{ image_pull_policy }}'


### PR DESCRIPTION
Fixes Issue: https://github.com/ansible/awx-operator/issues/802

This avoids issues with multple initContainers trying to mount the postgres pvc at once, as is the case when there are multiple replicas.  Instead of mounting the initContainer and running the check on the deployment config, it is now run on the postgres StatefulSet, and therefore will only be run once per deployment.