### PR TITLE
Add default resource requests for operator container

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -54,6 +54,13 @@ spec:
               port: 6789
             initialDelaySeconds: 5
             periodSeconds: 10
+          resources:
+            requests:
+              memory: "32Mi"
+              cpu: "50m"
+            limits:
+              memory: "4096Mi"
+              cpu: "2000m"
       serviceAccountName: controller-manager
       imagePullSecrets:
         - name: redhat-operators-pull-secret


### PR DESCRIPTION
OLM users can override these via the spec of the Subscription object.  

Having some defaults in place is necessary so that when quotas are used, operator pods still get scheduled.  

For example:

```
apiVersion: operators.coreos.com/v1alpha1
kind: Subscription
metadata:
  name: ansible-automation-platform-operator
  namespace: openshift-operators
spec:
  channel: stable-2.2-cluster-scoped
  installPlanApproval: Automatic
  name: ansible-automation-platform-operator
  source: redhat-operators
  sourceNamespace: openshift-marketplace
  config:
    resources:
      requests:
        memory: "16Mi"
        cpu: "25m"
      limits:
        memory: "512Mi"
        cpu: "1000m"
```


Docs - https://sdk.operatorframework.io/docs/best-practices/managing-resources/#managing-resources