### PR TITLE
Stop updating the admin user password

### DIFF
--- a/roles/installer/tasks/initialize_django.yml
+++ b/roles/installer/tasks/initialize_django.yml
@@ -13,18 +13,6 @@
   register: users_result
   changed_when: users_result.return_code > 0
 
-- name: Update super user password via Django if it does exist (same password is a noop)
-  k8s_exec:
-    namespace: "{{ ansible_operator_meta.namespace }}"
-    pod: "{{ tower_pod_name }}"
-    container: "{{ ansible_operator_meta.name }}-task"
-    command: >-
-      bash -c "awx-manage update_password --username '{{ admin_user }}' --password '{{ admin_password }}'"
-  register: update_pw_result
-  changed_when: users_result.stdout == 'Password not updated'
-  no_log: true
-  when: users_result.return_code == 0
-
 - name: Create super user via Django if it doesn't exist.
   k8s_exec:
     namespace: "{{ ansible_operator_meta.namespace }}"


### PR DESCRIPTION
Related Issue: https://github.com/ansible/awx-operator/issues/869

  * This is overwriting changes the user makes to the admin password via
    the app itself

This is undesirable because a user may want to change the admin password for security reasons, but currently it would be reset to the value in the awx-admin-password secret upon the next reconcilation loop.  