### PR TITLE
fix: add OPERATOR_VERSION as build-arg to pass the version to operator

### DIFF
--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -60,7 +60,8 @@ jobs:
       - name: Build and stage awx-operator
         working-directory: awx-operator
         run: |
-          BUILD_ARGS="--build-arg DEFAULT_AWX_VERSION=${{ github.event.inputs.default_awx_version }}" \
+          BUILD_ARGS="--build-arg DEFAULT_AWX_VERSION=${{ github.event.inputs.default_awx_version }} \
+                      --build-arg OPERATOR_VERSION=${{ github.event.inputs.version }}" \
           IMAGE_TAG_BASE=ghcr.io/${{ github.repository_owner }}/awx-operator \
           VERSION=${{ github.event.inputs.version }} make docker-build docker-push
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 FROM quay.io/operator-framework/ansible-operator:v1.12.0
 
 ARG DEFAULT_AWX_VERSION
+ARG OPERATOR_VERSION
 ENV DEFAULT_AWX_VERSION=${DEFAULT_AWX_VERSION}
+ENV OPERATOR_VERSION=${OPERATOR_VERSION}
 
 COPY requirements.yml ${HOME}/requirements.yml
 RUN ansible-galaxy collection install -r ${HOME}/requirements.yml \


### PR DESCRIPTION
Related #809.

This PR is to:

- Add `OPERATOR_VERSION` as `ENV` and `ARG` so that it can be specified through `--build-arg` as same as `DEFAULT_AWX_VERSION`
- Add `--build-arg` to specify `OPERATOR_VERSION` during `stage.yml` in GitHub Actions.

I've also made a PR ansible/awx#11880 for the similar fix to [the staging workflow in the ansible/awx repository](https://github.com/ansible/awx/blob/20.0.1/.github/workflows/stage.yml).

I have no idea if there is more prefer way, so if this PR is not appropriate and you know better method, please feel free to reject this PR. If you reject this PR, please reject the PR ansible/awx#11880 as well.

If this PR will be approved, please merge this BEFORE merging PR ansible/awx#11880.

I've tested this PR in my environment as follows:

- [New `stage.yml` works well on my repo](https://github.com/kurokobo/awx-operator/runs/5480898872?check_suite_focus=true#step:7:7)
- `OPERATOR_VERSION` is defined in the container image which built and pushed above workflow.
  ```bash
  $ docker run -it --rm --entrypoint /usr/bin/bash ghcr.io/kurokobo/awx-operator:0.19.0 -c env | grep OPERATOR_VERSION
  OPERATOR_VERSION=0.19.0
  ```
- Deploy new Operator and AWX, then ensure that the `app.kubernetes.io/operator-version` has correct value.
  ```bash
  $ IMG=ghcr.io/kurokobo/awx-operator:0.19.0 make deploy
  $ kubectl -n awx apply -f awx.yaml
  $ kubectl -n awx get deployment awx -o json | jq .metadata.labels
  {
    "app.kubernetes.io/component": "awx",
    "app.kubernetes.io/managed-by": "awx-operator",
    "app.kubernetes.io/name": "awx",
    "app.kubernetes.io/operator-version": "0.19.0",
    "app.kubernetes.io/part-of": "awx",
    "app.kubernetes.io/version": "20.0.1"
  }
  ```