### PR TITLE
Make Backup & restore requests and limits configurable

### DIFF
--- a/config/crd/bases/awx.ansible.com_awxbackups.yaml
+++ b/config/crd/bases/awx.ansible.com_awxbackups.yaml
@@ -54,6 +54,24 @@ spec:
               backup_storage_requirements:
                 description: Storage requirements for backup PVC (may be similar to existing postgres PVC backing up from)
                 type: string
+              backup_resource_requirements:
+                description: Resource requirements for the task container
+                properties:
+                  requests:
+                    properties:
+                      cpu:
+                        type: string
+                      memory:
+                        type: string
+                    type: object
+                  limits:
+                    properties:
+                      cpu:
+                        type: string
+                      memory:
+                        type: string
+                    type: object
+                type: object
               backup_storage_class:
                 description: Storage class to use when creating PVC for backup
                 type: string

--- a/config/crd/bases/awx.ansible.com_awxrestores.yaml
+++ b/config/crd/bases/awx.ansible.com_awxrestores.yaml
@@ -62,6 +62,24 @@ spec:
               backup_dir:
                 description: Backup directory name, set as a status found on the awxbackup object (backupDirectory)
                 type: string
+              backup_resource_requirements:
+                description: Resource requirements for the management pod that backs up AWX
+                properties:
+                  requests:
+                    properties:
+                      cpu:
+                        type: string
+                      memory:
+                        type: string
+                    type: object
+                  limits:
+                    properties:
+                      cpu:
+                        type: string
+                      memory:
+                        type: string
+                    type: object
+                type: object
               postgres_label_selector:
                 description: Label selector used to identify postgres pod for backing up data
                 type: string

--- a/config/crd/bases/awxbackup.ansible.com_awxbackups.yaml
+++ b/config/crd/bases/awxbackup.ansible.com_awxbackups.yaml
@@ -1,0 +1,105 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: awxbackups.awx.ansible.com
+spec:
+  group: awx.ansible.com
+  names:
+    kind: AWXBackup
+    listKind: AWXBackupList
+    plural: awxbackups
+    singular: awxbackup
+  scope: Namespaced
+  versions:
+    - name: v1beta1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+          description: Schema validation for the AWXBackup CRD
+          properties:
+            spec:
+              type: object
+              required:
+                - deployment_name
+              properties:
+                backup_resource_requirements:
+                  description: Resource requirements for the task container
+                  properties:
+                    requests:
+                      properties:
+                        cpu:
+                          type: string
+                        memory:
+                          type: string
+                      type: object
+                    limits:
+                      properties:
+                        cpu:
+                          type: string
+                        memory:
+                          type: string
+                      type: object
+                  type: object
+                deployment_name:
+                  description: Name of the deployment to be backed up
+                  type: string
+                backup_pvc:
+                  description: Name of the backup PVC
+                  type: string
+                backup_pvc_namespace:
+                  description: (Deprecated) Namespace the PVC is in
+                  type: string
+                backup_storage_requirements:
+                  description: Storage requirements for backup PVC (may be similar to existing postgres PVC backing up from)
+                  type: string
+                backup_storage_class:
+                  description: Storage class to use when creating PVC for backup
+                  type: string
+                clean_backup_on_delete:
+                  description: Flag to indicate if backup should be deleted on PVC if AWXBackup object is deleted
+                  type: boolean
+                postgres_label_selector:
+                  description: Label selector used to identify postgres pod for backing up data
+                  type: string
+                postgres_image:
+                  description: Registry path to the PostgreSQL container to use
+                  type: string
+                postgres_image_version:
+                  description: PostgreSQL container image version to use
+                  type: string
+                no_log:
+                  description: Configure no_log for no_log tasks
+                  type: string
+                set_self_labels:
+                  description: Maintain some of the recommended `app.kubernetes.io/*` labels on the resource (self)
+                  type: boolean
+                  default: true
+            status:
+              type: object
+              properties:
+                conditions:
+                  description: The resulting conditions when a Service Telemetry is instantiated
+                  items:
+                    properties:
+                      lastTransitionTime:
+                        type: string
+                      reason:
+                        type: string
+                      status:
+                        type: string
+                      type:
+                        type: string
+                    type: object
+                  type: array
+                backupDirectory:
+                  description: Backup directory name on the specified pvc
+                  type: string
+                backupClaim:
+                  description: Backup persistent volume claim
+                  type: string

