### PR TITLE
Fix helm package build redundancy and release automation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -295,6 +295,8 @@ helm-chart-generate: kustomize helm kubectl-slice yq charts
 			--output-dir=charts/$(CHART_NAME)/templates \
 			--sort-by-kind
 	@echo "AWX Operator installed with Helm Chart version $(VERSION)" > charts/$(CHART_NAME)/templates/NOTES.txt
+	# clean old crds dir before copying in newly generated CRDs
+	rm -rf charts/$(CHART_NAME)/crds
 	mkdir charts/$(CHART_NAME)/crds
 	mv charts/$(CHART_NAME)/templates/customresourcedefinition* charts/$(CHART_NAME)/crds
 

--- a/ansible/helm-release.yml
+++ b/ansible/helm-release.yml
@@ -16,7 +16,7 @@
 
     - name: Build and package helm chart
       command: |
-        make helm-chart helm-package
+        make helm-package
       environment:
         VERSION: "{{ tag }}"
         IMAGE_TAG_BASE: "{{ operator_image }}"


### PR DESCRIPTION
##### SUMMARY

The Helm package part of the AWX Operator release failed because of a conflict of sorts between these two PR that have merged:
* https://github.com/ansible/awx-operator/pull/984/files# (splits up helm-chart make target into helm-chart-generate and helm-chart-slice
* https://github.com/ansible/awx-operator/pull/994/files (which puts the CRD's in a separate directory so that helm knows to apply them first to avoid conflicts with other resources)

The error we saw on the Promote part of the release job for helm is:

```
mkdir: cannot create directory 'charts/awx-operator/crds': File exists
```

This is because the command that creates the directory is technically getting run twice because the make helm-chart target is run twice by the release automation (ansible/helm-release.yml).  In that file we run make helm-chart helm-package, which should actually be make helm-package  because that target calls helm-chart:

```
.PHONY: helm-package
helm-package: cr helm-chart
```

```diff
diff --git a/ansible/helm-release.yml b/ansible/helm-release.yml
index 7fca49d..47e2c8e 100644
--- a/ansible/helm-release.yml
+++ b/ansible/helm-release.yml
@@ -16,7 +16,7 @@
 
     - name: Build and package helm chart
       command: |
-        make helm-chart helm-package
+        make helm-package
```

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bug, Docs Fix or other nominal change

