### PR TITLE
Check if image_pull_secrets variable is defined

### DIFF
--- a/roles/backup/tasks/secrets.yml
+++ b/roles/backup/tasks/secrets.yml
@@ -26,13 +26,15 @@
 # image_pull_secret is deprecated in favor of image_pull_secrets
 - name: Dump image_pull_secret into file
   include_tasks: dump_secret.yml
-  loop:
+  with_items:
     - image_pull_secret
   when: image_pull_secret is defined
 
 - name: Dump image_pull_secrets into file
   include_tasks: dump_secret.yml
-  loop: "{{ awx_spec.spec[image_pull_secrets] }}"
+  with_items:
+    - image_pull_secrets
+  when: image_pull_secrets | default([]) | length
 
 - name: Nest secrets under a single variable
   set_fact:


### PR DESCRIPTION
  * Do not attempt to backup secret if none are defined

This is the PR that introduced the issue: https://github.com/ansible/awx-operator/pull/860