--- a/config/crd/bases/awxbackup.ansible.com_awxbackups.yaml
+++ b/config/crd/bases/awxbackup.ansible.com_awxbackups.yaml
@@ -28,6 +28,24 @@ spec:
               required:
                 - deployment_name
               properties:
+                backup_resource_requirements:
+                  description: Resource requirements for the task container
+                  properties:
+                    requests:
+                      properties:
+                        cpu:
+                          type: string
+                        memory:
+                          type: string
+                      type: object
+                    limits:
+                      properties:
+                        cpu:
+                          type: string
+                        memory:
+                          type: string
+                      type: object
+                  type: object
                 deployment_name:
                   description: Name of the deployment to be backed up
                   type: string

--- a/config/crd/bases/awxrestore.ansible.com_awxrestores.yaml
+++ b/config/crd/bases/awxrestore.ansible.com_awxrestores.yaml
@@ -1,0 +1,104 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: awxrestores.awx.ansible.com
+spec:
+  group: awx.ansible.com
+  names:
+    kind: AWXRestore
+    listKind: AWXRestoreList
+    plural: awxrestores
+    singular: awxrestore
+  scope: Namespaced
+  versions:
+    - name: v1beta1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+          description: Schema validation for the AWXRestore CRD
+          properties:
+            spec:
+              type: object
+              properties:
+                backup_source:
+                  description: Backup source
+                  type: string
+                  enum:
+                    - CR
+                    - PVC
+                restore_resource_requirements:
+                  description: Resource requirements for the management pod the restores the database to the new AWX instance
+                  properties:
+                    requests:
+                      properties:
+                        cpu:
+                          type: string
+                        memory:
+                          type: string
+                      type: object
+                    limits:
+                      properties:
+                        cpu:
+                          type: string
+                        memory:
+                          type: string
+                      type: object
+                  type: object
+                deployment_name:
+                  description: Name of the restored deployment. This should be different from the original deployment name
+                    if the original deployment still exists.
+                  type: string
+                backup_name:
+                  description: AWXBackup object name
+                  type: string
+                backup_pvc:
+                  description: Name of the PVC to be restored from, set as a status found on the awxbackup object (backupClaim)
+                  type: string
+                backup_pvc_namespace:
+                  description: (Deprecated) Namespace the PVC is in
+                  type: string
+                backup_dir:
+                  description: Backup directory name, set as a status found on the awxbackup object (backupDirectory)
+                  type: string
+                postgres_label_selector:
+                  description: Label selector used to identify postgres pod for backing up data
+                  type: string
+                postgres_image:
+                  description: Registry path to the PostgreSQL container to use
+                  type: string
+                postgres_image_version:
+                  description: PostgreSQL container image version to use
+                  type: string
+                no_log:
+                  description: Configure no_log for no_log tasks
+                  type: string
+                set_self_labels:
+                  description: Maintain some of the recommended `app.kubernetes.io/*` labels on the resource (self)
+                  type: boolean
+                  default: true
+            status:
+              type: object
+              properties:
+                conditions:
+                  description: The resulting conditions when a Service Telemetry is instantiated
+                  items:
+                    properties:
+                      lastTransitionTime:
+                        type: string
+                      reason:
+                        type: string
+                      status:
+                        type: string
+                      type:
+                        type: string
+                    type: object
+                  type: array
+                restoreComplete:
+                  description: Restore process complete
+                  type: boolean

--- a/config/crd/bases/awxrestore.ansible.com_awxrestores.yaml
+++ b/config/crd/bases/awxrestore.ansible.com_awxrestores.yaml
@@ -49,7 +49,7 @@ spec:
                         memory:
                           type: string
                       type: object
-                  type: object                      
+                  type: object
                 deployment_name:
                   description: Name of the restored deployment. This should be different from the original deployment name
                     if the original deployment still exists.

--- a/config/crd/bases/awxrestore.ansible.com_awxrestores.yaml
+++ b/config/crd/bases/awxrestore.ansible.com_awxrestores.yaml
@@ -32,6 +32,24 @@ spec:
                   enum:
                     - CR
                     - PVC
+                restore_resource_requirements:
+                  description: Resource requirements for the task container
+                  properties:
+                    requests:
+                      properties:
+                        cpu:
+                          type: string
+                        memory:
+                          type: string
+                      type: object
+                    limits:
+                      properties:
+                        cpu:
+                          type: string
+                        memory:
+                          type: string
+                      type: object
+                  type: object                      
                 deployment_name:
                   description: Name of the restored deployment. This should be different from the original deployment name
                     if the original deployment still exists.

