### PR TITLE
Use specific version of redis image

### DIFF
--- a/roles/installer/defaults/main.yml
+++ b/roles/installer/defaults/main.yml
@@ -127,7 +127,7 @@ extra_volumes: ''
 _image: quay.io/ansible/awx
 _image_version: "{{ lookup('env', 'DEFAULT_AWX_VERSION') or 'latest' }}"
 _redis_image: docker.io/redis
-_redis_image_version: latest
+_redis_image_version: 7
 _postgres_image: postgres
 _postgres_image_version: 12
 _init_container_image: quay.io/centos/centos


### PR DESCRIPTION
While redis has good backwards-compatability guarantees, it would be risky not to pin at least the major version of redis to a specific number. That way a pod restart won't silently upgrade someone's redis installation.

Additionally, some cluster admins ban the use of the "latest" tag: https://github.com/open-policy-agent/gatekeeper-library/blob/master/library/general/disallowedtags/samples/container-image-must-not-have-latest-tag/constraint.yaml