### PR TITLE
nodeport_port should map to nodePort

### DIFF
--- a/roles/installer/templates/service.yaml.j2
+++ b/roles/installer/templates/service.yaml.j2
@@ -18,12 +18,14 @@ metadata:
 spec:
   ports:
 {% if service_type | lower == "nodeport" %}
+  type: NodePort
     - port: 80
       protocol: TCP
       targetPort: 8052
       name: http
       nodePort: {{ nodeport_port }}
 {% elif service_type | lower == 'loadbalancer' %}
+  type: LoadBalancer
 {% if loadbalancer_protocol | lower == 'https' %}
     - port: {{ loadbalancer_port }}
       name: https
@@ -33,6 +35,13 @@ spec:
 {% endif %}
       protocol: TCP
       targetPort: 8052
+{% endif %}
+{% elif service_type | lower == 'clusterip' %}
+  type: ClusterIP
+    - port: 80
+      protocol: TCP
+      targetPort: 8052
+      name: http
 {% endif %}
 {% if ingress_type | lower == 'route' and route_tls_termination_mechanism | lower == 'passthrough' %}
     - port: 443
@@ -44,10 +53,3 @@ spec:
     app.kubernetes.io/name: '{{ ansible_operator_meta.name }}'
     app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
     app.kubernetes.io/component: '{{ deployment_type }}'
-{% if service_type | lower == "nodeport" %}
-  type: NodePort
-{% elif service_type | lower == "loadbalancer" %}
-  type: LoadBalancer
-{% else %}
-  type: ClusterIP
-{% endif %}

--- a/roles/installer/templates/service.yaml.j2
+++ b/roles/installer/templates/service.yaml.j2
@@ -17,11 +17,22 @@ metadata:
 {% endif %}
 spec:
   ports:
-{% if service_type | lower != 'loadbalancer' and loadbalancer_protocol | lower != 'https' %}
+{% if service_type | lower == "nodeport" %}
     - port: 80
       protocol: TCP
       targetPort: 8052
       name: http
+      nodePort: {{ nodeport_port }}
+{% elif service_type | lower == 'loadbalancer' %}
+{% if loadbalancer_protocol | lower == 'https' %}
+    - port: {{ loadbalancer_port }}
+      name: https
+{% else %}
+    - port: 80
+      name: http
+{% endif %}
+      protocol: TCP
+      targetPort: 8052
 {% endif %}
 {% if ingress_type | lower == 'route' and route_tls_termination_mechanism | lower == 'passthrough' %}
     - port: 443
@@ -29,28 +40,13 @@ spec:
       targetPort: 8053
       name: https
 {% endif %}
-{% if service_type | lower == 'loadbalancer' and loadbalancer_protocol | lower == 'https' %}
-    - port: {{ loadbalancer_port }}
-      protocol: TCP
-      targetPort: 8052
-      name: https
-{% elif service_type | lower == 'loadbalancer' and loadbalancer_protocol | lower != 'https' %}
-    - port: {{ loadbalancer_port }}
-      protocol: TCP
-      targetPort: 8052
-      name: http
-{% elif service_type | lower == "nodeport" %}
-    - port: {{ nodeport_port }}
-      protocol: TCP
-      targetPort: 8052
-      name: http
-  type: NodePort
-{% endif %}
   selector:
     app.kubernetes.io/name: '{{ ansible_operator_meta.name }}'
     app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
     app.kubernetes.io/component: '{{ deployment_type }}'
-{% if service_type | lower == "loadbalancer" %}
+{% if service_type | lower == "nodeport" %}
+  type: NodePort
+{% elif service_type | lower == "loadbalancer" %}
   type: LoadBalancer
 {% else %}
   type: ClusterIP


### PR DESCRIPTION
original PR https://github.com/ansible/awx-operator/pull/501

related: https://github.com/ansible/awx-operator/issues/291

The above PR sets `port` but that doesn't seem right. I think it should set `nodePort`
