### PR TITLE
Fix #958: allow pg_dump backup command customization

### DIFF
--- a/roles/backup/defaults/main.yml
+++ b/roles/backup/defaults/main.yml
@@ -19,3 +19,6 @@ clean_backup_on_delete: false
 
 # Variable to signal that this role is being run as a finalizer
 finalizer_run: false
+
+# Allow additional parameters to be added to the pg_dump backup command
+pg_dump_suffix: ''

--- a/roles/backup/tasks/postgres.yml
+++ b/roles/backup/tasks/postgres.yml
@@ -91,6 +91,7 @@
       -d {{ awx_postgres_database }}
       -p {{ awx_postgres_port }}
       -F custom
+      {{ pg_dump_suffix }}
   no_log: "{{ no_log }}"
 
 - name: Write pg_dump to backup on PVC


### PR DESCRIPTION
This PR adds an additional free format pg_dump backup parameter. This command is added to the list of parameters that are defined in the AWX Backup Operator.