### PR TITLE
Pre-create dummy rh secret to avoid errors

### DIFF
--- a/playbooks/awx.yml
+++ b/playbooks/awx.yml
@@ -1,0 +1,31 @@
+---
+- hosts: localhost
+  gather_facts: no
+  collections:
+    - kubernetes.core
+    - operator_sdk.util
+  vars:
+    no_log: true
+  pre_tasks:
+    - name: Verify imagePullSecrets
+      k8s_info:
+        kind: Secret
+        namespace: '{{ ansible_operator_meta.namespace }}'
+        name: redhat-operators-pull-secret
+      register: _rh_ops_secret
+      no_log: "{{ no_log }}"
+    - name: Create imagePullSecret
+      k8s:
+        state: present
+        definition:
+          apiVersion: v1
+          kind: Secret
+          metadata:
+            name: redhat-operators-pull-secret
+            namespace: '{{ ansible_operator_meta.namespace }}'
+          stringData:
+            operator: awx
+      when:
+        - (_rh_ops_secret is not defined) or not (_rh_ops_secret['resources'] | length)
+  roles:
+    - installer

--- a/watches.yaml
+++ b/watches.yaml
@@ -3,7 +3,7 @@
 - version: v1beta1
   group: awx.ansible.com
   kind: AWX
-  role: installer
+  playbook: playbooks/awx.yml
   snakeCaseParameters: False
 
 - version: v1beta1


### PR DESCRIPTION
Fixes: https://github.com/ansible/awx-operator/issues/922

For a particular disconnected deployment scenario, it was necessary to add an "expected" secret in order to pull the operator container image.  

Adding this had an undesired side-effect: errors in the logs when trying to find the pull secret.  There is nothing functionally wrong with the resulting deployment, but the logs are annoying, so this creates a dummy secret to remedy that.  

ISSUE TYPE
* Bug, Docs Fix or other nominal change