### PR TITLE
Fix ldap bind password secret usage: ldap_password_secret

### DIFF
--- a/roles/installer/templates/config.yaml.j2
+++ b/roles/installer/templates/config.yaml.j2
@@ -101,6 +101,11 @@ data:
     BROADCAST_WEBSOCKET_PORT = 8052
     BROADCAST_WEBSOCKET_PROTOCOL = 'http'
 
+    # Load LDAP BIND password from Kubernetes secret if define
+    {% if ldap_password_secret -%}
+    AUTH_LDAP_BIND_PASSWORD = "{{ ldap_bind_password }}"
+    {% endif %}
+
 {% for item in extra_settings | default([]) %}
     {{ item.setting }} = {{ item.value }}
 {% endfor %}

--- a/roles/installer/templates/config.yaml.j2
+++ b/roles/installer/templates/config.yaml.j2
@@ -101,11 +101,6 @@ data:
     BROADCAST_WEBSOCKET_PORT = 8052
     BROADCAST_WEBSOCKET_PROTOCOL = 'http'
 
-    # Load LDAP BIND password from Kubernetes secret if define
-    {% if ldap_password_secret -%}
-    AUTH_LDAP_BIND_PASSWORD = "{{ ldap_bind_password }}"
-    {% endif %}
-
 {% for item in extra_settings | default([]) %}
     {{ item.setting }} = {{ item.value }}
 {% endfor %}

--- a/roles/installer/templates/ldap.py.j2
+++ b/roles/installer/templates/ldap.py.j2
@@ -4,3 +4,8 @@ AUTH_LDAP_GLOBAL_OPTIONS = {
     ldap.OPT_X_TLS_CACERTFILE: "/etc/openldap/certs/ldap-ca.crt"
 {% endif %}
 }
+
+# Load LDAP BIND password from Kubernetes secret if define
+{% if ldap_password_secret -%}
+AUTH_LDAP_BIND_PASSWORD = "{{ ldap_bind_password }}"
+{% endif %}


### PR DESCRIPTION
## Overview
This PR is created to fixed the missing configuration of the previous feature by @hungtran84 : [PR-659](https://github.com/ansible/awx-operator/pull/659)

Related issue: https://github.com/ansible/awx-operator/issues/937  

## Description
The `ldap_password_secret` will not take effect unless it is added into settings.py. Previous owner of this configuration has developed to read the password from k8s secret, but sadly, it is not used anywhere in the code.

## Note
If this pr can be approved and merged, can you please add this to version v0.21.1. Otherwise, the configuration `ldap_password_secret` in v0.21.0 is useless. 