### PR TITLE
added support for pod annotations to awx deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -574,6 +574,7 @@ The ability to specify topologySpreadConstraints is also allowed through `topolo
 | node_selector                  | AWX pods' nodeSelector                   | ''      |
 | topology_spread_constraints    | AWX pods' topologySpreadConstraints      | ''      |
 | tolerations                    | AWX pods' tolerations                    | ''      |
+| annotations                    | AWX pods' annotations                    | ''      |
 | postgres_selector              | Postgres pods' nodeSelector              | ''      |
 | postgres_tolerations           | Postgres pods' tolerations               | ''      |
 

--- a/config/crd/bases/awx.ansible.com_awxs.yaml
+++ b/config/crd/bases/awx.ansible.com_awxs.yaml
@@ -140,6 +140,9 @@ spec:
                 service_labels:
                   description: Additional labels to apply to the service
                   type: string
+                annotations:
+                  description: annotations for the pods
+                  type: string
                 tolerations:
                   description: node tolerations for the pods
                   type: string

--- a/config/manifests/bases/olm-parameters.yaml
+++ b/config/manifests/bases/olm-parameters.yaml
@@ -527,6 +527,11 @@
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:text
         - urn:alm:descriptor:com.tectonic.ui:hidden
+    - displayName: Annotations
+      path: annotations
+      x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:hidden
     - displayName: Tolerations
       path: tolerations
       x-descriptors:

--- a/roles/installer/defaults/main.yml
+++ b/roles/installer/defaults/main.yml
@@ -83,6 +83,12 @@ topology_spread_constraints: ''
 #     effect: "NoSchedule"
 tolerations: ''
 
+# Add annotations to awx pods. Specify as literal block. E.g.:
+# annotations: |
+#   my.annotation/1: value
+#   my.annotation/2: value2
+annotations: ''
+
 admin_user: admin
 admin_email: test@example.com
 

--- a/roles/installer/templates/deployment.yaml.j2
+++ b/roles/installer/templates/deployment.yaml.j2
@@ -27,6 +27,10 @@ spec:
         app.kubernetes.io/part-of: '{{ ansible_operator_meta.name }}'
         app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
         app.kubernetes.io/component: '{{ deployment_type }}'
+{% if annotations %}
+      annotations:
+        {{ annotations | indent(width=8) }}
+{% endif %}
     spec:
       serviceAccountName: '{{ ansible_operator_meta.name }}'
 {% if image_pull_secret %}


### PR DESCRIPTION
Hello,

I recently came across a use case where I needed pod annotations on my awx deployment.
I made the changes in this PR, and then found the MR here which appears to have gone silent: https://github.com/ansible/awx-operator/pull/780

I modeled by change here after the tolerations parameter, if needed I can change this to pod_annotations as requested in the other PR, though initially this made more sense to be to align with the tolerations param. Let me know.

Cheers :)