### PR TITLE
Fix namespace name in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Install the manifests by running this:
 
 ```
 $ kustomize build . | kubectl apply -f -
-namespace/machaffe created
+namespace/awx created
 customresourcedefinition.apiextensions.k8s.io/awxbackups.awx.ansible.com created
 customresourcedefinition.apiextensions.k8s.io/awxrestores.awx.ansible.com created
 customresourcedefinition.apiextensions.k8s.io/awxs.awx.ansible.com created


### PR DESCRIPTION
I copy/pasted the command output for the kustomize install but forgot that I had been using a different namespace than then one in the kustomization.yaml file example.