### PR TITLE
Enable ipv6 listening in nginx config

### DIFF
--- a/roles/installer/templates/config.yaml.j2
+++ b/roles/installer/templates/config.yaml.j2
@@ -145,6 +145,7 @@ data:
         {% if route_tls_termination_mechanism | lower == 'passthrough' %}
         server {
             listen 8052 default_server;
+            listen [::]:8052 default_server;
             server_name _;
 
             # Redirect all HTTP links to the matching HTTPS page
@@ -155,6 +156,7 @@ data:
         server {
         {% if route_tls_termination_mechanism | lower == 'passthrough' %}
             listen 8053 ssl;
+            listen [::]:8053 ssl;
 
             ssl_certificate /etc/nginx/pki/web.crt;
             ssl_certificate_key /etc/nginx/pki/web.key;
@@ -165,6 +167,7 @@ data:
             ssl_prefer_server_ciphers on;
         {% else %}
             listen 8052 default_server;
+            listen [::]:8052 default_server;
         {% endif %}
 
             # If you have a domain name, this is where to add it


### PR DESCRIPTION
This makes awx-operator work in IPv6-only Kubernetes clusters.

You can test the changes by using this in your `kustomization.yml`:

```yaml
images:
  - name: quay.io/ansible/awx-operator
    newName: astehlik/awx-operator
    newTag: "0.22.0"
```

The image is based on `quay.io/ansible/awx-operator:0.22.0` and the changes from this pull requests are applied.
