### PR TITLE
Added helm values, templates, and readme

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -60,7 +60,25 @@ jobs:
           kustomize edit add patch --path ../testing/pull_policy/Never.yaml
         working-directory: config/default
 
-      - name: Build and install helm chart
+      - name: Build and lint helm chart
         run: |
           IMG=awx-operator-ci make helm-chart
+          helm lint ./charts/awx-operator
+
+      - name: Install kubeval
+        run: |
+          mkdir tmp && cd tmp
+          wget https://github.com/instrumenta/kubeval/releases/latest/download/kubeval-linux-amd64.tar.gz
+          tar xf kubeval-linux-amd64.tar.gz
+          sudo cp kubeval /usr/local/bin
+        working-directory: ./charts
+
+      - name: Run kubeval
+        run: |
+          helm template -n awx awx-operator > tmp/test.yaml
+          kubeval --strict --force-color --ignore-missing-schemas tmp/test.yaml
+        working-directory: ./charts
+
+      - name: Install helm chart
+        run: |
           helm install --wait my-awx-operator --namespace awx --create-namespace ./charts/awx-operator

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /bundle.Dockerfile
 /charts
 /.cr-release-packages
+.vscode/

--- a/.helm/starter/README.md
+++ b/.helm/starter/README.md
@@ -1,0 +1,56 @@
+# AWX Operator Helm Chart
+
+This chart installs the AWX Operator resources configured in [this](https://github.com/ansible/awx-operator) repository. 
+
+## Getting Started
+To configure your AWX resource using this chart, create your own `yaml` values file. The name is up to personal preference since it will explicitly be passed into the helm chart. Helm will merge whatever values you specify in your file with the default `values.yaml`, overriding any settings you've changed while allowing you to fall back on defaults. Because of this functionality, `values.yaml` should not be edited directly.
+
+In your values config, enable `AWX.enable` and add `AWX.spec` values based on the awx operator's [documentation](https://github.com/ansible/awx-operator/blob/devel/README.md). Consult the docs below for additional functionality.
+
+### Installing
+The operator's [helm install](https://github.com/ansible/awx-operator/blob/devel/README.md#helm-install-on-existing-cluster) guide provides key installation instructions. 
+
+Example:
+```
+helm install my-awx-operator awx-operator/awx-operator -n awx --create-namespace -f myvalues.yaml
+```
+
+Argument breakdown:
+* `-f` passes in the file with your custom values
+* `-n` sets the namespace to be installed in
+  * This value is accessed by `{{ $.Release.Namespace }}` in the templates
+  * Acts as the default namespace for all unspecified resources
+* `--create-namespace` specifies that helm should create the namespace before installing
+
+To update an existing installation, use `helm upgrade` instead of `install`. The rest of the syntax remains the same.
+
+## Configuration
+The goal of adding helm configurations is to abstract out and simplify the creation of multi-resource configs. The `AWX.spec` field maps directly to the spec configs of the `AWX` resource that the operator provides, which are detailed in the [main README](https://github.com/ansible/awx-operator/blob/devel/README.md). Other sub-config can be added with the goal of simplifying more involved setups that require additional resources to be specified.
+
+These sub-headers aim to be a more intuitive entrypoint into customizing your deployment, and are easier to manage in the long-term. By design, the helm templates will defer to the manually defined specs to avoid configuration conflicts. For example, if `AWX.spec.postgres_configuration_secret` is being used, the `AWX.postgres` settings will not be applied, even if enabled. 
+
+### External Postgres
+The `AWX.postgres` section simplifies the creation of the external postgres secret. If enabled, the configs provided will automatically be placed in a `postgres-config` secret and linked to the `AWX` resource. For proper secret management, the `AWX.postgres.password` value, and any other sensitive values, can be passed in at the command line rather than specified in code. Use the `--set` argument with `helm install`. 
+
+
+## Values Summary
+
+### AWX
+| Value | Description | Default |
+|---|---|---|
+| `AWX.enabled` | Enable this AWX resource configuration | `false` |
+| `AWX.name` | The name of the AWX resource and default prefix for other resources | `"awx"` |
+| `AWX.spec` | specs to directly configure the AWX resource | `{}` |
+| `AWX.postgres` | configurations for the external postgres secret | - |
+
+
+# Contributing 
+
+## Adding abstracted sections
+Where possible, defer to `AWX.spec` configs before applying the abstracted configs to avoid collision. This can be facilitated by the `(hasKey .spec what_i_will_abstract)` check. 
+
+## Building and Testing
+This chart is built using the Makefile in the [awx-operator repo](https://github.com/ansible/awx-operator). Clone the repo and run `make helm-chart`. This will create the awx-operator chart in the `charts/awx-operator` directory. In this process, the contents of the `.helm/starter` directory will be added to the chart.
+
+## Future Goals
+All values under the `AWX` header are focused on configurations that use the operator. Configurations that relate to the Operator itself could be placed under an `Operator` heading, but that may add a layer of complication over current development.

--- a/.helm/starter/templates/_helpers.tpl
+++ b/.helm/starter/templates/_helpers.tpl
@@ -1,0 +1,6 @@
+{{/*
+Generate the name of the postgres secret, expects AWX context passed in
+*/}}
+{{- define "postgres.secretName" -}}
+{{ default (printf "%s-postgres-configuration" .Values.AWX.name) .Values.AWX.postgres.secretName }}
+{{- end }}

--- a/.helm/starter/templates/awx-deploy.yaml
+++ b/.helm/starter/templates/awx-deploy.yaml
@@ -1,0 +1,24 @@
+{{- if $.Values.AWX.enabled }}
+{{- with .Values.AWX }}
+apiVersion: awx.ansible.com/v1beta1
+kind: AWX
+metadata:
+  name: {{ .name }}
+  namespace: {{ $.Release.Namespace }}
+spec:
+{{- /* Include raw map from the values file spec */}}
+{{ .spec | toYaml | indent 2 }}
+{{- /* Provide security context defaults */}}
+  {{- if not (hasKey .spec "security_context_settings") }}
+  security_context_settings:
+    runAsGroup: 0
+    runAsUser: 0
+    fsGroup: 0
+    fsGroupChangePolicy: OnRootMismatch
+  {{- end }}
+{{- /* Postgres configs if enabled and not already present */}}
+  {{- if and .postgres.enabled (not (hasKey .spec "postgres_configuration_secret")) }}
+  postgres_configuration_secret: {{ include "postgres.secretName" $ }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/.helm/starter/templates/postgres-config.yaml
+++ b/.helm/starter/templates/postgres-config.yaml
@@ -1,0 +1,18 @@
+{{- if and $.Values.AWX.enabled $.Values.AWX.postgres.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "postgres.secretName" . }}
+  namespace: {{ $.Release.Namespace }}
+{{- with $.Values.AWX.postgres }}
+stringData:
+  host: {{ .host }}
+  port: {{ .port }}
+  database: {{ .dbName }}
+  username: {{ .username }}
+  password: {{ .password }}
+  sslmode: {{ .sslmode }}
+  type: {{ .type }}
+type: Opaque
+{{- end }}
+{{- end }}

--- a/.helm/starter/values.yaml
+++ b/.helm/starter/values.yaml
@@ -1,0 +1,19 @@
+AWX: 
+  # enable use of awx-deploy template
+  enabled: false
+  name: awx
+  spec:
+    admin_user: admin
+
+  # configurations for external postgres instance
+  postgres:
+    enabled: false
+    host: Unset
+    port: 5678
+    dbName: Unset
+    username: admin
+    # for secret management, pass in the password independently of this file
+    # at the command line, use --set AWX.postgres.password
+    password: Unset
+    sslmode: prefer
+    type: unmanaged

--- a/.yamllint
+++ b/.yamllint
@@ -6,6 +6,7 @@ ignore: |
   kustomization.yaml
   awx-operator.clusterserviceversion.yaml
   bundle
+  .helm/starter
 
 rules:
   truthy: disable

--- a/Makefile
+++ b/Makefile
@@ -291,7 +291,7 @@ helm-chart: kustomize helm kubectl-slice yq charts
 		$(KUBECTL_SLICE) --input-file=- \
 			--output-dir=charts/$(CHART_NAME)/templates \
 			--sort-by-kind
-	@echo "Helm Chart $(VERSION)" > charts/$(CHART_NAME)/templates/NOTES.txt
+	@echo "AWX Operator installed with Helm Chart version $(VERSION)" > charts/$(CHART_NAME)/templates/NOTES.txt
 	$(foreach file, $(wildcard charts/$(CHART_NAME)/templates/*),$(YQ) -i 'del(.. | select(has("namespace")).namespace)' $(file);)
 	$(foreach file, $(wildcard charts/$(CHART_NAME)/templates/*rolebinding*),$(YQ) -i '.subjects[0].namespace = "{{ .Release.Namespace }}"' $(file);)
 	rm -f charts/$(CHART_NAME)/templates/namespace*.yaml

--- a/README.md
+++ b/README.md
@@ -259,6 +259,8 @@ For an example using the Nginx Controller in Minukube, don't miss our [demo vide
 
 For those that wish to use [Helm](https://helm.sh/) to install the awx-operator to an existing K8s cluster:
 
+The helm chart is generated from the `helm-chart` Makefile section using the starter files in `.helm/starter`. Consult [the documentation](.helm/starter/README.md) on how to customize the AWX resource with your own values.
+
 ```bash
 $ helm repo add awx-operator https://ansible.github.io/awx-operator/
 "awx-operator" has been added to your repositories
@@ -272,7 +274,7 @@ $ helm search repo awx-operator
 NAME                            CHART VERSION   APP VERSION     DESCRIPTION
 awx-operator/awx-operator       0.17.1          0.17.1          A Helm chart for the AWX Operator
 
-$ helm install my-awx-operator awx-operator/awx-operator
+$ helm install -n awx --create-namespace my-awx-operator awx-operator/awx-operator
 NAME: my-awx-operator
 LAST DEPLOYED: Thu Feb 17 22:09:05 2022
 NAMESPACE: default


### PR DESCRIPTION
Closes #960 by adding structure to the helm `values.yaml`. Added functionality to simplify linking to an external postgres module using a helm template. This creates a pattern that can be used to simplify other processes, like using a PVC for external storage.

I would be happy to iterate on the helm values format or add additional functionality if there is interest. I also think that this should be merged after PR #954, and I can rebase the branch off of those changes once approved. This allows us to fully leverage the unified functionality of `$.Release.Namespace`