### PR TITLE
fix: change to safely skip task if backupDirectory is not defined

### DIFF
--- a/roles/backup/tasks/finalizer.yml
+++ b/roles/backup/tasks/finalizer.yml
@@ -14,6 +14,7 @@
 
     - include_tasks: cleanup.yml
   vars:
-    backup_dir: "{{ this_backup['resources'][0]['status']['backupDirectory'] }}"
+    backup_dir: "{{ this_backup['resources'][0]['status']['backupDirectory'] | default() }}"
   when:
-    - clean_backup_on_delete and backup_dir is defined
+    - clean_backup_on_delete
+    - backup_dir | length > 0


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

Change to safely skip task if backupDirectory is not defined.

Closes #1003 

<!---
If you are fixing an existing issue, please include "fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug or Docs Fix

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
-->

Tested as:

```bash
# Build and push custom image including this PR
BUILD_ARGS="--build-arg DEFAULT_AWX_VERSION=21.3.0" \
IMAGE_TAG_BASE=registry.example.com/awx/awx-operator \
VERSION=0.25.0 make docker-build docker-push

# Deploy custom operator
IMG=registry.example.com/awx/awx-operator:0.25.0 make deploy
```

Then test following four cases confirm that the resource deletion completes successfully.

- Delete succeeded AWXBackup
- Delete succeeded AWXBackup with `clean_backup_on_delete: true`
- Delete failed AWXBackup
- Delete failed AWXBackup with `clean_backup_on_delete: true`

This is the Operator's log when deleting a failed AWXBackup that does not have `backupDirectory` field. Success with no error.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```text
{"level":"info","ts":1659112467.6370494,"logger":"logging_event_handler","msg":"[playbook task start]","name":"awxbackup-failed","namespace":"awx","gvk":"awx.ansible.com/v1beta1, Kind=AWXBackup","event_type":"playbook_on_task_start","job":"2402709775665985177","EventData.Name":"backup : Run creation tasks"}

--------------------------- Ansible Task StdOut -------------------------------

TASK [backup : Run creation tasks] *********************************************
task path: /opt/ansible/roles/backup/tasks/main.yml:2

-------------------------------------------------------------------------------
{"level":"info","ts":1659112467.6964478,"logger":"logging_event_handler","msg":"[playbook task start]","name":"awxbackup-failed","namespace":"awx","gvk":"awx.ansible.com/v1beta1, Kind=AWXBackup","event_type":"playbook_on_task_start","job":"2402709775665985177","EventData.Name":"backup : Run finalizer tasks"}

--------------------------- Ansible Task StdOut -------------------------------

TASK [backup : Run finalizer tasks] ********************************************
task path: /opt/ansible/roles/backup/tasks/main.yml:6

-------------------------------------------------------------------------------
{"level":"info","ts":1659112467.7122743,"logger":"logging_event_handler","msg":"[playbook task start]","name":"awxbackup-failed","namespace":"awx","gvk":"awx.ansible.com/v1beta1, Kind=AWXBackup","event_type":"playbook_on_task_start","job":"2402709775665985177","EventData.Name":"Look up details for this backup object"}

--------------------------- Ansible Task StdOut -------------------------------

TASK [Look up details for this backup object] **********************************
task path: /opt/ansible/roles/backup/tasks/finalizer.yml:2

-------------------------------------------------------------------------------
{"level":"info","ts":1659112468.5401518,"logger":"proxy","msg":"Read object from cache","resource":{"IsResourceRequest":true,"Path":"/apis/awx.ansible.com/v1beta1/namespaces/awx/awxbackups/awxbackup-failed","Verb":"get","APIPrefix":"apis","APIGroup":"awx.ansible.com","APIVersion":"v1beta1","Namespace":"awx","Resource":"awxbackups","Subresource":"","Name":"awxbackup-failed","Parts":["awxbackups","awxbackup-failed"]}}
{"level":"info","ts":1659112468.6105304,"logger":"logging_event_handler","msg":"[playbook task start]","name":"awxbackup-failed","namespace":"awx","gvk":"awx.ansible.com/v1beta1, Kind=AWXBackup","event_type":"playbook_on_task_start","job":"2402709775665985177","EventData.Name":"backup : include_tasks"}

--------------------------- Ansible Task StdOut -------------------------------

TASK [backup : include_tasks] **************************************************
task path: /opt/ansible/roles/backup/tasks/finalizer.yml:11

-------------------------------------------------------------------------------
{"level":"info","ts":1659112468.6218684,"logger":"logging_event_handler","msg":"[playbook task start]","name":"awxbackup-failed","namespace":"awx","gvk":"awx.ansible.com/v1beta1, Kind=AWXBackup","event_type":"playbook_on_task_start","job":"2402709775665985177","EventData.Name":"backup : include_tasks"}

--------------------------- Ansible Task StdOut -------------------------------

TASK [backup : include_tasks] **************************************************
task path: /opt/ansible/roles/backup/tasks/finalizer.yml:13

-------------------------------------------------------------------------------

--------------------------- Ansible Task StdOut -------------------------------

TASK [backup : include_tasks] **************************************************
task path: /opt/ansible/roles/backup/tasks/finalizer.yml:15

-------------------------------------------------------------------------------
{"level":"info","ts":1659112468.6314862,"logger":"logging_event_handler","msg":"[playbook task start]","name":"awxbackup-failed","namespace":"awx","gvk":"awx.ansible.com/v1beta1, Kind=AWXBackup","event_type":"playbook_on_task_start","job":"2402709775665985177","EventData.Name":"backup : include_tasks"}
{"level":"info","ts":1659112468.8152208,"logger":"runner","msg":"Ansible-runner exited successfully","job":"2402709775665985177","name":"awxbackup-failed","namespace":"awx"}

----- Ansible Task Status Event StdOut (awx.ansible.com/v1beta1, Kind=AWXBackup, awxbackup-failed/awx) -----


PLAY RECAP *********************************************************************
localhost                  : ok=2    changed=0    unreachable=0    failed=0    skipped=4    rescued=0    ignored=0 
```
