### PR TITLE
Restore not managed external postgresql

### DIFF
--- a/roles/restore/tasks/postgres.yml
+++ b/roles/restore/tasks/postgres.yml
@@ -27,24 +27,26 @@
     postgres_label_selector: "app.kubernetes.io/instance=postgres-{{ deployment_name }}"
   when: postgres_label_selector is not defined
 
-- name: Get the postgres pod information
-  k8s_info:
-    kind: Pod
-    namespace: '{{ ansible_operator_meta.namespace }}'
-    label_selectors:
-      - "{{ postgres_label_selector }}"
-  register: postgres_pod
-  until:
-    - "postgres_pod['resources'] | length"
-    - "postgres_pod['resources'][0]['status']['phase'] == 'Running'"
-    - "postgres_pod['resources'][0]['status']['containerStatuses'][0]['ready'] == true"
-  delay: 5
-  retries: 60
+- block:
+  - name: Get the postgres pod information
+    k8s_info:
+      kind: Pod
+      namespace: '{{ ansible_operator_meta.namespace }}'
+      label_selectors:
+        - "{{ postgres_label_selector }}"
+    register: postgres_pod
+    until:
+      - "postgres_pod['resources'] | length"
+      - "postgres_pod['resources'][0]['status']['phase'] == 'Running'"
+      - "postgres_pod['resources'][0]['status']['containerStatuses'][0]['ready'] == true"
+    delay: 5
+    retries: 60
 
-- name: Set the resource pod name as a variable.
-  set_fact:
-    postgres_pod_name: "{{ postgres_pod['resources'][0]['metadata']['name'] }}"
-
+  - name: Set the resource pod name as a variable.
+    set_fact:
+      postgres_pod_name: "{{ postgres_pod['resources'][0]['metadata']['name'] }}"
+ when: awx_postgres_type == 'managed'
+ 
 - name: Check for presence of AWX Deployment
   k8s_info:
     api_version: v1

--- a/roles/restore/tasks/postgres.yml
+++ b/roles/restore/tasks/postgres.yml
@@ -28,24 +28,23 @@
   when: postgres_label_selector is not defined
 
 - block:
-  - name: Get the postgres pod information
-    k8s_info:
-      kind: Pod
-      namespace: '{{ ansible_operator_meta.namespace }}'
-      label_selectors:
-        - "{{ postgres_label_selector }}"
-    register: postgres_pod
-    until:
-      - "postgres_pod['resources'] | length"
-      - "postgres_pod['resources'][0]['status']['phase'] == 'Running'"
-      - "postgres_pod['resources'][0]['status']['containerStatuses'][0]['ready'] == true"
-    delay: 5
-    retries: 60
-
-  - name: Set the resource pod name as a variable.
-    set_fact:
-      postgres_pod_name: "{{ postgres_pod['resources'][0]['metadata']['name'] }}"
- when: awx_postgres_type == 'managed'
+    - name: Get the postgres pod information
+      k8s_info:
+        kind: Pod
+        namespace: '{{ ansible_operator_meta.namespace }}'
+        label_selectors:
+          - "{{ postgres_label_selector }}"
+      register: postgres_pod
+      until:
+        - "postgres_pod['resources'] | length"
+        - "postgres_pod['resources'][0]['status']['phase'] == 'Running'"
+        - "postgres_pod['resources'][0]['status']['containerStatuses'][0]['ready'] == true"
+      delay: 5
+      retries: 60
+    - name: Set the resource pod name as a variable.
+      set_fact:
+        postgres_pod_name: "{{ postgres_pod['resources'][0]['metadata']['name'] }}"
+  when: awx_postgres_type == 'managed'
  
 - name: Check for presence of AWX Deployment
   k8s_info:

--- a/roles/restore/tasks/postgres.yml
+++ b/roles/restore/tasks/postgres.yml
@@ -45,7 +45,7 @@
       set_fact:
         postgres_pod_name: "{{ postgres_pod['resources'][0]['metadata']['name'] }}"
   when: awx_postgres_type == 'managed'
- 
+
 - name: Check for presence of AWX Deployment
   k8s_info:
     api_version: v1


### PR DESCRIPTION
Update postgres.yml for restore from backup not managed external postgresql db.
Current role version always failed on step [Get the postgres pod information], because pod does't exist. But backup role make it success with awx_postgres_type condition.