### PR TITLE
Render cookie settings as a boolean

### DIFF
--- a/roles/installer/templates/config.yaml.j2
+++ b/roles/installer/templates/config.yaml.j2
@@ -60,8 +60,8 @@ data:
     CLUSTER_HOST_ID = socket.gethostname()
     SYSTEM_UUID = os.environ.get('MY_POD_UID', '00000000-0000-0000-0000-000000000000')
     
-    CSRF_COOKIE_SECURE = '{{ csrf_cookie_secure }}'
-    SESSION_COOKIE_SECURE = '{{ session_cookie_secure }}'
+    CSRF_COOKIE_SECURE = {{ csrf_cookie_secure | bool }}
+    SESSION_COOKIE_SECURE = {{ session_cookie_secure | bool }}
     
     SERVER_EMAIL = 'root@localhost'
     DEFAULT_FROM_EMAIL = 'webmaster@localhost'


### PR DESCRIPTION
these values are being rendered as strings, and django is recognizing them as strings

```
>>> settings.SESSION_COOKIE_SECURE
'False'
>>> type(settings.SESSION_COOKIE_SECURE)
<class 'str'>
```

should be rendered as booleans

This was causing problems when trying to log into app, `Forbidden (CSRF cookie not set.)`