### PR TITLE
Add back image_pull_secret field for backwards compatibility

### DIFF
--- a/config/crd/bases/awx.ansible.com_awxs.yaml
+++ b/config/crd/bases/awx.ansible.com_awxs.yaml
@@ -180,10 +180,13 @@ spec:
                     - IfNotPresent
                     - ifnotpresent
                 image_pull_secrets:
-                  description: The image pull secrets
+                  description: Image pull secrets for app and database containers
                   type: array
                   items:
                     type: string
+                image_pull_secret: # deprecated
+                  description: (Deprecated) Image pull secret for app and database containers
+                  type: string
                 task_resource_requirements:
                   description: Resource requirements for the task container
                   properties:


### PR DESCRIPTION
https://github.com/ansible/awx-operator/pull/860 introduced a new field (`image_pull_secrets`) which allows users to specify multiple pull secrets if needed for app and database container images.  The old field on the CRD (`image_pull_secret`) was removed at that time.  

This patch adds that back for backwards compatibility.  Without this change, users who specify it the old way will be met with a validator error when applying the AWX CR.  

The new syntax that should be used is:

```
---
apiVersion: awx.ansible.com/v1beta1
kind: AWX
metadata:
  name: awx
spec:
  image_pull_secrets:
    - pull-secret
 ```