### PR TITLE
Allow for disabling management of status fields on CR

### DIFF
--- a/config/crd/bases/awx.ansible.com_awxs.yaml
+++ b/config/crd/bases/awx.ansible.com_awxs.yaml
@@ -497,7 +497,11 @@ spec:
                   type: boolean
                   default: true
                 set_self_labels:
-                  description: Maintain some of the recommended `app.kubernetes.io/*` labels on the resource (self)
+                  description: Maintain some of the recommended `app.kubernetes.io/*` labels on the custom resource object
+                  type: boolean
+                  default: true
+                set_self_status:
+                  description: Set some helpful status indicators on the custom resource object
                   type: boolean
                   default: true
               type: object

--- a/config/crd/bases/awxbackup.ansible.com_awxbackups.yaml
+++ b/config/crd/bases/awxbackup.ansible.com_awxbackups.yaml
@@ -59,7 +59,11 @@ spec:
                   description: Configure no_log for no_log tasks
                   type: string
                 set_self_labels:
-                  description: Maintain some of the recommended `app.kubernetes.io/*` labels on the resource (self)
+                  description: Maintain some of the recommended `app.kubernetes.io/*` labels on the custom resource object
+                  type: boolean
+                  default: true
+                set_self_status:
+                  description: Set some helpful status indicators on the custom resource object
                   type: boolean
                   default: true
             status:

--- a/config/crd/bases/awxrestore.ansible.com_awxrestores.yaml
+++ b/config/crd/bases/awxrestore.ansible.com_awxrestores.yaml
@@ -61,7 +61,11 @@ spec:
                   description: Configure no_log for no_log tasks
                   type: string
                 set_self_labels:
-                  description: Maintain some of the recommended `app.kubernetes.io/*` labels on the resource (self)
+                  description: Maintain some of the recommended `app.kubernetes.io/*` labels on the custom resource object
+                  type: boolean
+                  default: true
+                set_self_status:
+                  description: Set some helpful status indicators on the custom resource object
                   type: boolean
                   default: true
             status:

--- a/roles/backup/defaults/main.yml
+++ b/roles/backup/defaults/main.yml
@@ -23,5 +23,8 @@ finalizer_run: false
 # Allow additional parameters to be added to the pg_dump backup command
 pg_dump_suffix: ''
 
-# Maintain some of the recommended `app.kubernetes.io/*` labels on the resource (self)
+# Maintain some of the recommended `app.kubernetes.io/*` labels on the custom resource object
 set_self_labels: true
+
+# Set some helpful status indicators on the custom resource object
+set_self_status: true

--- a/roles/backup/tasks/creation.yml
+++ b/roles/backup/tasks/creation.yml
@@ -46,3 +46,4 @@
 
 - name: Update status variables
   include_tasks: update_status.yml
+  when: set_self_status | bool

--- a/roles/installer/defaults/main.yml
+++ b/roles/installer/defaults/main.yml
@@ -292,5 +292,8 @@ no_log: 'true'
 #
 auto_upgrade: true
 
-# Maintain some of the recommended `app.kubernetes.io/*` labels on the resource (self)
+# Maintain some of the recommended `app.kubernetes.io/*` labels on the custom resource object
 set_self_labels: true
+
+# Set some helpful status indicators on the custom resource object
+set_self_status: true

--- a/roles/installer/tasks/install.yml
+++ b/roles/installer/tasks/install.yml
@@ -84,6 +84,7 @@
 
 - name: Update status variables
   include_tasks: update_status.yml
+  when: set_self_status | bool
 
 - name: Cleanup & Set garbage collection refs
   include_tasks: cleanup.yml

--- a/roles/restore/defaults/main.yml
+++ b/roles/restore/defaults/main.yml
@@ -14,5 +14,8 @@ backup_dir: ''
 # Set no_log settings on certain tasks
 no_log: 'true'
 
-# Maintain some of the recommended `app.kubernetes.io/*` labels on the resource (self)
+# Maintain some of the recommended `app.kubernetes.io/*` labels on the custom resource object
 set_self_labels: true
+
+# Set some helpful status indicators on the custom resource object
+set_self_status: true

--- a/roles/restore/tasks/main.yml
+++ b/roles/restore/tasks/main.yml
@@ -46,3 +46,4 @@
 
 - name: Update status variables
   include_tasks: update_status.yml
+  when: set_self_status | bool


### PR DESCRIPTION
##### SUMMARY
I was playing around with using the installer role without running the full operator. Something like:

```
podman run -u0 -ti --entrypoint=ansible-runner \
    -v $PWD/env/:/opt/ansible/env:Z \
    -v $HOME/.kube/:/opt/ansible/.kube:Z \
    quay.io/shanemcd/awx-operator:test run -r installer /opt/ansible
```

Where `$PWD/env/extravars` contains:

```
ansible_operator_meta:
  name: local-operator-test
  namespace: local-operator-test
set_self_labels: no
set_self_status: no
ingress_type: route
ansible_python_interpreter: /usr/bin/python3.8
```

We recently added `set_self_labels` in https://github.com/ansible/awx-operator/pull/979, but I also needed the ability to skip `update_status.yml`, since the CR does not exist at all under this scenario.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New or Enhanced Feature