### PR TITLE
Add default resource requests for postgres containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,14 +434,14 @@ If you don't have access to an external PostgreSQL service, the AWX operator can
 
 The following variables are customizable for the managed PostgreSQL service
 
-| Name                                          | Description                                   | Default                           |
-| --------------------------------------------- | --------------------------------------------- | --------------------------------- |
-| postgres_image                                | Path of the image to pull                     | postgres:12                       |
-| postgres_init_container_resource_requirements | Database init container resource requirements | requests: {}                      |
-| postgres_resource_requirements                | PostgreSQL container resource requirements    | requests: {}                      |
-| postgres_storage_requirements                 | PostgreSQL container storage requirements     | requests: {storage: 8Gi}          |
-| postgres_storage_class                        | PostgreSQL PV storage class                   | Empty string                      |
-| postgres_data_path                            | PostgreSQL data path                          | `/var/lib/postgresql/data/pgdata` |
+| Name                                          | Description                                   | Default                            |
+| --------------------------------------------- | --------------------------------------------- | ---------------------------------- |
+| postgres_image                                | Path of the image to pull                     | postgres:12                        |
+| postgres_init_container_resource_requirements | Database init container resource requirements | requests: {cpu: 10m, memory: 64Mi} |
+| postgres_resource_requirements                | PostgreSQL container resource requirements    | requests: {cpu: 10m, memory: 64Mi} |
+| postgres_storage_requirements                 | PostgreSQL container storage requirements     | requests: {storage: 8Gi}           |
+| postgres_storage_class                        | PostgreSQL PV storage class                   | Empty string                       |
+| postgres_data_path                            | PostgreSQL data path                          | `/var/lib/postgresql/data/pgdata`  |
 
 Example of customization could be:
 
@@ -541,11 +541,11 @@ Again, this is the most relaxed SCC that is provided by OpenShift, so be sure to
 
 The resource requirements for both, the task and the web containers are configurable - both the lower end (requests) and the upper end (limits).
 
-| Name                       | Description                                      | Default                             |
-| -------------------------- | ------------------------------------------------ | ----------------------------------- |
-| web_resource_requirements  | Web container resource requirements              | requests: {cpu: 1000m, memory: 2Gi} |
-| task_resource_requirements | Task container resource requirements             | requests: {cpu: 500m, memory: 1Gi}  |
-| ee_resource_requirements   | EE control plane container resource requirements | requests: {cpu: 500m, memory: 1Gi}  |
+| Name                       | Description                                      | Default                              |
+| -------------------------- | ------------------------------------------------ | ------------------------------------ |
+| web_resource_requirements  | Web container resource requirements              | requests: {cpu: 100m, memory: 128Mi} |
+| task_resource_requirements | Task container resource requirements             | requests: {cpu: 100m, memory: 128Mi} |
+| ee_resource_requirements   | EE control plane container resource requirements | requests: {cpu: 100m, memory: 128Mi} |
 
 Example of customization could be:
 
@@ -555,24 +555,24 @@ spec:
   ...
   web_resource_requirements:
     requests:
-      cpu: 1000m
+      cpu: 250m
       memory: 2Gi
     limits:
-      cpu: 2000m
+      cpu: 1000m
       memory: 4Gi
   task_resource_requirements:
     requests:
-      cpu: 500m
+      cpu: 250m
       memory: 1Gi
     limits:
-      cpu: 1000m
+      cpu: 2000m
       memory: 2Gi
   ee_resource_requirements:
     requests:
-      cpu: 500m
-      memory: 1Gi
+      cpu: 250m
+      memory: 100Mi
     limits:
-      cpu: 1000m
+      cpu: 500m
       memory: 2Gi
 ```
 

--- a/roles/installer/defaults/main.yml
+++ b/roles/installer/defaults/main.yml
@@ -169,18 +169,18 @@ web_command: []
 
 task_resource_requirements:
   requests:
-    cpu: 500m
-    memory: 1Gi
+    cpu: 100m
+    memory: 128Mi
 
 web_resource_requirements:
   requests:
-    cpu: 1000m
-    memory: 2Gi
+    cpu: 100m
+    memory: 128Mi
 
 ee_resource_requirements:
   requests:
-    cpu: 500m
-    memory: 1Gi
+    cpu: 100m
+    memory: 64Mi
 
 # Customize CSRF options
 csrf_cookie_secure: False
@@ -226,8 +226,14 @@ postgres_tolerations: ''
 postgres_storage_requirements:
   requests:
     storage: 8Gi
-postgres_init_container_resource_requirements: {}
-postgres_resource_requirements: {}
+postgres_resource_requirements:
+  requests:
+    cpu: 10m
+    memory: 64Mi
+postgres_init_container_resource_requirements:
+  requests:
+    cpu: 10m
+    memory: 64Mi
 postgres_data_path: '/var/lib/postgresql/data/pgdata'
 
 # Persistence to the AWX project data folder


### PR DESCRIPTION
### Background

When deploying the awx-operator on some cloud providers, we noticed that sometimes the UI doesn't load properly, evidenced by 404's for assets and a blank page in the UI.  What was happening is that the web container came up before the postgresql container was completely set up.  This was partially resolved by adding a more specific check for the ready status of the postgresql container in another PR.  But this problem was also seen as a result of the resource requests not being set for the postgresql containers.  

On resource constrained clusters, k8s will give priority to containers that have explicitly requested resources.  Containers that don't get squeezed, which means the container may not have enough resources to process requests, or may be terminated.  

### Solution

This PR also lowers the default requests for the other awx containers.  This is because if the cluster does not have enough resources to satisfy the requests of all of the containers in a deployment, not all of the pods will be scheduled.  Prior to this PR, our requests were unnecessarily high.

### Additional Info

These changes were based on these k8s docs: https://cloud.google.com/blog/products/containers-kubernetes/kubernetes-best-practices-resource-requests-and-limits