### PR TITLE
Add to Backup and Restore roles option to set Limits/Requests over {{ ansible_operator_meta.name }}-db-management Pod.

### DIFF
--- a/config/crd/bases/awxbackup.ansible.com_awxbackups.yaml
+++ b/config/crd/bases/awxbackup.ansible.com_awxbackups.yaml
@@ -28,6 +28,24 @@ spec:
               required:
                 - deployment_name
               properties:
+                backup_resource_requirements:
+                  description: Resource requirements for the task container
+                  properties:
+                    requests:
+                      properties:
+                        cpu:
+                          type: string
+                        memory:
+                          type: string
+                      type: object
+                    limits:
+                      properties:
+                        cpu:
+                          type: string
+                        memory:
+                          type: string
+                      type: object
+                  type: object
                 deployment_name:
                   description: Name of the deployment to be backed up
                   type: string

--- a/config/crd/bases/awxrestore.ansible.com_awxrestores.yaml
+++ b/config/crd/bases/awxrestore.ansible.com_awxrestores.yaml
@@ -49,7 +49,7 @@ spec:
                         memory:
                           type: string
                       type: object
-                  type: object                      
+                  type: object
                 deployment_name:
                   description: Name of the restored deployment. This should be different from the original deployment name
                     if the original deployment still exists.

--- a/config/crd/bases/awxrestore.ansible.com_awxrestores.yaml
+++ b/config/crd/bases/awxrestore.ansible.com_awxrestores.yaml
@@ -32,6 +32,24 @@ spec:
                   enum:
                     - CR
                     - PVC
+                restore_resource_requirements:
+                  description: Resource requirements for the task container
+                  properties:
+                    requests:
+                      properties:
+                        cpu:
+                          type: string
+                        memory:
+                          type: string
+                      type: object
+                    limits:
+                      properties:
+                        cpu:
+                          type: string
+                        memory:
+                          type: string
+                      type: object
+                  type: object                      
                 deployment_name:
                   description: Name of the restored deployment. This should be different from the original deployment name
                     if the original deployment still exists.

--- a/roles/backup/README.md
+++ b/roles/backup/README.md
@@ -45,7 +45,7 @@ The resulting pvc will contain a backup tar that can be used to restore to a new
 Role Variables
 --------------
 
-A custom, pre-created pvc can be used by setting the following variables.  
+A custom, pre-created pvc can be used by setting the following variables.
 
 ```
 backup_pvc: 'awx-backup-volume-claim'
@@ -60,10 +60,17 @@ backup_storage_class: 'standard'
 backup_storage_requirements: '20Gi'
 ```
 
+By default, the backup pvc will be created in the same namespace the awxbackup object is created in.  If you want your backup to be stored
+in a specific namespace, you can do so by specifying `backup_pvc_namespace`.  Keep in mind that you will
+need to provide the same namespace when restoring.
+
+```
+backup_pvc_namespace: 'custom-namespace'
+```
 The backup pvc will be created in the same namespace the awxbackup object is created in.
 
-If a custom postgres configuration secret was used when deploying AWX, it will automatically be used by the backup role.  
-To check the name of this secret, look at the postgresConfigurationSecret status on your AWX object.  
+If a custom postgres configuration secret was used when deploying AWX, it will automatically be used by the backup role.
+To check the name of this secret, look at the postgresConfigurationSecret status on your AWX object.
 
 The postgresql pod for the old deployment is used when backing up data to the new postgresql pod.  If your postgresql pod has a custom label,
 you can pass that via the `postgres_label_selector` variable to make sure the postgresql pod can be found.
@@ -74,6 +81,18 @@ It is also possible to tie the lifetime of the backup files to that of the AWXBa
 ```
 clean_backup_on_delete: true
 ```
+
+Variable to define resources limits and request for backup CR.
+```
+backup_resource_requirements:
+  limits:
+    cpu: "500m"
+    memory: "512Mi"
+  requests:
+    cpu: "500m"
+    memory: "512Mi"
+```
+
 Testing
 ----------------
 

--- a/roles/backup/defaults/main.yml
+++ b/roles/backup/defaults/main.yml
@@ -20,8 +20,17 @@ clean_backup_on_delete: false
 # Variable to signal that this role is being run as a finalizer
 finalizer_run: false
 
+# Default resource requirements
+backup_resource_requirements:
+  limits:
+    cpu: "500m"
+    memory: "512Mi"
+  requests:
+    cpu: "500m"
+    memory: "512Mi"
 # Allow additional parameters to be added to the pg_dump backup command
 pg_dump_suffix: ''
 
 # Maintain some of the recommended `app.kubernetes.io/*` labels on the resource (self)
 set_self_labels: true
