### PR TITLE
Expect pull secret for some environments

### DIFF
--- a/roles/installer/tasks/main.yml
+++ b/roles/installer/tasks/main.yml
@@ -17,6 +17,9 @@
           app.kubernetes.io/component: '{{ deployment_type }}'
           app.kubernetes.io/operator-version: '{{ lookup("env", "OPERATOR_VERSION") }}'
 
+- name: Patch default pull secret to operator ServiceAccount (Upstream)
+  include_tasks: patch_service_account.yml
+
 - name: Include secret key configuration tasks
   include_tasks: secret_key_configuration.yml
 

--- a/roles/installer/tasks/patch_service_account.yml
+++ b/roles/installer/tasks/patch_service_account.yml
@@ -1,0 +1,42 @@
+---
+- name: Patch default pull secret to operator ServiceAccount (Upstream)
+  block:
+    - name: Check for existing operator SA
+      k8s_info:
+        kind: ServiceAccount
+        namespace: '{{ ansible_operator_meta.namespace }}'
+        name: '{{ _sa_prefix }}-controller-manager'
+      vars:
+        _sa_prefix: awx-operator
+      register: _sa_exists
+      no_log: true
+
+    - name: Patch SA with image pull secret default
+      k8s:
+        apply: yes
+        definition: "{{ lookup('template', 'patch_operator_service_account.yml') }}"
+        wait: yes
+      vars:
+        _sa_prefix: awx-operator
+      when: _sa_exists['resources'] | length
+
+- name: Patch default pull secret to operator ServiceAccount (Downstream)
+  block:
+    - name: Check for existing operator SA
+      k8s_info:
+        kind: ServiceAccount
+        namespace: '{{ ansible_operator_meta.namespace }}'
+        name: '{{ _sa_prefix }}-controller-manager'
+      vars:
+        _sa_prefix: automation-controller-operator
+      register: _sa_exists
+      no_log: true
+
+    - name: Patch SA with image pull secret default
+      k8s:
+        apply: yes
+        definition: "{{ lookup('template', 'patch_operator_service_account.yml') }}"
+        wait: yes
+      vars:
+        _sa_prefix: automation-controller-operator
+      when: _sa_exists['resources'] | length

--- a/roles/installer/templates/patch_operator_service_account.yml
+++ b/roles/installer/templates/patch_operator_service_account.yml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: "{{ _sa_prefix }}-controller-manager"
+  namespace: "{{ ansible_operator_meta.namespace }}"
+imagePullSecrets:
+  - name: deployment-pull-secret


### PR DESCRIPTION
Some environments require pull secrets for operand containers.  The pull secret needs to be added to the Service Account of the operator pulling those operand container images.  

Unfortunately, adding the pull secret to service_account.yaml is not sufficient because the image pull secret gets lost when generating the CSV.  As a result, I have devised this hack as a work around.  The pull secrets will be patched to the SA in the reconciliation loop for the AWX CR before the images are pulled.  

With this change, it will be possible to pre-create a secret called `deployment-pull-secret` that will be automatically attached to the operator SA.  