### PR TITLE
Added pg_dump_suffix doc and crd property

### DIFF
--- a/config/crd/bases/awx.ansible.com_awxbackups.yaml
+++ b/config/crd/bases/awx.ansible.com_awxbackups.yaml
@@ -78,6 +78,9 @@ spec:
               clean_backup_on_delete:
                 description: Flag to indicate if backup should be deleted on PVC if AWXBackup object is deleted
                 type: boolean
+              pg_dump_suffix:
+                description: Additional parameters for the pg_dump command
+                type: string
               postgres_label_selector:
                 description: Label selector used to identify postgres pod for backing up data
                 type: string

--- a/roles/backup/README.md
+++ b/roles/backup/README.md
@@ -93,6 +93,12 @@ backup_resource_requirements:
     memory: "32Mi"
 ```
 
+To customize the pg_dump command that will be executed on a backup use the `pg_dump_suffix` variable. This variable will append your provided pg_dump parameters to the end of the 'standard' command. For example to exclude the data from 'main_jobevent' and 'main_job' to decrease the size of the backup use:
+
+```
+pg_dump_suffix: "--exclude-table-data 'main_jobevent*' --exclude-table-data 'main_job'"
+```
+
 Testing
 ----------------
 


### PR DESCRIPTION
Fixes: #958

##### SUMMARY
Add documentation for the 'pg_dump_suffix' parameter.
Also add this option to the awxbackup crd properties so it can be used inside the crd. Without a definition inside the crd we won't be able to use the 'pg_dump_suffix' parameter.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change