### PR TITLE
fix: add quotes for PGPASSWORD for the backup and restore roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,7 +403,7 @@ stringData:
 type: Opaque
 ```
 
-> Please ensure that the value for the variable "password" is wrapped in quotes if the password contains any special characters.
+> Please ensure that the value for the variable `password` should _not_ contain single or double quotes (`'`, `"`) or backslashes (`\`) to avoid any issues during deployment, backup or restoration.
 
 > It is possible to set a specific username, password, port, or database, but still have the database managed by the operator. In this case, when creating the postgres-configuration secret, the `type: managed` field should be added.
 

--- a/roles/backup/tasks/postgres.yml
+++ b/roles/backup/tasks/postgres.yml
@@ -99,7 +99,7 @@
     command: |
       bash -c """
       set -e -o pipefail
-      PGPASSWORD={{ awx_postgres_pass }} {{ pgdump }} > {{ backup_dir }}/tower.db
+      PGPASSWORD='{{ awx_postgres_pass }}' {{ pgdump }} > {{ backup_dir }}/tower.db
       echo 'Successful'
       """
   register: data_migration

--- a/roles/installer/tasks/migrate_data.yml
+++ b/roles/installer/tasks/migrate_data.yml
@@ -65,7 +65,7 @@
     command: |
       bash -c """
       set -e -o pipefail
-      PGPASSWORD={{ awx_old_postgres_pass }} {{ pgdump }} | PGPASSWORD={{ awx_postgres_pass }} {{ pg_restore }}
+      PGPASSWORD='{{ awx_old_postgres_pass }}' {{ pgdump }} | PGPASSWORD='{{ awx_postgres_pass }}' {{ pg_restore }}
       echo 'Successful'
       """
   no_log: true

--- a/roles/restore/tasks/postgres.yml
+++ b/roles/restore/tasks/postgres.yml
@@ -86,7 +86,7 @@
     command: |
       bash -c """
       set -e -o pipefail
-      cat {{ backup_dir }}/tower.db | PGPASSWORD={{ awx_postgres_pass }} {{ pg_restore }}
+      cat {{ backup_dir }}/tower.db | PGPASSWORD='{{ awx_postgres_pass }}' {{ pg_restore }}
       echo 'Successful'
       """
   register: data_migration


### PR DESCRIPTION
Closes #837.

- [x] Add explicit single-quotes for `PGPASSWORD` for `backup` and `restore` roles.
- [x] Clarify the restriction for the password in `README.md`

According to #187, there are some reasons to avoid using `quote` filter, so I added single-quote explicitly.

Here is the reason for the restriction for the password I added to the `README.md`:

- Double quote `"` should not be used to avoid breaking quoted strings in `credentials.py`.
- Single quote `'` should not be used to avoid breaking quoted strings in the shell command for `pg_dump`
- Backslash `\` shoutl not be used to avoid unexpected escaping and password-mismatch between python and shell.

Tested as follows:

- Build and deploy custom Operator including this PR.
  ```bash
  # Build and push custom Operator
  BUILD_ARGS="--build-arg DEFAULT_AWX_VERSION=20.0.1 \
              --build-arg OPERATOR_VERSION=0.19.0" \
  IMAGE_TAG_BASE=registry.example.com/awx/awx-operator \
  VERSION=0.19.0 make docker-build docker-push
  
  # Deploy custom Operator
  IMG=registry.example.com/awx/awx-operator:0.19.0 make deploy
  ```
- Deploy AWX with super-complicated password without quotes.
  ```bash
  $ cat <<EOF > awx.yaml
  ---
  apiVersion: awx.ansible.com/v1beta1
  kind: AWX
  metadata:
    name: awx
    namespace: awx
  spec:
    ingress_type: ingress
    hostname: awx.example.com
    postgres_configuration_secret: awx-postgres-configuration
  ---
  apiVersion: v1
  kind: Secret
  metadata:
    name: awx-postgres-configuration
    namespace: awx
  stringData:
    host: awx-postgres
    port: "5432"
    database: awx
    username: awx
    # Password contains lots of special charactors
    password: a b!c#d$e%f&g(h)i*j+k,l-m.n/o:p+q<r=s>t?u@v[w]x^y_z`a{b|c}d~e
    type: managed
  type: Opaque
  EOF
  
  $ kubectl apply -f awx.yaml
  ```
- Check the password
  ```bash
  # Ensure the password has configured as expected.
  $ kubectl -n awx exec -it deployment/awx -c awx-web -- cat /etc/tower/conf.d/credentials.py | grep PASSWORD
      'PASSWORD': "a b!c#d$e%f&g(h)i*j+k,l-m.n/o:p+q<r=s>t?u@v[w]x^y_z`a{b|c}d~e",
  
  $ kubectl -n awx exec -it statefulset/awx-postgres -c postgres -- env | grep PASSWORD
  POSTGRESQL_PASSWORD=a b!c#d$e%f&g(h)i*j+k,l-m.n/o:p+q<r=s>t?u@v[w]x^y_z`a{b|c}d~e
  POSTGRES_PASSWORD=a b!c#d$e%f&g(h)i*j+k,l-m.n/o:p+q<r=s>t?u@v[w]x^y_z`a{b|c}d~e
  ```
- Take backup
  ```bash
  $ cat <<EOF > awxbackup.yaml
  ---
  apiVersion: awx.ansible.com/v1beta1
  kind: AWXBackup
  metadata:
    name: awxbackup-2022-03-20
    namespace: awx
  spec:
    deployment_name: awx
  EOF
  
  $ kubectl apply -f awxbackup.yaml
  ```
- Wipe whole envirinment and restore from backup
  ```bash
  $ kubectl -n awx delete awx awx
  $ kubectl -n awx delete pvc postgres-awx-postgres-0
  $ kubectl -n awx delete secret awx-postgres-configuration awx-admin-password  awx-secret-key awx-broadcast-websocket
  $ cat <<EOF > awxrestore.yaml
  ---
  apiVersion: awx.ansible.com/v1beta1
  kind: AWXRestore
  metadata:
    name: awxrestore-2022-03-20
    namespace: awx
  spec:
    deployment_name: awx
    backup_pvc_namespace: awx
    backup_name: awxbackup-2022-03-20
  EOF
  
  $ kubectl apply -f awxrestore.yaml
  ```