--- a/config/manifests/bases/awx-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/awx-operator.clusterserviceversion.yaml
@@ -34,6 +34,11 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
         - urn:alm:descriptor:com.tectonic.ui:advanced
+      - displayName: Backup management pod resource requirements
+        path: backup_resource_requirements
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
       - displayName: Backup PVC storage class
         path: backup_storage_class
         x-descriptors:
@@ -112,6 +117,11 @@ spec:
         path: postgres_image_version
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:hidden
+      - displayName: Restore management pod resource requirements
+        path: restore_resource_requirements
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
       statusDescriptors:
       - description: The state of the restore
         displayName: Restore status

--- a/config/samples/awx_v1beta1_awxbackup.yaml
+++ b/config/samples/awx_v1beta1_awxbackup.yaml
@@ -4,3 +4,10 @@ metadata:
   name: example-awx-backup
 spec:
   deployment_name: example-awx
+  backup_resource_requirements:
+    limits:
+      cpu: "1000m"
+      memory: "4096Mi"
+    requests:
+      cpu: "25m"
+      memory: "32Mi"

--- a/config/samples/awx_v1beta1_awxrestore.yaml
+++ b/config/samples/awx_v1beta1_awxrestore.yaml
@@ -5,3 +5,10 @@ metadata:
 spec:
   deployment_name: example-awx-2
   backup_name: example-awx-backup
+  restore_resource_requirements:
+    limits:
+      cpu: "1000m"
+      memory: "4096Mi"
+    requests:
+      cpu: "25m"
+      memory: "32Mi"

--- a/roles/backup/README.md
+++ b/roles/backup/README.md
@@ -45,7 +45,7 @@ The resulting pvc will contain a backup tar that can be used to restore to a new
 Role Variables
 --------------
 
-A custom, pre-created pvc can be used by setting the following variables.  
+A custom, pre-created pvc can be used by setting the following variables.
 
 ```
 backup_pvc: 'awx-backup-volume-claim'
@@ -60,10 +60,17 @@ backup_storage_class: 'standard'
 backup_storage_requirements: '20Gi'
 ```
 
+By default, the backup pvc will be created in the same namespace the awxbackup object is created in.  If you want your backup to be stored
+in a specific namespace, you can do so by specifying `backup_pvc_namespace`.  Keep in mind that you will
+need to provide the same namespace when restoring.
+
+```
+backup_pvc_namespace: 'custom-namespace'
+```
 The backup pvc will be created in the same namespace the awxbackup object is created in.
 
-If a custom postgres configuration secret was used when deploying AWX, it will automatically be used by the backup role.  
-To check the name of this secret, look at the postgresConfigurationSecret status on your AWX object.  
+If a custom postgres configuration secret was used when deploying AWX, it will automatically be used by the backup role.
+To check the name of this secret, look at the postgresConfigurationSecret status on your AWX object.
 
 The postgresql pod for the old deployment is used when backing up data to the new postgresql pod.  If your postgresql pod has a custom label,
 you can pass that via the `postgres_label_selector` variable to make sure the postgresql pod can be found.
@@ -74,6 +81,18 @@ It is also possible to tie the lifetime of the backup files to that of the AWXBa
 ```
 clean_backup_on_delete: true
 ```
+
+Variable to define resources limits and request for backup CR.
+```
+backup_resource_requirements:
+  limits:
+    cpu: "1000m"
+    memory: "4096Mi"
+  requests:
+    cpu: "25m"
+    memory: "32Mi"
+```
+
 Testing
 ----------------
 

--- a/roles/backup/README.md
+++ b/roles/backup/README.md
@@ -45,7 +45,7 @@ The resulting pvc will contain a backup tar that can be used to restore to a new
 Role Variables
 --------------
 
-A custom, pre-created pvc can be used by setting the following variables.  
+A custom, pre-created pvc can be used by setting the following variables.
 
 ```
 backup_pvc: 'awx-backup-volume-claim'
@@ -60,10 +60,17 @@ backup_storage_class: 'standard'
 backup_storage_requirements: '20Gi'
 ```
 
+By default, the backup pvc will be created in the same namespace the awxbackup object is created in.  If you want your backup to be stored
+in a specific namespace, you can do so by specifying `backup_pvc_namespace`.  Keep in mind that you will
+need to provide the same namespace when restoring.
+
+```
+backup_pvc_namespace: 'custom-namespace'
+```
 The backup pvc will be created in the same namespace the awxbackup object is created in.
 
