### PR TITLE
Option to delete backup dir on PV when AWXBackup object is deleted

### DIFF
--- a/config/crd/bases/awxbackup.ansible.com_awxbackups.yaml
+++ b/config/crd/bases/awxbackup.ansible.com_awxbackups.yaml
@@ -43,6 +43,9 @@ spec:
                 backup_storage_class:
                   description: Storage class to use when creating PVC for backup
                   type: string
+                clean_backup_on_delete:
+                  description: Flag to indicate if backup should be deleted on PVC if AWXBackup object is deleted
+                  type: boolean
                 postgres_label_selector:
                   description: Label selector used to identify postgres pod for backing up data
                   type: string

--- a/roles/backup/README.md
+++ b/roles/backup/README.md
@@ -74,7 +74,12 @@ To check the name of this secret, look at the postgresConfigurationSecret status
 The postgresql pod for the old deployment is used when backing up data to the new postgresql pod.  If your postgresql pod has a custom label,
 you can pass that via the `postgres_label_selector` variable to make sure the postgresql pod can be found.
 
+It is also possible to tie the lifetime of the backup files to that of the AWXBackup resource object. To do that you can set the
+`clean_backup_on_delete` value to true. This will delete the `backupDirectory` on the pvc associated with the AWXBackup object deleted.
 
+```
+clean_backup_on_delete: true
+```
 Testing
 ----------------
 

--- a/roles/backup/defaults/main.yml
+++ b/roles/backup/defaults/main.yml
@@ -13,3 +13,9 @@ backup_storage_requirements: ''
 
 # Set no_log settings on certain tasks
 no_log: 'true'
+
+# Variable to set when you want backups to be cleaned up when the CRD object is deleted
+clean_backup_on_delete: false
+
+# Variable to signal that this role is being run as a finalizer
+finalizer_run: false

--- a/roles/backup/tasks/creation.yml
+++ b/roles/backup/tasks/creation.yml
@@ -1,0 +1,47 @@
+---
+- name: Patching labels to {{ kind }} kind
+  k8s:
+    state: present
+    definition:
+      apiVersion: "{{ api_version }}"
+      kind: "{{ kind }}"
+      name: "{{ ansible_operator_meta.name }}"
+      namespace: "{{ ansible_operator_meta.namespace }}"
+      metadata:
+        name: "{{ ansible_operator_meta.name }}"
+        namespace: "{{ ansible_operator_meta.namespace }}"
+        labels:
+          app.kubernetes.io/name: "{{ ansible_operator_meta.name }}"
+          app.kubernetes.io/part-of: "{{ ansible_operator_meta.name }}"
+          app.kubernetes.io/managed-by: "{{ deployment_type }}-operator"
+          app.kubernetes.io/component: "{{ deployment_type }}"
+          app.kubernetes.io/operator-version: '{{ lookup("env", "OPERATOR_VERSION") }}'
+
+- name: Look up details for this backup object
+  k8s_info:
+    api_version: "{{ api_version }}"
+    kind: "{{ kind }}"
+    name: "{{ ansible_operator_meta.name }}"
+    namespace: "{{ ansible_operator_meta.namespace }}"
+  register: this_backup
+
+- block:
+    - include_tasks: init.yml
+
+    - include_tasks: postgres.yml
+
+    - include_tasks: awx-cro.yml
+
+    - include_tasks: secrets.yml
+
+    - name: Set flag signifying this backup was successful
+      set_fact:
+        backup_complete: true
+
+    - include_tasks: cleanup.yml
+
+  when:
+    - this_backup['resources'][0]['status']['backupDirectory'] is not defined
+
+- name: Update status variables
+  include_tasks: update_status.yml

--- a/roles/backup/tasks/delete_backup.yml
+++ b/roles/backup/tasks/delete_backup.yml
@@ -1,0 +1,7 @@
+---
+- name: Cleanup backup associated with this option if enabled
+  k8s_exec:
+    namespace: "{{ backup_pvc_namespace }}"
+    pod: "{{ ansible_operator_meta.name }}-db-management"
+    command: >-
+      bash -c 'rm -rf {{ backup_dir  }}'

