### PR TITLE
Added basic liveness- & readinessProbe for awx-web & awx-task containers

### DIFF
--- a/roles/installer/tasks/install.yml
+++ b/roles/installer/tasks/install.yml
@@ -56,28 +56,6 @@
 - name: Include resources configuration tasks
   include_tasks: resources_configuration.yml
 
-- name: Check for pending migrations
-  k8s_exec:
-    namespace: "{{ ansible_operator_meta.namespace }}"
-    pod: "{{ tower_pod_name }}"
-    container: "{{ ansible_operator_meta.name }}-task"
-    command: >-
-      bash -c "awx-manage showmigrations | grep -v '[X]' | grep '[ ]' | wc -l"
-  changed_when: false
-  register: database_check
-
-- name: Migrate the database if the K8s resources were updated.  # noqa 305
-  k8s_exec:
-    namespace: "{{ ansible_operator_meta.namespace }}"
-    pod: "{{ tower_pod_name }}"
-    container: "{{ ansible_operator_meta.name }}-task"
-    command: >-
-      bash -c "awx-manage migrate --noinput"
-  register: migrate_result
-  when:
-    - database_check is defined
-    - (database_check.stdout|trim) != '0'
-
 - name: Initialize Django
   include_tasks: initialize_django.yml
 

--- a/roles/installer/tasks/resources_configuration.yml
+++ b/roles/installer/tasks/resources_configuration.yml
@@ -77,6 +77,7 @@
     apply: yes
     definition: "{{ lookup('template', 'deployment.yaml.j2') }}"
     wait: yes
+    wait_timeout: 600
   register: tower_deployment_result
 
 - block:

--- a/roles/installer/templates/deployment.yaml.j2
+++ b/roles/installer/templates/deployment.yaml.j2
@@ -82,6 +82,56 @@ spec:
             {{ init_container_extra_volume_mounts | indent(width=12, indentfirst=True) }}
 {% endif %}
 {% endif %}
+        - name: 'database-migration'
+          image: '{{ _image }}'
+          imagePullPolicy: '{{ image_pull_policy }}'
+          command:
+            - '/bin/sh'
+          args:
+            - '-c'
+            - '/usr/bin/awx-manage migrate --no-input || /usr/local/bin/wait-for-migrations'
+          volumeMounts:
+{% if bundle_ca_crt %}
+            - name: "ca-trust-extracted"
+              mountPath: "/etc/pki/ca-trust/extracted"
+            - name: "{{ ansible_operator_meta.name }}-bundle-cacert"
+              mountPath: /etc/pki/ca-trust/source/anchors/bundle-ca.crt
+              subPath: bundle-ca.crt
+              readOnly: true
+{% endif %}
+            - name: "{{ ansible_operator_meta.name }}-application-credentials"
+              mountPath: "/etc/tower/conf.d/credentials.py"
+              subPath: credentials.py
+              readOnly: true
+            - name: "{{ secret_key_secret_name }}"
+              mountPath: /etc/tower/SECRET_KEY
+              subPath: SECRET_KEY
+              readOnly: true
+            - name: {{ ansible_operator_meta.name }}-settings
+              mountPath: /etc/tower/settings.py
+              subPath: settings.py
+              readOnly: true
+{% if development_mode | bool %}
+            - name: awx-devel
+              mountPath: "/awx_devel"
+{% endif %}
+          env:
+            - name: MY_POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: MY_POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+{% if development_mode | bool %}
+            - name: AWX_KUBE_DEVEL
+              value: "1"
+{% endif %}
       containers:
         - image: '{{ _redis_image }}'
           imagePullPolicy: '{{ image_pull_policy }}'
@@ -111,6 +161,17 @@ spec:
           args: {{ web_args }}
 {% endif %}
           imagePullPolicy: '{{ image_pull_policy }}'
+          livenessProbe:
+            httpGet:
+              path: /api/v2/ping/
+              port: 8052
+            initialDelaySeconds: 90
+            timeoutSeconds: 2
+          readinessProbe:
+            httpGet:
+              path: /api/v2/ping/
+              port: 8052
+            timeoutSeconds: 2
           ports:
             - containerPort: 8052
 {% if ingress_type | lower == 'route' and route_tls_termination_mechanism | lower == 'passthrough' %}
@@ -195,6 +256,12 @@ spec:
         - image: '{{ _image }}'
           name: '{{ ansible_operator_meta.name }}-task'
           imagePullPolicy: '{{ image_pull_policy }}'
+          readinessProbe:
+            exec:
+              command:
+              - /usr/bin/awx-manage
+              - check
+            timeoutSeconds: 10
 {% if task_privileged == true %}
           securityContext:
             privileged: true
@@ -260,8 +327,6 @@ spec:
           env:
             - name: SUPERVISOR_WEB_CONFIG_PATH
               value: "/etc/supervisord.conf"
-            - name: AWX_SKIP_MIGRATIONS
-              value: "1"
             - name: MY_POD_UID
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
Adds basic livenessProbe & readinessProbe for containers web & task.
See issue #926 for background on this.

Removes env var `AWX_SKIP_MIGRATIONS` as it was removed in AWX 18.0.0 version of launch scripts and is not used anymore.

As discussed in this PR:
Adds initContainer `database-migration` that applies migrations or waits if migrations are being applied. This way no launch script can interfere and no AWX pod can come online without having migrations already applied and being unavailable.
Removes `awx-operator`-based db migration handling in installer, as at this point containers already did the job.
As a cause of this, `wait_timeout` had to be increased in installer for the AWX pods deployment to adhere for longer initial startup time of AWX pods when a lot/all migrations have to be applied.
I've copied ca-volume-mounts from web & task containers to this new initContainer as well, as these may be required depending on the SSL certificate being used on a (external) database host.