### PR TITLE
Adding option to enable a websocket listener

### DIFF
--- a/roles/installer/defaults/main.yml
+++ b/roles/installer/defaults/main.yml
@@ -275,3 +275,8 @@ garbage_collect_secrets: false
 development_mode: false
 
 security_context_settings: {}
+
+# Enable a websocket listener on the awx-task container
+websocket_listener_enable: false
+# Websocket listener port
+websocket_listener_port: 8080

--- a/roles/installer/templates/config.yaml.j2
+++ b/roles/installer/templates/config.yaml.j2
@@ -249,7 +249,12 @@ data:
         filename: /var/run/receptor/receptor.sock
         permissions: 0660
 
+    {% if websocket_listener_enable %}    
+    - ws-listener:
+        port: {{ websocket_listener_port }}
+    {% else %}
     - local-only:
+    {% endif %}
 
     - work-command:
         worktype: local

--- a/roles/installer/templates/deployment.yaml.j2
+++ b/roles/installer/templates/deployment.yaml.j2
@@ -194,6 +194,10 @@ spec:
         - image: '{{ _image }}'
           name: '{{ ansible_operator_meta.name }}-task'
           imagePullPolicy: '{{ image_pull_policy }}'
+{% if websocket_listener_enable %}
+          ports:
+            - containerPort: {{ websocket_listener_port }}
+{% endif %}
 {% if task_privileged == true %}
           securityContext:
             privileged: true

--- a/roles/installer/templates/service.yaml.j2
+++ b/roles/installer/templates/service.yaml.j2
@@ -16,8 +16,7 @@ metadata:
     {{ service_annotations | indent(width=4) }}
 {% endif %}
 spec:
-  ports:
-  
+  ports:  
 {% if service_type | lower == "nodeport" %}
     - port: 80
       protocol: TCP
@@ -46,6 +45,12 @@ spec:
       protocol: TCP
       targetPort: 8052
       name: http
+{% endif %}
+{% if websocket_listener_enable %}
+    - port: {{ websocket_listener_port }}
+      protocol: TCP
+      targetPort: {{ websocket_listener_port }}
+      name: ws-listener
 {% endif %}
   selector:
     app.kubernetes.io/name: '{{ ansible_operator_meta.name }}'


### PR DESCRIPTION
This is a simple way to add a websocket listener to the AWX deployment.  Doing so will allow for the introduction of remote execution nodes.

related #634 

There are a couple of questions that need to be addressed...
- Should it be possible to expose any type of listener (TCP / UDP / websocket)?  Websocket is simplest because it can be handled most easily by an ingress controller.  Should this PR also handle the other two cases?
- How should the ingress for the websocket be provided?  In my testing, I created an additional Ingress object to handle connections.  Should an additional ingress template be added to the repo?  Or should the websocket port be available through the primary ingress?
- Do the field names follow convention?  i.e. I wasn't sure whether to name the field _enable or _enabled. 