### PR TITLE
Use awx web launch script to pick up the correct supervisor config

### DIFF
--- a/config/samples/awx_v1beta1_awx.yaml
+++ b/config/samples/awx_v1beta1_awx.yaml
@@ -6,13 +6,13 @@ metadata:
 spec:
   web_resource_requirements:
     requests:
-      cpu: 250m
+      cpu: 50m
       memory: 128M
   task_resource_requirements:
     requests:
-      cpu: 250m
+      cpu: 50m
       memory: 128M
   ee_resource_requirements:
     requests:
-      cpu: 200m
+      cpu: 50m
       memory: 64M

--- a/molecule/default/templates/awx_cr_molecule.yml.j2
+++ b/molecule/default/templates/awx_cr_molecule.yml.j2
@@ -15,16 +15,16 @@ spec:
     kubernetes.io/ingress.class: nginx
   web_resource_requirements:
     requests:
-      cpu: 100m
+      cpu: 50m
       memory: 32M
   task_resource_requirements:
     requests:
-      cpu: 100m
+      cpu: 50m
       memory: 32M
   ee_resource_requirements:
     requests:
-      cpu: 200m
-      memory: 32M
+      cpu: 50m
+      memory: 16M
   postgres_resource_requirements: {}
   postgres_init_container_resource_requirements: {}
   redis_resource_requirements: {}

--- a/roles/installer/defaults/main.yml
+++ b/roles/installer/defaults/main.yml
@@ -164,7 +164,8 @@ replicas: "1"
 task_args:
   - /usr/bin/launch_awx_task.sh
 task_command: []
-web_args: []
+web_args:
+  - /usr/bin/launch_awx.sh
 web_command: []
 
 task_resource_requirements:


### PR DESCRIPTION
Due to a prior change which added the ability to customize arguments passed to the web and task containers, the launch script for the web container was no longer being called properly.  This resulted in some alarming, but ultimately innocuous error messages in the supervisorctl status output.  

This fixes that.  