### PR TITLE
Remove reference to cluster.local

### DIFF
--- a/roles/installer/tasks/upgrade_postgres.yml
+++ b/roles/installer/tasks/upgrade_postgres.yml
@@ -64,7 +64,7 @@
 
 - name: Set full resolvable host name for postgres pod
   set_fact:
-    resolvable_db_host: "{{ ansible_operator_meta.name }}-postgres.{{ ansible_operator_meta.namespace }}.svc.cluster.local"  # yamllint disable-line rule:line-length
+    resolvable_db_host: "{{ ansible_operator_meta.name }}-postgres.{{ ansible_operator_meta.namespace }}.svc"  # yamllint disable-line rule:line-length
   no_log: "{{ no_log }}"
 
 - name: Set pg_dump command


### PR DESCRIPTION
##### SUMMARY
Fixes https://github.com/ansible/awx-operator/issues/1031

This change is to remove the `cluster.local` reference from the DNS lookup in `roles/installer/tasks/upgrade_postgres.yml`

The purpose of this change is to offload the resolution of the full FQDN to the search domains configured on the environment where the cluster's domain may be customized.

According to the [documentation ](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#namespaces-of-services) of Kubernetes it is permitted to query in `pod.namespace` or `pod.namespace.svc` format as the remaining is auto-expanded

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change
