### PR TITLE
Move custom resource definitions into a CRDs folder

### DIFF
--- a/.helm/starter/templates/postgres-config.yaml
+++ b/.helm/starter/templates/postgres-config.yaml
@@ -7,7 +7,7 @@ metadata:
 {{- with $.Values.AWX.postgres }}
 stringData:
   host: {{ .host }}
-  port: {{ .port }}
+  port: {{ .port | quote }}
   database: {{ .dbName }}
   username: {{ .username }}
   password: {{ .password }}

--- a/Makefile
+++ b/Makefile
@@ -295,6 +295,8 @@ helm-chart-generate: kustomize helm kubectl-slice yq charts
 			--output-dir=charts/$(CHART_NAME)/templates \
 			--sort-by-kind
 	@echo "AWX Operator installed with Helm Chart version $(VERSION)" > charts/$(CHART_NAME)/templates/NOTES.txt
+	mkdir charts/$(CHART_NAME)/crds
+	mv charts/$(CHART_NAME)/templates/customresourcedefinition* charts/$(CHART_NAME)/crds
 
 .PHONY: helm-chart-edit
 helm-chart-slice:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

As described in the Helm documentation (https://helm.sh/docs/chart_best_practices/custom_resource_definitions/), custom resource definitions should be included in a separate "crds" directory to ensure that Helm imports them before trying to create any custom resources. I've added a couple steps to the Makefile to move all `customresourcedefinitions` out of the template directory and into the "crds" directory.

I also found an issue with the Postgres deployment where the Port value was not being stringified properly. I've added `| quote` to ensure the templated `Secret` is valid.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug or Docs Fix

fixes #993 