### PR TITLE
Use new postgres pod label when migrating from old instance

### DIFF
--- a/roles/installer/tasks/migrate_data.yml
+++ b/roles/installer/tasks/migrate_data.yml
@@ -21,17 +21,12 @@
 - name: Get the postgres pod information
   k8s_info:
     kind: Pod
-    namespace: '{{ ansible_operator_meta.namespace }}'
-    name: '{{ ansible_operator_meta.name }}-postgres-0'  # using name to keep compatibility
+    namespace: "{{ ansible_operator_meta.namespace }}"
+    label_selectors:
+      - "{{ postgres_label_selector }}"
     field_selectors:
       - status.phase=Running
   register: postgres_pod
-  until:
-    - "postgres_pod['resources'] | length"
-    - "postgres_pod['resources'][0]['status']['phase'] == 'Running'"
-    - "postgres_pod['resources'][0]['status']['containerStatuses'][0]['ready'] == true"
-  delay: 5
-  retries: 60
 
 - name: Set the resource pod name as a variable.
   set_fact:


### PR DESCRIPTION
##### SUMMARY

Follow-up for https://github.com/ansible/awx-operator/pull/841

##### ISSUE TYPE

 - Bug

##### ADDITIONAL INFORMATION

We can no longer hard-code the name of the postgres pod in the logic used to migrate data from an old AWX deployment (migrate_data.yml).  