### PR TITLE
Import all ldap config classes in settings.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -785,7 +785,9 @@ To create the secrets, you can use the commands below:
 
 #### Enabling LDAP Integration at AWX bootstrap
 
-A sample of extra settings can be found as below:
+A sample of extra settings can be found as below. All possible options can be found here: https://django-auth-ldap.readthedocs.io/en/latest/reference.html#settings
+
+> **NOTE:** These values are inserted into a Python file, so pay close attention to which values need quotes and which do not.
 
 ```yaml
     - setting: AUTH_LDAP_SERVER_URI
@@ -801,6 +803,9 @@ A sample of extra settings can be found as below:
 
     - setting: AUTH_LDAP_GROUP_SEARCH
       value: 'LDAPSearch("OU=Groups,DC=abc,DC=com",ldap.SCOPE_SUBTREE,"(objectClass=group)",)'
+
+    - setting: AUTH_LDAP_GROUP_TYPE
+      value: 'GroupOfNamesType(name_attr="cn")'
 
     - setting: AUTH_LDAP_USER_ATTR_MAP
       value: '{"first_name": "givenName","last_name": "sn","email": "mail"}'

--- a/roles/installer/templates/configmaps/config.yaml.j2
+++ b/roles/installer/templates/configmaps/config.yaml.j2
@@ -18,7 +18,8 @@ data:
   settings: |
     import os
     import socket
-    from django_auth_ldap.config import LDAPSearch
+    # Import all so that extra_settings works properly
+    from django_auth_ldap.config import *
     
     def get_secret():
         if os.path.exists("/etc/tower/SECRET_KEY"):


### PR DESCRIPTION
As discovered in #642 , if you are using AUTH_LDAP_GROUP_SEARCH, you also need to specify AUTH_LDAP_GROUP_TYPE (since different LDAP providers have different ways of representing groups). However, AUTH_LDAP_GROUP_TYPE needs to reference an object of type `django_auth_ldap.config.LDAPGroupType`, which means those classes must be imported at the top of the settings file (discovered in #925 ).


-----------------------
Edit: to make CI pass

#### Issue Type:
- Bug, Docs Fix or other nominal change