### PR TITLE
Look for a specific pull secret for certain scenarios

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -55,4 +55,6 @@ spec:
             initialDelaySeconds: 5
             periodSeconds: 10
       serviceAccountName: controller-manager
+      imagePullSecrets:
+        - name: ansible-deployment-pull-secret
       terminationGracePeriodSeconds: 10


### PR DESCRIPTION
### Summary

There are some scenarios in certain cloud deployments that require us to provide a pull secret for the operator containers.  It is not possible to do this on the service account for the operators before installing the operator, but we can do it on the deployment for the operator container and it will be propagated into the CSV and deploy propely via OLM. 

With this PR, users can now pre-seed a pull secret named `deployment-pull-secret` in the namespace they wish to deploy in and it will be used by the operator deployment automatically.  


After deploying, I see the pull secret added on the deployment for the operator and kube-rbac-proxy containers:

```
$ oc get deployment awx-operator-controller-manager -o yaml | grep imagePullSecrets: -A1
            f:imagePullSecrets:
              .: {}
--
      imagePullSecrets:
      - name: deployment-pull-secret
```

### Testing

To test this, I:
1. created a bundle, catalog, and catalogsource and applied the catalogsource to my cluster.  
2. installed the awx-operator from OperatorHub on Openshift
3. inspected the deployment to see that the pull secret was added
4. observed that the operator image gets pulled successfully and the deployment suceeds
5. did steps 1-5 with and without the `deployment-pull-secret` actually present in that namespace.  