### PR TITLE
Add pg password encrypt functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,7 +463,9 @@ stringData:
 type: Opaque
 ```
 
-> Please ensure that the value for the variable `password` should _not_ contain single or double quotes (`'`, `"`) or backslashes (`\`) to avoid any issues during deployment, backup or restoration.
+> Please ensure that the value for the variable `password` should _not_ contain single or double quotes (`'`, `"`) or backslashes (`\`) to avoid any issues during deployment, backup or restoration.  
+
+> In order to use an encrypted value for the password, it needs to be formatted like the following: $encrypted$AESCBC$Z0FBQUFBQmNONU9BbGQ1VjJyNDJRVTRKaFRIR09Ib2U5TGdaYVRfcXFXRjlmdmpZNjdoZVpEZ21QRWViMmNDOGJaM0dPeHN2b194NUxvQ1M5X3dSc1gxQ29TdDBKRkljWHc9PQ==
 
 > It is possible to set a specific username, password, port, or database, but still have the database managed by the operator. In this case, when creating the postgres-configuration secret, the `type: managed` field should be added.
 

--- a/roles/backup/tasks/postgres.yml
+++ b/roles/backup/tasks/postgres.yml
@@ -24,6 +24,39 @@
   no_log: "{{ no_log }}"
 
 - block:
+    - name: Get the controller pod information
+      k8s_info:
+        kind: Pod
+        namespace: '{{ ansible_operator_meta.namespace }}'
+        label_selectors:
+          - "app.kubernetes.io/name = {{ deployment_name }}"
+      register: controller_pod
+      until:
+        - "controller_pod['resources'] | length"
+        - "controller_pod['resources'][0]['status']['phase'] == 'Running'"
+        - "controller_pod['resources'][0]['status']['containerStatuses'][0]['ready'] == true"
+      delay: 5
+      retries: 60
+
+    - name: Get decrypted variable
+      k8s_exec:
+        namespace: '{{ ansible_operator_meta.namespace }}'
+        pod: "{{ controller_pod.resources[0].metadata.name }}"
+        container: "{{ deployment_name }}-task"
+        command: |
+          awx-manage shell_plus -c """
+          from awx.main.utils import decrypt_value, get_encryption_key
+          decrypted_value = decrypt_value(get_encryption_key('value'),'{{postgresql_password}}')
+          print(decrypted_value)
+          """
+      register: decrypt_postgres_pass
+
+    - name: Set decrypted postgres pass as awx_postgres_pass
+      set_fact: 
+        awx_postgres_pass: "{{ decrypt_postgres_pass.stdout_lines[1] }}"
+  when: "'encrypted' in awx_postgres_pass"
+
+- block:
     - name: Delete pod to reload a resource configuration
       set_fact:
         postgres_label_selector: "app.kubernetes.io/instance=postgres-{{ deployment_name }}"

--- a/roles/installer/templates/credentials.py.j2
+++ b/roles/installer/templates/credentials.py.j2
@@ -1,10 +1,18 @@
+{% if awx_postgres_pass.startswith('$encrypted$') | bool %}
+from awx.main.utils import decrypt_value, get_encryption_key
+
+{% endif %}
 DATABASES = {
     'default': {
         'ATOMIC_REQUESTS': True,
         'ENGINE': 'awx.main.db.profiled_pg',
         'NAME': "{{ awx_postgres_database }}",
         'USER': "{{ awx_postgres_user }}",
+{% if awx_postgres_pass.startswith('$encrypted$') | bool %}
+        'PASSWORD': decrypt_value(get_encryption_key('value'),'"{{ awx_postgres_pass }}"'),
+{% else %}
         'PASSWORD': "{{ awx_postgres_pass }}",
+{% endif %}
         'HOST': '{{ awx_postgres_host }}',
         'PORT': "{{ awx_postgres_port }}",
         'OPTIONS': { 'sslmode': '{{ awx_postgres_sslmode }}',


### PR DESCRIPTION
In the following KCS, we allow the passing of encrypted postgres password in credentials.py:
https://access.redhat.com/solutions/4309941

In the operator, this is not possible at the moment as any changes to that file is not persistent.  I have added a variable to toggle adding the `from awx.main.utils import decrypt_value, get_encryption_key` in order to enable the functionality.  By default, I have disabled it.