--- a/roles/backup/tasks/finalizer.yml
+++ b/roles/backup/tasks/finalizer.yml
@@ -1,0 +1,19 @@
+---
+- name: Look up details for this backup object
+  k8s_info:
+    api_version: "{{ api_version }}"
+    kind: "{{ kind }}"
+    name: "{{ ansible_operator_meta.name }}"
+    namespace: "{{ ansible_operator_meta.namespace }}"
+  register: this_backup
+
+- block:
+    - include_tasks: init.yml
+
+    - include_tasks: delete_backup.yml
+
+    - include_tasks: cleanup.yml
+  vars:
+    backup_dir: "{{ this_backup['resources'][0]['status']['backupDirectory'] }}"
+  when:
+    - clean_backup_on_delete and backup_dir is defined

--- a/roles/backup/tasks/init.yml
+++ b/roles/backup/tasks/init.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: Delete any existing management pod
   k8s:
     name: "{{ ansible_operator_meta.name }}-db-management"
@@ -57,8 +56,8 @@
           apiVersion: v1
           kind: PersistentVolumeClaim
           metadata:
-            name: '{{ deployment_name }}-backup-claim'
-            namespace: '{{ backup_pvc_namespace }}'
+            name: "{{ deployment_name }}-backup-claim"
+            namespace: "{{ backup_pvc_namespace }}"
             ownerReferences: null
   when:
     - backup_pvc == '' or backup_pvc is not defined

--- a/roles/backup/tasks/main.yml
+++ b/roles/backup/tasks/main.yml
@@ -1,47 +1,8 @@
 ---
-- name: Patching labels to {{ kind }} kind
-  k8s:
-    state: present
-    definition:
-      apiVersion: '{{ api_version }}'
-      kind: '{{ kind }}'
-      name: '{{ ansible_operator_meta.name }}'
-      namespace: '{{ ansible_operator_meta.namespace }}'
-      metadata:
-        name: '{{ ansible_operator_meta.name }}'
-        namespace: '{{ ansible_operator_meta.namespace }}'
-        labels:
-          app.kubernetes.io/name: '{{ ansible_operator_meta.name }}'
-          app.kubernetes.io/part-of: '{{ ansible_operator_meta.name }}'
-          app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
-          app.kubernetes.io/component: '{{ deployment_type }}'
-          app.kubernetes.io/operator-version: '{{ lookup("env", "OPERATOR_VERSION") }}'
+- name: Run creation tasks
+  include_tasks: creation.yml
+  when: not finalizer_run
 
-- name: Look up details for this backup object
-  k8s_info:
-    api_version: "{{ api_version }}"
-    kind: "{{ kind }}"
-    name: "{{ ansible_operator_meta.name }}"
-    namespace: "{{ ansible_operator_meta.namespace }}"
-  register: this_backup
-
-- block:
-    - include_tasks: init.yml
-
-    - include_tasks: postgres.yml
-
-    - include_tasks: awx-cro.yml
-
-    - include_tasks: secrets.yml
-
-    - name: Set flag signifying this backup was successful
-      set_fact:
-        backup_complete: true
-
-    - include_tasks: cleanup.yml
-
-  when:
-    - this_backup['resources'][0]['status']['backupDirectory'] is not defined
-
-- name: Update status variables
-  include_tasks: update_status.yml
+- name: Run finalizer tasks
+  include_tasks: finalizer.yml
+  when: finalizer_run

--- a/watches.yaml
+++ b/watches.yaml
@@ -11,6 +11,11 @@
   kind: AWXBackup
   role: backup
   snakeCaseParameters: False
+  finalizer:
+    name: awx.ansible.com/finalizer
+    role: backup
+    vars:
+      finalizer_run: true
 
 - version: v1beta1
   group: awx.ansible.com


### PR DESCRIPTION
This allows external tools better management of the number of backups stored on a PV where the same volume is used for every export and the volume itself is periodically backed up e.g. to S3 using Rancher.

Mechanism was implemented by setting a Finalizer on the AWXBackup object which runs the backup role with `finalizer_run` variable set to true. This then checks if there is a property called `clean_backup_on_delete` on the AWXBackup object being deleted, and if true, then fires up the backup pod and removes the directory on the PV.