+...

--- a/roles/backup/templates/management-pod.yml.j2
+++ b/roles/backup/templates/management-pod.yml.j2
@@ -20,6 +20,10 @@ spec:
     - name: {{ ansible_operator_meta.name }}-backup
       mountPath: /backups
       readOnly: false
+{% if backup_resource_requirements is defined %}
+    resources:
+      {{ backup_resource_requirements | to_nice_yaml(indent=2) | indent(width=6, indentfirst=False) }}
+{%- endif %}
   volumes:
     - name: {{ ansible_operator_meta.name }}-backup
       persistentVolumeClaim:

--- a/roles/restore/README.md
+++ b/roles/restore/README.md
@@ -35,9 +35,9 @@ spec:
   backup_name: awxbackup-2021-04-22
 ```
 
-Note that the `deployment_name` above is the name of the AWX deployment you intend to create and restore to.  
+Note that the `deployment_name` above is the name of the AWX deployment you intend to create and restore to.
 
-The namespace specified is the namespace the resulting AWX deployment will be in.  The namespace you specified must be pre-created.  
+The namespace specified is the namespace the resulting AWX deployment will be in.  The namespace you specified must be pre-created.
 
 ```
 kubectl create ns my-namespace
@@ -57,7 +57,7 @@ This will create a new deployment and restore your backup to it.
 Role Variables
 --------------
 
-The name of the backup directory can be found as a status on your AWXBackup object.  This can be found in your cluster's console, or with the client as shown below.  
+The name of the backup directory can be found as a status on your AWXBackup object.  This can be found in your cluster's console, or with the client as shown below.
 
 ```bash
 $ kubectl get awxbackup awxbackup1 -o jsonpath="{.items[0].status.backupDirectory}"
@@ -69,7 +69,7 @@ backup_dir: '/backups/tower-openshift-backup-2021-04-02-03:25:08'
 ```
 
 
-The name of the PVC can also be found by looking at the backup object.  
+The name of the PVC can also be found by looking at the backup object.
 
 ```bash
 $ kubectl get awxbackup awxbackup1 -o jsonpath="{.items[0].status.backupClaim}"

--- a/roles/restore/README.md
+++ b/roles/restore/README.md
@@ -95,6 +95,17 @@ backup_pvc: myoldtower-backup-claim
 backup_dir: /backups/tower-openshift-backup-2021-04-02-03:25:08
 ```
 
+Variable to define resources limits and request for restore CR.
+
+```
+restore_resource_requirements:
+  limits:
+    cpu: "500m"
+    memory: "512Mi"
+  requests:
+    cpu: "500m"
+    memory: "512Mi"
+```
 
 Testing
 ----------------

--- a/roles/restore/defaults/main.yml
+++ b/roles/restore/defaults/main.yml
@@ -14,5 +14,15 @@ backup_dir: ''
 # Set no_log settings on certain tasks
 no_log: 'true'
 
+# Default resource requirements
+restore_resource_requirements:
+  limits:
+    cpu: "500m"
+    memory: "512Mi"
+  requests:
+    cpu: "500m"
+    memory: "512Mi"
+
 # Maintain some of the recommended `app.kubernetes.io/*` labels on the resource (self)
 set_self_labels: true
+...

--- a/roles/restore/templates/management-pod.yml.j2
+++ b/roles/restore/templates/management-pod.yml.j2
@@ -20,6 +20,10 @@ spec:
     - name: {{ ansible_operator_meta.name }}-backup
       mountPath: /backups
       readOnly: false
+{% if restore_resource_requirements is defined %}
+    resources:
+      {{ restore_resource_requirements | to_nice_yaml(indent=2) | indent(width=6, indentfirst=False) }}
+{%- endif %}
   volumes:
     - name: {{ ansible_operator_meta.name }}-backup
       persistentVolumeClaim:


### PR DESCRIPTION
**ISSUE TYPE**

-  New or Enhanced Feature

Backup and Restore roles does not take into account set this options as we can see in the upstream code, the pods are created from a template[1][2] which doesn't have the parameters necessary to be applied in the resource.

Cheers,
Thanks in advance,

[1].-roles/backup/templates/management-pod.yml.j2
[2].-roles/restore/templates/management-pod.yml.j2


--------------------------
Edit so that CI passes:
* New or Enhanced Feature