### PR TITLE
Adding ingress class name to ingress template (#716)

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,6 +442,7 @@ The following variables are customizable when `ingress_type=ingress`. The `ingre
 | ------------------- | ---------------------------------------- | --------------------------- |
 | ingress_annotations | Ingress annotations                      | Empty string                |
 | ingress_tls_secret  | Secret that contains the TLS information | Empty string                |
+| ingress_class_name  | Define the ingress class name            | Cluster default             |
 | hostname            | Define the FQDN                          | {{ meta.name }}.example.com |
 | ingress_path        | Define the ingress path to the service   | /                           |
 | ingress_path_type   | Define the type of the path (for LBs)    | Prefix                      |

--- a/config/crd/bases/awx.ansible.com_awxs.yaml
+++ b/config/crd/bases/awx.ansible.com_awxs.yaml
@@ -115,6 +115,9 @@ spec:
               ingress_tls_secret:
                 description: Secret where the Ingress TLS secret can be found
                 type: string
+              ingress_class_name:
+                description: The name of ingress class to use instead of the cluster default.
+                type: string
               loadbalancer_protocol:
                 description: Protocol to use for the loadbalancer
                 type: string

--- a/config/manifests/bases/awx-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/awx-operator.clusterserviceversion.yaml
@@ -193,6 +193,12 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:select:none
         - urn:alm:descriptor:com.tectonic.ui:select:Ingress
         - urn:alm:descriptor:com.tectonic.ui:select:Route
+      - displayName: Ingress Class Name
+        path: ingress_class_name
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:text
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:ingress_type:Ingress
       - displayName: Ingress Path
         path: ingress_path
         x-descriptors:

--- a/roles/installer/defaults/main.yml
+++ b/roles/installer/defaults/main.yml
@@ -9,6 +9,7 @@ database_username: "{{ deployment_type }}"
 task_privileged: false
 service_type: ClusterIP
 ingress_type: none
+ingress_class_name: ''
 ingress_path: '/'
 ingress_path_type: 'Prefix'
 # Add annotations to the service account. Specify as literal block. E.g.:

--- a/roles/installer/templates/networking/ingress.yaml.j2
+++ b/roles/installer/templates/networking/ingress.yaml.j2
@@ -16,6 +16,9 @@ metadata:
     {{ ingress_annotations | indent(width=4) }}
 {% endif %}
 spec:
+{% if ingress_class_name %}
+  ingressClassName: '{{ ingress_class_name }}'
+{% endif %}
   rules:
     - http:
         paths:


### PR DESCRIPTION
Added `ingress_class_name` variable to allow you to set `ingressClassName` in the ingress resource.