### PR TITLE
added auto_upgrade flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ An [Ansible AWX](https://github.com/ansible/awx) operator for Kubernetes built w
          * [Session Cookie Secure Setting](#session-cookie-secure-setting)
          * [Extra Settings](#extra-settings)
          * [Configure no_log](#no-log)
+         * [Auto Upgrade](#auto-upgrade)
+            * [Upgrade of instances without auto upgrade](#upgrade-of-instances-without-auto-upgrade)
          * [Service Account](#service-account)
       * [Uninstall](#uninstall)
       * [Upgrading](#upgrading)
@@ -1033,6 +1035,42 @@ Example configuration of `no_log` parameter
   spec:
     no_log: 'true'
 ```
+
+#### Auto upgrade
+With this parameter you can influence the behaviour during an operator upgrade.  
+If set to `true`, the operator will upgrade the specific instance directly.  
+When the value is set to `false`, and we have a running deployment, the operator will not update the AWX instance.  
+This can be useful when you have multiple AWX instances which you want to upgrade step by step instead of all at once.  
+
+
+| Name         | Description                        | Default |
+| -------------| ---------------------------------- | ------- |
+| auto_upgrade | Automatic upgrade of AWX instances | true    |
+
+Example configuration of `auto_upgrade` parameter
+
+```yaml
+  spec:
+    auto_upgrade: true
+```
+
+##### Upgrade of instances without auto upgrade
+
+There are two ways to upgrade instances which are marked with the 'auto_upgrade: false' flag.  
+
+Changing flags:
+
+- change the auto_upgrade flag on your AWX object to true  
+- wait until the upgrade process of that instance is finished
+- change the auto_upgrade flag on your AWX object back to false  
+
+Delete the deployment:
+
+- delete the deployment object of your AWX instance  
+```
+$ kubectl -n awx delete deployment <yourInstanceName> 
+```
+- wait until the instance gets redeployed  
 
 
 #### Service Account

--- a/config/crd/bases/awx.ansible.com_awxs.yaml
+++ b/config/crd/bases/awx.ansible.com_awxs.yaml
@@ -489,6 +489,10 @@ spec:
                   description: Key/values that will be set under the pod-level securityContext field
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
+                auto_upgrade:
+                  description: Should AWX instances be automatically upgraded when operator gets upgraded
+                  type: boolean
+                  default: true
               type: object
             status:
               properties:

--- a/roles/installer/defaults/main.yml
+++ b/roles/installer/defaults/main.yml
@@ -284,3 +284,7 @@ security_context_settings: {}
 
 # Set no_log settings on certain tasks
 no_log: 'true'
+
+# Should AWX instances be automatically upgraded when operator gets upgraded
+#
+auto_upgrade: true

--- a/roles/installer/tasks/install.yml
+++ b/roles/installer/tasks/install.yml
@@ -1,0 +1,88 @@
+---
+- name: Patching labels to AWX kind
+  k8s:
+    state: present
+    definition:
+      apiVersion: '{{ api_version }}'
+      kind: '{{ kind }}'
+      name: '{{ ansible_operator_meta.name }}'
+      namespace: '{{ ansible_operator_meta.namespace }}'
+      metadata:
+        name: '{{ ansible_operator_meta.name }}'
+        namespace: '{{ ansible_operator_meta.namespace }}'
+        labels:
+          app.kubernetes.io/name: '{{ ansible_operator_meta.name }}'
+          app.kubernetes.io/part-of: '{{ ansible_operator_meta.name }}'
+          app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
+          app.kubernetes.io/component: '{{ deployment_type }}'
+          app.kubernetes.io/operator-version: '{{ lookup("env", "OPERATOR_VERSION") }}'
+
+- name: Include secret key configuration tasks
+  include_tasks: secret_key_configuration.yml
+
+- name: Load LDAP CAcert certificate
+  include_tasks: load_ldap_cacert_secret.yml
+  when:
+    - ldap_cacert_secret != ''
+
+- name: Load ldap bind password
+  include_tasks: load_ldap_password_secret.yml
+  when:
+    - ldap_password_secret != ''
+
+- name: Load bundle certificate authority certificate
+  include_tasks: load_bundle_cacert_secret.yml
+  when:
+    - bundle_cacert_secret != ''
+
+- name: Include admin password configuration tasks
+  include_tasks: admin_password_configuration.yml
+
+- name: Include broadcast websocket configuration tasks
+  include_tasks: broadcast_websocket_configuration.yml
+
+- name: Include set_images tasks
+  include_tasks: set_images.yml
+
+- name: Include database configuration tasks
+  include_tasks: database_configuration.yml
+
+- name: Load Route TLS certificate
+  include_tasks: load_route_tls_secret.yml
+  when:
+    - ingress_type | lower == 'route'
+    - route_tls_secret != ''
+
+- name: Include resources configuration tasks
+  include_tasks: resources_configuration.yml
+
+- name: Check for pending migrations
+  k8s_exec:
+    namespace: "{{ ansible_operator_meta.namespace }}"
+    pod: "{{ tower_pod_name }}"
+    container: "{{ ansible_operator_meta.name }}-task"
+    command: >-
+      bash -c "awx-manage showmigrations | grep -v '[X]' | grep '[ ]' | wc -l"
+  changed_when: false
+  register: database_check
+
+- name: Migrate the database if the K8s resources were updated.  # noqa 305
+  k8s_exec:
+    namespace: "{{ ansible_operator_meta.namespace }}"
+    pod: "{{ tower_pod_name }}"
+    container: "{{ ansible_operator_meta.name }}-task"
+    command: >-
+      bash -c "awx-manage migrate --noinput"
+  register: migrate_result
+  when:
+    - database_check is defined
+    - (database_check.stdout|trim) != '0'
+
+- name: Initialize Django
+  include_tasks: initialize_django.yml
+
+- name: Update status variables
+  include_tasks: update_status.yml
+
+- name: Cleanup & Set garbage collection refs
+  include_tasks: cleanup.yml

--- a/roles/installer/tasks/main.yml
+++ b/roles/installer/tasks/main.yml
@@ -1,88 +1,13 @@
 ---
-- name: Patching labels to AWX kind
-  k8s:
-    state: present
-    definition:
-      apiVersion: '{{ api_version }}'
-      kind: '{{ kind }}'
-      name: '{{ ansible_operator_meta.name }}'
-      namespace: '{{ ansible_operator_meta.namespace }}'
-      metadata:
-        name: '{{ ansible_operator_meta.name }}'
-        namespace: '{{ ansible_operator_meta.namespace }}'
-        labels:
-          app.kubernetes.io/name: '{{ ansible_operator_meta.name }}'
-          app.kubernetes.io/part-of: '{{ ansible_operator_meta.name }}'
-          app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
-          app.kubernetes.io/component: '{{ deployment_type }}'
-          app.kubernetes.io/operator-version: '{{ lookup("env", "OPERATOR_VERSION") }}'
-
-- name: Include secret key configuration tasks
-  include_tasks: secret_key_configuration.yml
-
-- name: Load LDAP CAcert certificate
-  include_tasks: load_ldap_cacert_secret.yml
-  when:
-    - ldap_cacert_secret != ''
-
-- name: Load ldap bind password
-  include_tasks: load_ldap_password_secret.yml
-  when:
-    - ldap_password_secret != ''
-
-- name: Load bundle certificate authority certificate
-  include_tasks: load_bundle_cacert_secret.yml
-  when:
-    - bundle_cacert_secret != ''
-
-- name: Include admin password configuration tasks
-  include_tasks: admin_password_configuration.yml
-
-- name: Include broadcast websocket configuration tasks
-  include_tasks: broadcast_websocket_configuration.yml
-
-- name: Include set_images tasks
-  include_tasks: set_images.yml
-
-- name: Include database configuration tasks
-  include_tasks: database_configuration.yml
-
-- name: Load Route TLS certificate
-  include_tasks: load_route_tls_secret.yml
-  when:
-    - ingress_type | lower == 'route'
-    - route_tls_secret != ''
-
-- name: Include resources configuration tasks
-  include_tasks: resources_configuration.yml
-
-- name: Check for pending migrations
-  k8s_exec:
+- name: Check for presence of Deployment
+  k8s_info:
+    api_version: v1
+    kind: Deployment
+    name: "{{ ansible_operator_meta.name }}"
     namespace: "{{ ansible_operator_meta.namespace }}"
-    pod: "{{ tower_pod_name }}"
-    container: "{{ ansible_operator_meta.name }}-task"
-    command: >-
-      bash -c "awx-manage showmigrations | grep -v '[X]' | grep '[ ]' | wc -l"
-  changed_when: false
-  register: database_check
+  register: tower_deployment
 
-- name: Migrate the database if the K8s resources were updated.  # noqa 305
-  k8s_exec:
-    namespace: "{{ ansible_operator_meta.namespace }}"
-    pod: "{{ tower_pod_name }}"
-    container: "{{ ansible_operator_meta.name }}-task"
-    command: >-
-      bash -c "awx-manage migrate --noinput"
-  register: migrate_result
-  when:
-    - database_check is defined
-    - (database_check.stdout|trim) != '0'
-
-- name: Initialize Django
-  include_tasks: initialize_django.yml
-
-- name: Update status variables
-  include_tasks: update_status.yml
-
-- name: Cleanup & Set garbage collection refs
-  include_tasks: cleanup.yml
+# Just execute deployment steps when auto_upgrade is true or when no deployment exists
+- name: Start installation
+  include_tasks: install.yml
+  when: (tower_deployment['resources'] | length > 0 and auto_upgrade | bool ) or (tower_deployment['resources'] | length == 0)


### PR DESCRIPTION
Adds the possibility to set an auto_upgrade flag (true|false) to optionally prevent automatic AWX instance upgrades when the operator gets upgraded.

AWX will be upgraded if a deployment exists and the flag is set to true or no deployment exits.
With this we can set instances to "auto_upgrade: false" and recreate the deployment of multiple AWX instances step by step instead of doing it all at once.

Related issue: https://github.com/ansible/awx-operator/issues/936 