### PR TITLE
Deprecate the backup_pvc_namespace field

### DIFF
--- a/config/crd/bases/awxbackup.ansible.com_awxbackups.yaml
+++ b/config/crd/bases/awxbackup.ansible.com_awxbackups.yaml
@@ -32,13 +32,13 @@ spec:
                   description: Name of the deployment to be backed up
                   type: string
                 backup_pvc:
-                  description: Name of the PVC to be used for storing the backup
+                  description: Name of the backup PVC
                   type: string
                 backup_pvc_namespace:
-                  description: Namespace the PVC is in
+                  description: (Deprecated) Namespace the PVC is in
                   type: string
                 backup_storage_requirements:
-                  description: Storage requirements for the PostgreSQL container
+                  description: Storage requirements for backup PVC (may be similar to existing postgres PVC backing up from)
                   type: string
                 backup_storage_class:
                   description: Storage class to use when creating PVC for backup

--- a/config/crd/bases/awxrestore.ansible.com_awxrestores.yaml
+++ b/config/crd/bases/awxrestore.ansible.com_awxrestores.yaml
@@ -33,7 +33,8 @@ spec:
                     - CR
                     - PVC
                 deployment_name:
-                  description: Name of the deployment to be restored to
+                  description: Name of the restored deployment. This should be different from the original deployment name
+                    if the original deployment still exists.
                   type: string
                 backup_name:
                   description: AWXBackup object name
@@ -42,7 +43,7 @@ spec:
                   description: Name of the PVC to be restored from, set as a status found on the awxbackup object (backupClaim)
                   type: string
                 backup_pvc_namespace:
-                  description: Namespace the PVC is in
+                  description: (Deprecated) Namespace the PVC is in
                   type: string
                 backup_dir:
                   description: Backup directory name, set as a status found on the awxbackup object (backupDirectory)

--- a/config/manifests/bases/awx-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/awx-operator.clusterserviceversion.yaml
@@ -28,8 +28,7 @@ spec:
       - displayName: Backup persistent volume claim namespace
         path: backup_pvc_namespace
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:text
-        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:hidden
       - displayName: Backup PVC storage requirements
         path: backup_storage_requirements
         x-descriptors:
@@ -67,12 +66,13 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
       version: v1beta1
-    - description: Restore a previous awx deployment into the namespace
+    - description: Restore a previous awx deployment from an AWXBackup. The 
+        deployment name you provide will be the name of the new AWX CR that will be created.
       displayName: AWX Restore
       kind: AWXRestore
       name: awxrestores.awx.ansible.com
       specDescriptors:
-      - displayName: Backup source to restore ?
+      - displayName: Backup source to restore from
         path: backup_source
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:select:CR
@@ -94,7 +94,7 @@ spec:
       - displayName: Backup namespace
         path: backup_pvc_namespace
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:text
+        - urn:alm:descriptor:com.tectonic.ui:hidden
       - displayName: Backup directory in the persistent volume claim
         path: backup_dir
         x-descriptors:
@@ -107,12 +107,10 @@ spec:
       - displayName: PostgreSQL Image
         path: postgres_image
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:hidden
       - displayName: PostgreSQL Image Version
         path: postgres_image_version
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:hidden
       statusDescriptors:
       - description: The state of the restore

--- a/roles/backup/README.md
+++ b/roles/backup/README.md
@@ -60,13 +60,7 @@ backup_storage_class: 'standard'
 backup_storage_requirements: '20Gi'
 ```
 
-By default, the backup pvc will be created in the same namespace the awxbackup object is created in.  If you want your backup to be stored
-in a specific namespace, you can do so by specifying `backup_pvc_namespace`.  Keep in mind that you will
-need to provide the same namespace when restoring.  
-
-```
-backup_pvc_namespace: 'custom-namespace'
-```
+The backup pvc will be created in the same namespace the awxbackup object is created in.
 
 If a custom postgres configuration secret was used when deploying AWX, it will automatically be used by the backup role.  
 To check the name of this secret, look at the postgresConfigurationSecret status on your AWX object.  

--- a/roles/restore/README.md
+++ b/roles/restore/README.md
@@ -33,7 +33,6 @@ metadata:
 spec:
   deployment_name: mytower
   backup_name: awxbackup-2021-04-22
-  backup_pvc_namespace: 'old-awx-namespace'
 ```
 
 Note that the `deployment_name` above is the name of the AWX deployment you intend to create and restore to.  
@@ -81,11 +80,7 @@ awx-backup-volume-claim
 backup_pvc: 'awx-backup-volume-claim'
 ```
 
-By default, the backup pvc will be created in the same namespace the awxbackup object is created in. This namespace must be specified using the `backup_pvc_namespace` variable.
-
-```
-backup_pvc_namespace: 'custom-namespace'
-```
+The backup pvc will be created in the same namespace the awxbackup object is created in.
 
 If a custom postgres configuration secret was used when deploying AWX, it must be set:
 


### PR DESCRIPTION
  - Removes backup_pvc_namespace field from OLM forms
  - This field has created confusion for users and there is no strong
    case for needing this functionality
  - Users will still be able to add it to the yaml for the CR if they
    want to use it with the cluster-scoped AWX operator

> Note: a cluster-scoped AWX operator does not exist OOTB at the moment, but it may be added in the future, which is why I mention it above.  