### PR TITLE
Make image_version usable alone

### DIFF
--- a/roles/installer/tasks/resources_configuration.yml
+++ b/roles/installer/tasks/resources_configuration.yml
@@ -38,9 +38,8 @@
 
 - name: Set user provided awx app image
   set_fact:
-    _custom_image: "{{ image }}:{{ image_version }}"
+    _custom_image: "{{ image | default(_image) }}:{{ image_version }}"
   when:
-    - image | default([]) | length
     - image_version is defined or image_version != ''
 
 - name: Set AWX app image URL


### PR DESCRIPTION
Related to https://github.com/ansible/awx-operator/issues/805 & https://github.com/ansible/awx-operator/issues/829

With this PR you don't need to set `image:` anymore to manipulate the desired awx version with `image_version:`.