### PR TITLE
Introduce `set_self_labels` in CRDs

### DIFF
--- a/config/crd/bases/awx.ansible.com_awxs.yaml
+++ b/config/crd/bases/awx.ansible.com_awxs.yaml
@@ -493,6 +493,10 @@ spec:
                   description: Should AWX instances be automatically upgraded when operator gets upgraded
                   type: boolean
                   default: true
+                set_self_labels:
+                  description: Maintain some of the recommended `app.kubernetes.io/*` labels on the resource (self)
+                  type: boolean
+                  default: true
               type: object
             status:
               properties:

--- a/config/crd/bases/awxbackup.ansible.com_awxbackups.yaml
+++ b/config/crd/bases/awxbackup.ansible.com_awxbackups.yaml
@@ -58,6 +58,10 @@ spec:
                 no_log:
                   description: Configure no_log for no_log tasks
                   type: string
+                set_self_labels:
+                  description: Maintain some of the recommended `app.kubernetes.io/*` labels on the resource (self)
+                  type: boolean
+                  default: true
             status:
               type: object
               properties:

--- a/config/crd/bases/awxrestore.ansible.com_awxrestores.yaml
+++ b/config/crd/bases/awxrestore.ansible.com_awxrestores.yaml
@@ -59,6 +59,10 @@ spec:
                 no_log:
                   description: Configure no_log for no_log tasks
                   type: string
+                set_self_labels:
+                  description: Maintain some of the recommended `app.kubernetes.io/*` labels on the resource (self)
+                  type: boolean
+                  default: true
             status:
               type: object
               properties:

--- a/roles/backup/defaults/main.yml
+++ b/roles/backup/defaults/main.yml
@@ -22,3 +22,6 @@ finalizer_run: false
 
 # Allow additional parameters to be added to the pg_dump backup command
 pg_dump_suffix: ''
+
+# Maintain some of the recommended `app.kubernetes.io/*` labels on the resource (self)
+set_self_labels: true

--- a/roles/backup/tasks/creation.yml
+++ b/roles/backup/tasks/creation.yml
@@ -16,6 +16,7 @@
           app.kubernetes.io/managed-by: "{{ deployment_type }}-operator"
           app.kubernetes.io/component: "{{ deployment_type }}"
           app.kubernetes.io/operator-version: '{{ lookup("env", "OPERATOR_VERSION") }}'
+  when: set_self_labels | bool
 
 - name: Look up details for this backup object
   k8s_info:

--- a/roles/installer/defaults/main.yml
+++ b/roles/installer/defaults/main.yml
@@ -288,3 +288,6 @@ no_log: 'true'
 # Should AWX instances be automatically upgraded when operator gets upgraded
 #
 auto_upgrade: true
+
+# Maintain some of the recommended `app.kubernetes.io/*` labels on the resource (self)
+set_self_labels: true

--- a/roles/installer/tasks/install.yml
+++ b/roles/installer/tasks/install.yml
@@ -16,6 +16,7 @@
           app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
           app.kubernetes.io/component: '{{ deployment_type }}'
           app.kubernetes.io/operator-version: '{{ lookup("env", "OPERATOR_VERSION") }}'
+  when: set_self_labels | bool
 
 - name: Include secret key configuration tasks
   include_tasks: secret_key_configuration.yml

--- a/roles/restore/defaults/main.yml
+++ b/roles/restore/defaults/main.yml
@@ -13,3 +13,6 @@ backup_dir: ''
 
 # Set no_log settings on certain tasks
 no_log: 'true'
+
+# Maintain some of the recommended `app.kubernetes.io/*` labels on the resource (self)
+set_self_labels: true

--- a/roles/restore/tasks/main.yml
+++ b/roles/restore/tasks/main.yml
@@ -16,6 +16,7 @@
           app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
           app.kubernetes.io/component: '{{ deployment_type }}'
           app.kubernetes.io/operator-version: '{{ lookup("env", "OPERATOR_VERSION") }}'
+  when: set_self_labels | bool
 
 - name: Look up details for this restore object
   k8s_info:


### PR DESCRIPTION
To allow skipping labels maintenance on CRs processed by the operator.
Resolves https://github.com/ansible/awx-operator/issues/756
