### PR TITLE
Wait for the postgres pod to enter the ready state before continuing

### DIFF
--- a/roles/backup/tasks/postgres.yml
+++ b/roles/backup/tasks/postgres.yml
@@ -39,6 +39,7 @@
       until:
         - "postgres_pod['resources'] | length"
         - "postgres_pod['resources'][0]['status']['phase'] == 'Running'"
+        - "postgres_pod['resources'][0]['status']['containerStatuses'][0]['ready'] == true"
       delay: 5
       retries: 60
 

--- a/roles/installer/tasks/database_configuration.yml
+++ b/roles/installer/tasks/database_configuration.yml
@@ -153,6 +153,7 @@
   until:
     - "postgres_pod['resources'] | length"
     - "postgres_pod['resources'][0]['status']['phase'] == 'Running'"
+    - "postgres_pod['resources'][0]['status']['containerStatuses'][0]['ready'] == true"
   delay: 5
   retries: 60
   when: pg_config['resources'][0]['data']['type'] | default('') | b64decode == 'managed'

--- a/roles/installer/tasks/migrate_data.yml
+++ b/roles/installer/tasks/migrate_data.yml
@@ -29,6 +29,7 @@
   until:
     - "postgres_pod['resources'] | length"
     - "postgres_pod['resources'][0]['status']['phase'] == 'Running'"
+    - "postgres_pod['resources'][0]['status']['containerStatuses'][0]['ready'] == true"
   delay: 5
   retries: 60
 

--- a/roles/restore/tasks/postgres.yml
+++ b/roles/restore/tasks/postgres.yml
@@ -37,6 +37,7 @@
   until:
     - "postgres_pod['resources'] | length"
     - "postgres_pod['resources'][0]['status']['phase'] == 'Running'"
+    - "postgres_pod['resources'][0]['status']['containerStatuses'][0]['ready'] == true"
   delay: 5
   retries: 60
 


### PR DESCRIPTION
We added an initContainer for the postgres pod to help with an upgrade bug.  Unfortunately the initContainer makes the postgres pod take longer to initialize.  As a result, is some scenarios, it is possible that the postgres pod will not be up by the time the web and task containers come online.  

The symptoms of this bug are that the containers appear to be running, but requests in the browser to the UI return 404's.  This is because the launch_awx.sh entrypoint script which copies over the static files for nginx fails before it gets to that step because it cannot reach the database.  Unfortunately, it does not recover and the user must manually scale their deployment to 0, and back up to 1 to resolve the issue.  

This patch waits until the postgres pod is in the "ready" state before proceeding and applying the deployment config (which starts the containers).  