### PR TITLE
Streamlined chart build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -269,43 +269,63 @@ charts:
 	mkdir -p $@
 
 .PHONY: helm-chart
-helm-chart: helm-chart-generate helm-chart-slice
+helm-chart: helm-chart-generate
 
 .PHONY: helm-chart-generate
 helm-chart-generate: kustomize helm kubectl-slice yq charts
-	@echo "== KUSTOMIZE (image and namespace) =="
+	@echo "== KUSTOMIZE: Set image and chart label =="
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
+	cd config/manager && $(KUSTOMIZE) edit set label helm.sh/chart:$(CHART_NAME)-$(VERSION)
+	cd config/default && $(KUSTOMIZE) edit set label helm.sh/chart:$(CHART_NAME)-$(VERSION)
 
-	@echo "== HELM =="
+	@echo "== Gather Helm Chart Metadata =="
+	# remove the existing chart if it exists
+	rm -rf charts/$(CHART_NAME)
+	# create new chart metadata in Chart.yaml
 	cd charts && \
 		$(HELM) create awx-operator --starter $(shell pwd)/.helm/starter ;\
 		$(YQ) -i '.version = "$(VERSION)"' $(CHART_NAME)/Chart.yaml ;\
 		$(YQ) -i '.appVersion = "$(VERSION)" | .appVersion style="double"' $(CHART_NAME)/Chart.yaml ;\
 		$(YQ) -i '.description = "$(CHART_DESCRIPTION)"' $(CHART_NAME)/Chart.yaml ;\
 
+	@echo "Generated chart metadata:"
 	@cat charts/$(CHART_NAME)/Chart.yaml
 
-	@echo "== KUSTOMIZE (annotation) =="
-	cd config/manager && $(KUSTOMIZE) edit set annotation helm.sh/chart:$(CHART_NAME)-$(VERSION)
-	cd config/default && $(KUSTOMIZE) edit set annotation helm.sh/chart:$(CHART_NAME)-$(VERSION)
-
-	@echo "== SLICE =="
+	@echo "== KUSTOMIZE: Generate resources and slice into templates =="
+	# place in raw-files directory so they can be modified while they are valid yaml - as soon as they are in templates/,
+	# wild cards pick up the actual templates, which are not real yaml and can't have yq run on them.
 	$(KUSTOMIZE) build --load-restrictor LoadRestrictionsNone config/default | \
 		$(KUBECTL_SLICE) --input-file=- \
-			--output-dir=charts/$(CHART_NAME)/templates \
+			--output-dir=charts/$(CHART_NAME)/raw-files \
 			--sort-by-kind
-	@echo "AWX Operator installed with Helm Chart version $(VERSION)" > charts/$(CHART_NAME)/templates/NOTES.txt
-	# clean old crds dir before copying in newly generated CRDs
-	rm -rf charts/$(CHART_NAME)/crds
-	mkdir charts/$(CHART_NAME)/crds
-	mv charts/$(CHART_NAME)/templates/customresourcedefinition* charts/$(CHART_NAME)/crds
 
-.PHONY: helm-chart-edit
-helm-chart-slice:
-	@echo "== EDIT =="
-	$(foreach file, $(wildcard charts/$(CHART_NAME)/templates/*),$(YQ) -i 'del(.. | select(has("namespace")).namespace)' $(file);)
-	$(foreach file, $(wildcard charts/$(CHART_NAME)/templates/*rolebinding*),$(YQ) -i '.subjects[0].namespace = "{{ .Release.Namespace }}"' $(file);)
-	rm -f charts/$(CHART_NAME)/templates/namespace*.yaml
+	@echo "== GIT: Reset kustomize configs =="
+	# reset kustomize configs following kustomize build
+	git checkout -f config/.
+
+	@echo "== Build Templates and CRDS =="
+	# Delete metadata.namespace, release namespace will be automatically inserted by helm
+	for file in charts/$(CHART_NAME)/raw-files/*; do\
+		$(YQ) -i 'del(.metadata.namespace)' $${file};\
+	done
+	# Correct namespace for rolebinding to be release namespace, this must be explicit
+	for file in charts/$(CHART_NAME)/raw-files/*rolebinding*; do\
+		$(YQ) -i '.subjects[0].namespace = "{{ .Release.Namespace }}"' $${file};\
+	done
+	# move all custom resource definitions to crds folder
+	mkdir charts/$(CHART_NAME)/crds
+	mv charts/$(CHART_NAME)/raw-files/customresourcedefinition*.yaml charts/$(CHART_NAME)/crds/.
+	# remove any namespace definitions
+	rm -f charts/$(CHART_NAME)/raw-files/namespace*.yaml
+	# move remaining resources to helm templates
+	mv charts/$(CHART_NAME)/raw-files/* charts/$(CHART_NAME)/templates/.
+	# remove the raw-files folder
+	rm -rf charts/$(CHART_NAME)/raw-files
+
+	# create and populate NOTES.txt
+	@echo "AWX Operator installed with Helm Chart version $(VERSION)" > charts/$(CHART_NAME)/templates/NOTES.txt
+
+	@echo "Helm chart successfully configured for $(CHART_NAME) version $(VERSION)"
 
 
 .PHONY: helm-package


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Makes the following changes to the makefile for helm chart creation:
* Unify chart build under `helm-chart-generate` header
* Clear out the charts/$chart_name folder before building
* Checkout kustomize `config` directory after building chart
  * could go more complex with conditional git stash, but this stops having to reset after building chart 
* Reconfigured yq calls based on helm template yaml limitation:
  * as soon as we add template calls to a yaml file, it can no longer be edited by yq because it is not pure yaml
  * Two-step solution:
     * Build the resources from kustomize into another directory so that the wildcard glob doesnt include real templates like `helpers` and `awx-deploy`
     * Make sure that any yq changes to the awx-operator resources that make them templates happen at the *very* end
  * Then, CRDs get copied to CRD folder, the rest of the templates get copied to the template folder
* Finally, the `helm.sh/chart` kustomization was added as an annotation, it should be a label according to the [official helm docs ](https://helm.sh/docs/chart_best_practices/labels/)

*WE SHOULD BE CAREFUL about which PRs to merge related to the makefile, it seems like there have been lots of changes that could overlap*
<!---
If you are fixing an existing issue, please include "fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
fixes #1011 

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
