### PR TITLE
Add docs for proper kustomization installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,12 +117,12 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   # Find the latest tag here: https://github.com/ansible/awx-operator/releases
-  - github.com/ansible/awx-operator/config/default?ref=0.18.0
+  - github.com/ansible/awx-operator/config/default?ref=<tag>
 
 # Set the image tags to match the git version from above
 images:
   - name: quay.io/ansible/awx-operator
-    newTag: 0.18.0
+    newTag: <tag>
 
 # Specify a custom namespace in which to install AWX
 namespace: awx
@@ -184,7 +184,7 @@ Make sure to add this new file to the list of "resources" in your `kustomization
 ```yaml
 ...
 resources:
-  - github.com/ansible/awx-operator/config/default?ref=0.18.0
+  - github.com/ansible/awx-operator/config/default?ref=<tag>
   # Add this extra line:
   - awx-demo.yaml
 ...

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ $ alias kubectl="minikube kubectl --"
 
 ### Basic Install
 
-Once you have a running Kubernetes cluster, you can deploy AWX Operator into your cluster using [Kustomize](https://kubectl.docs.kubernetes.io/guides/introduction/kustomize/).
+Once you have a running Kubernetes cluster, you can deploy AWX Operator into your cluster using [Kustomize](https://kubectl.docs.kubernetes.io/guides/introduction/kustomize/). Follow the instructions here to install the latest version of Kustomize: https://kubectl.docs.kubernetes.io/installation/kustomize/
 
 First, create a file called `kustomization.yaml` with the following content:
 
@@ -165,7 +165,7 @@ So we don't have to keep repeating `-n awx`, let's set the current namespace for
 $ kubectl config set-context --current --namespace=awx
 ```
 
-Next, create a file named `awx-demo.yml` in the same folder with the suggested content below. The `metadata.name` you provide will be the name of the resulting AWX deployment.
+Next, create a file named `awx-demo.yaml` in the same folder with the suggested content below. The `metadata.name` you provide will be the name of the resulting AWX deployment.
 
 **Note:** If you deploy more than one AWX instance to the same namespace, be sure to use unique names.
 


### PR DESCRIPTION
Closes #840 

This PR adds documentation for installing awx-operator natively with Kustomize, rather than requireing the user to clone the repo. This way, users can provide their own patches and additional resources on top of the base resources.

I also regenerated the table of contents and added a comment telling users how to regenerate it like #793 found.