-If a custom postgres configuration secret was used when deploying AWX, it will automatically be used by the backup role.  
-To check the name of this secret, look at the postgresConfigurationSecret status on your AWX object.  
+If a custom postgres configuration secret was used when deploying AWX, it will automatically be used by the backup role.
+To check the name of this secret, look at the postgresConfigurationSecret status on your AWX object.
 
 The postgresql pod for the old deployment is used when backing up data to the new postgresql pod.  If your postgresql pod has a custom label,
 you can pass that via the `postgres_label_selector` variable to make sure the postgresql pod can be found.
@@ -74,6 +81,18 @@ It is also possible to tie the lifetime of the backup files to that of the AWXBa
 ```
 clean_backup_on_delete: true
 ```
+
+Variable to define resources limits and request for backup CR.
+```
+backup_resource_requirements:
+  limits:
+    cpu: "500m"
+    memory: "512Mi"
+  requests:
+    cpu: "500m"
+    memory: "512Mi"
+```
+
 Testing
 ----------------
 

--- a/roles/backup/defaults/main.yml
+++ b/roles/backup/defaults/main.yml
@@ -20,8 +20,17 @@ clean_backup_on_delete: false
 # Variable to signal that this role is being run as a finalizer
 finalizer_run: false
 
+# Default resource requirements
+backup_resource_requirements:
+  limits:
+    cpu: "1000m"
+    memory: "4096Mi"
+  requests:
+    cpu: "25m"
+    memory: "32Mi"
 # Allow additional parameters to be added to the pg_dump backup command
 pg_dump_suffix: ''
 
 # Maintain some of the recommended `app.kubernetes.io/*` labels on the resource (self)
 set_self_labels: true
+...

--- a/roles/backup/defaults/main.yml
+++ b/roles/backup/defaults/main.yml
@@ -20,8 +20,17 @@ clean_backup_on_delete: false
 # Variable to signal that this role is being run as a finalizer
 finalizer_run: false
 
+# Default resource requirements
+backup_resource_requirements:
+  limits:
+    cpu: "500m"
+    memory: "512Mi"
+  requests:
+    cpu: "500m"
+    memory: "512Mi"
 # Allow additional parameters to be added to the pg_dump backup command
 pg_dump_suffix: ''
 
 # Maintain some of the recommended `app.kubernetes.io/*` labels on the resource (self)
 set_self_labels: true
+...

--- a/roles/backup/templates/management-pod.yml.j2
+++ b/roles/backup/templates/management-pod.yml.j2
@@ -20,6 +20,10 @@ spec:
     - name: {{ ansible_operator_meta.name }}-backup
       mountPath: /backups
       readOnly: false
+{% if backup_resource_requirements is defined %}
+    resources:
+      {{ backup_resource_requirements | to_nice_yaml(indent=2) | indent(width=6, indentfirst=False) }}
+{%- endif %}
   volumes:
     - name: {{ ansible_operator_meta.name }}-backup
       persistentVolumeClaim:

--- a/roles/restore/README.md
+++ b/roles/restore/README.md
@@ -35,9 +35,9 @@ spec:
   backup_name: awxbackup-2021-04-22
 ```
 
-Note that the `deployment_name` above is the name of the AWX deployment you intend to create and restore to.  
+Note that the `deployment_name` above is the name of the AWX deployment you intend to create and restore to.
 
-The namespace specified is the namespace the resulting AWX deployment will be in.  The namespace you specified must be pre-created.  
+The namespace specified is the namespace the resulting AWX deployment will be in.  The namespace you specified must be pre-created.
 
 ```
 kubectl create ns my-namespace
@@ -57,7 +57,7 @@ This will create a new deployment and restore your backup to it.
 Role Variables
 --------------
 
-The name of the backup directory can be found as a status on your AWXBackup object.  This can be found in your cluster's console, or with the client as shown below.  
+The name of the backup directory can be found as a status on your AWXBackup object.  This can be found in your cluster's console, or with the client as shown below.
 
 ```bash
 $ kubectl get awxbackup awxbackup1 -o jsonpath="{.items[0].status.backupDirectory}"
@@ -69,7 +69,7 @@ backup_dir: '/backups/tower-openshift-backup-2021-04-02-03:25:08'
 ```
 
 
-The name of the PVC can also be found by looking at the backup object.  
+The name of the PVC can also be found by looking at the backup object.
 
 ```bash
 $ kubectl get awxbackup awxbackup1 -o jsonpath="{.items[0].status.backupClaim}"

--- a/roles/restore/README.md
+++ b/roles/restore/README.md
@@ -35,9 +35,9 @@ spec:
   backup_name: awxbackup-2021-04-22
 ```
 
