### PR TITLE
installer: fix undefined limit key in config

### DIFF
--- a/roles/installer/templates/config.yaml.j2
+++ b/roles/installer/templates/config.yaml.j2
@@ -32,15 +32,15 @@ data:
 
     IS_K8S = True
 
+{% if "limits" in task_resource_requirements and "memory" in task_resource_requirements["limits"] %}
     # Set memory available based off of resource request/limit for the task pod
-    memory_limit = '{{ task_resource_requirements["limits"]["memory"] if "limits" in task_resource_requirements and "memory" in task_resource_requirements["limits"] }}'
-    if memory_limit:
-        SYSTEM_TASK_ABS_MEM = memory_limit
+    SYSTEM_TASK_ABS_MEM = '{{ task_resource_requirements["limits"]["memory"] }}'
+{% endif %}
 
+{% if "limits" in task_resource_requirements and "cpu" in task_resource_requirements["limits"] %}
     # Set cpu available based off of resource request/limit for the task pod
-    cpu_limit = '{{ task_resource_requirements["limits"]["cpu"] if "limits" in task_resource_requirements and "cpu" in task_resource_requirements["limits"] }}'
-    if cpu_limit:
-        SYSTEM_TASK_ABS_CPU = cpu_limit
+    SYSTEM_TASK_ABS_CPU = '{{ task_resource_requirements["limits"]["cpu"] }}'
+{% endif %}
 
     SECRET_KEY = get_secret()
     


### PR DESCRIPTION
When the `task_resource_requirements` variable has no "limits" key (which
is the default value) then the config template generation fails

----------------------------------
```yaml
looking for "config.yaml.j2" at "/opt/ansible/roles/installer/templates/config.yaml.j2"
File lookup using /opt/ansible/roles/installer/templates/config.yaml.j2 as file
fatal: [localhost]: FAILED! => {
"msg": "The task includes an option with an undefined variable. The error was: the inline if-expression on line 36 evaluated to false and no else section was defined.

The error appears to be in /opt/ansible/roles/installer/tasks/resources_configuration.yml: line 30, column 3, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:

- name: Apply Resources
 ^ here
```
----------------------------------

The current condition doesn't have a else statement so the template fails
when the "limits" key isn't present.
This rewrite the current if/else statement in jinja template.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>