### PR TITLE
fix: fix corrupted spec for the service with nodeport type (#814)

### DIFF
--- a/roles/installer/templates/service.yaml.j2
+++ b/roles/installer/templates/service.yaml.j2
@@ -17,7 +17,14 @@ metadata:
 {% endif %}
 spec:
   ports:
-{% if service_type | lower != 'loadbalancer' and loadbalancer_protocol | lower != 'https' %}
+  
+{% if service_type | lower == "nodeport" %}
+    - port: 80
+      protocol: TCP
+      targetPort: 8052
+      name: http
+      nodePort: {{ nodeport_port }}
+{% elif service_type | lower != 'loadbalancer' and loadbalancer_protocol | lower != 'https' %}
     - port: 80
       protocol: TCP
       targetPort: 8052
@@ -39,18 +46,14 @@ spec:
       protocol: TCP
       targetPort: 8052
       name: http
-{% elif service_type | lower == "nodeport" %}
-    - port: {{ nodeport_port }}
-      protocol: TCP
-      targetPort: 8052
-      name: http
-  type: NodePort
 {% endif %}
   selector:
     app.kubernetes.io/name: '{{ ansible_operator_meta.name }}'
     app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
     app.kubernetes.io/component: '{{ deployment_type }}'
-{% if service_type | lower == "loadbalancer" %}
+{% if service_type | lower == "nodeport" %}
+  type: NodePort
+{% elif service_type | lower == "loadbalancer" %}
   type: LoadBalancer
 {% else %}
   type: ClusterIP


### PR DESCRIPTION
Closes #814, closes #813, closes #504, closes #291

Tested in my K3s with values:

- `service_type: nodeport`, with/without `nodeport_port`
- `service_type: loadbalancer`
- `ingress_type: ingress`

by building new image for testing by:

```bash
# build
BUILD_ARGS="--build-arg DEFAULT_AWX_VERSION=20.0.1" \
IMAGE_TAG_BASE=registry.example.com/awx/awx-operator \
VERSION=0.19.0 make docker-build

# push
docker push registry.example.com/awx/awx-operator:0.19.0

# deploy operator
IMG=registry.example.com/awx/awx-operator:0.19.0 make deploy

# deploy awx
kubectl -n awx apply -f awx.yaml
```