-Note that the `deployment_name` above is the name of the AWX deployment you intend to create and restore to.  
+Note that the `deployment_name` above is the name of the AWX deployment you intend to create and restore to.
 
-The namespace specified is the namespace the resulting AWX deployment will be in.  The namespace you specified must be pre-created.  
+The namespace specified is the namespace the resulting AWX deployment will be in.  The namespace you specified must be pre-created.
 
 ```
 kubectl create ns my-namespace
@@ -57,7 +57,7 @@ This will create a new deployment and restore your backup to it.
 Role Variables
 --------------
 
-The name of the backup directory can be found as a status on your AWXBackup object.  This can be found in your cluster's console, or with the client as shown below.  
+The name of the backup directory can be found as a status on your AWXBackup object.  This can be found in your cluster's console, or with the client as shown below.
 
 ```bash
 $ kubectl get awxbackup awxbackup1 -o jsonpath="{.items[0].status.backupDirectory}"
@@ -69,7 +69,7 @@ backup_dir: '/backups/tower-openshift-backup-2021-04-02-03:25:08'
 ```
 
 
-The name of the PVC can also be found by looking at the backup object.  
+The name of the PVC can also be found by looking at the backup object.
 
 ```bash
 $ kubectl get awxbackup awxbackup1 -o jsonpath="{.items[0].status.backupClaim}"
@@ -95,6 +95,17 @@ backup_pvc: myoldtower-backup-claim
 backup_dir: /backups/tower-openshift-backup-2021-04-02-03:25:08
 ```
 
+Variable to define resources limits and request for restore CR.
+
+```
+restore_resource_requirements:
+  limits:
+    cpu: "1000m"
+    memory: "4096Mi"
+  requests:
+    cpu: "25m"
+    memory: "32Mi"
+```
 
 Testing
 ----------------

--- a/roles/restore/README.md
+++ b/roles/restore/README.md
@@ -95,6 +95,17 @@ backup_pvc: myoldtower-backup-claim
 backup_dir: /backups/tower-openshift-backup-2021-04-02-03:25:08
 ```
 
+Variable to define resources limits and request for restore CR.
+
+```
+restore_resource_requirements:
+  limits:
+    cpu: "500m"
+    memory: "512Mi"
+  requests:
+    cpu: "500m"
+    memory: "512Mi"
+```
 
 Testing
 ----------------

--- a/roles/restore/defaults/main.yml
+++ b/roles/restore/defaults/main.yml
@@ -14,5 +14,15 @@ backup_dir: ''
 # Set no_log settings on certain tasks
 no_log: 'true'
 
+# Default resource requirements
+restore_resource_requirements:
+  limits:
+    cpu: "1000m"
+    memory: "4096Mi"
+  requests:
+    cpu: "25m"
+    memory: "32Mi"
+
 # Maintain some of the recommended `app.kubernetes.io/*` labels on the resource (self)
 set_self_labels: true
+...

--- a/roles/restore/defaults/main.yml
+++ b/roles/restore/defaults/main.yml
@@ -14,5 +14,15 @@ backup_dir: ''
 # Set no_log settings on certain tasks
 no_log: 'true'
 
+# Default resource requirements
+restore_resource_requirements:
+  limits:
+    cpu: "500m"
+    memory: "512Mi"
+  requests:
+    cpu: "500m"
+    memory: "512Mi"
+
 # Maintain some of the recommended `app.kubernetes.io/*` labels on the resource (self)
 set_self_labels: true
+...

--- a/roles/restore/templates/management-pod.yml.j2
+++ b/roles/restore/templates/management-pod.yml.j2
@@ -20,6 +20,10 @@ spec:
     - name: {{ ansible_operator_meta.name }}-backup
       mountPath: /backups
       readOnly: false
+{% if restore_resource_requirements is defined %}
+    resources:
+      {{ restore_resource_requirements | to_nice_yaml(indent=2) | indent(width=6, indentfirst=False) }}
+{%- endif %}
   volumes:
     - name: {{ ansible_operator_meta.name }}-backup
       persistentVolumeClaim:


### PR DESCRIPTION
##### SUMMARY

Add requests and limits for the Backup & Restore management pods.  

This PR cleans up some merge conflicts that were on https://github.com/ansible/awx-operator/pull/972 due to the Operator SDK upgrade.  

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION
This will help ensure that the management pod required for backups and restores will be scheduled properly by the k8s scheduler.  It also allows users to configure it themselves to tailor it to their own environments.  

