### PR TITLE
reording the django tasks to avoid race condition aap-2847

### DIFF
--- a/roles/installer/tasks/initialize_django.yml
+++ b/roles/installer/tasks/initialize_django.yml
@@ -118,3 +118,4 @@
   register: cdo
   changed_when: "'added' in cdo.stdout"
   when: create_preload_data | bool
+  

--- a/roles/installer/tasks/initialize_django.yml
+++ b/roles/installer/tasks/initialize_django.yml
@@ -118,4 +118,3 @@
   register: cdo
   changed_when: "'added' in cdo.stdout"
   when: create_preload_data | bool
-  

--- a/roles/installer/tasks/initialize_django.yml
+++ b/roles/installer/tasks/initialize_django.yml
@@ -37,17 +37,6 @@
   no_log: true
   when: users_result.return_code > 0
 
-- name: Create preload data if necessary.  # noqa 305
-  k8s_exec:
-    namespace: "{{ ansible_operator_meta.namespace }}"
-    pod: "{{ tower_pod_name }}"
-    container: "{{ ansible_operator_meta.name }}-task"
-    command: >-
-      bash -c "awx-manage create_preload_data"
-  register: cdo
-  changed_when: "'added' in cdo.stdout"
-  when: create_preload_data | bool
-
 - name: Check if legacy queue is present
   k8s_exec:
     namespace: "{{ ansible_operator_meta.namespace }}"
@@ -118,3 +107,14 @@
       changed_when: "'changed: True' in ree.stdout"
       no_log: true
   when: _execution_environments_pull_credentials['resources'] | default([]) | length
+
+- name: Create preload data if necessary.  # noqa 305
+  k8s_exec:
+    namespace: "{{ ansible_operator_meta.namespace }}"
+    pod: "{{ tower_pod_name }}"
+    container: "{{ ansible_operator_meta.name }}-task"
+    command: >-
+      bash -c "awx-manage create_preload_data"
+  register: cdo
+  changed_when: "'added' in cdo.stdout"
+  when: create_preload_data | bool


### PR DESCRIPTION
trying to squash a weird race in which the initial project sync fails due to no Execution environments:

'The project could not sync because there is no Execution Environment.'