### PR TITLE
Fixes #1032 - Update filter to jinja 3.x format

### DIFF
--- a/roles/backup/templates/management-pod.yml.j2
+++ b/roles/backup/templates/management-pod.yml.j2
@@ -22,7 +22,7 @@ spec:
       readOnly: false
 {% if backup_resource_requirements is defined %}
     resources:
-      {{ backup_resource_requirements | to_nice_yaml(indent=2) | indent(width=6, indentfirst=False) }}
+      {{ backup_resource_requirements | to_nice_yaml(indent=2) | indent(width=6, first=False) }}
 {%- endif %}
   volumes:
     - name: {{ ansible_operator_meta.name }}-backup

--- a/roles/installer/templates/deployments/deployment.yaml.j2
+++ b/roles/installer/templates/deployments/deployment.yaml.j2
@@ -79,7 +79,7 @@ spec:
               mountPath: "/var/lib/awx/projects"
 {% endif %}
 {% if init_container_extra_volume_mounts -%}
-            {{ init_container_extra_volume_mounts | indent(width=12, indentfirst=True) }}
+            {{ init_container_extra_volume_mounts | indent(width=12, first=True) }}
 {% endif %}
 {% endif %}
       containers:
@@ -175,7 +175,7 @@ spec:
               mountPath: "/awx_devel"
 {% endif %}
 {% if web_extra_volume_mounts -%}
-            {{ web_extra_volume_mounts | indent(width=12, indentfirst=True) }}
+            {{ web_extra_volume_mounts | indent(width=12, first=True) }}
 {% endif %}
           env:
             - name: MY_POD_NAMESPACE
@@ -189,7 +189,7 @@ spec:
               value: "1"
 {% endif %}
 {% if web_extra_env -%}
-            {{ web_extra_env | indent(width=12, indentfirst=True) }}
+            {{ web_extra_env | indent(width=12, first=True) }}
 {% endif %}
           resources: {{ web_resource_requirements }}
         - image: '{{ _image }}'
@@ -255,7 +255,7 @@ spec:
               mountPath: "/awx_devel"
 {% endif %}
 {% if task_extra_volume_mounts -%}
-            {{ task_extra_volume_mounts | indent(width=12, indentfirst=True) }}
+            {{ task_extra_volume_mounts | indent(width=12, first=True) }}
 {% endif %}
           env:
             - name: SUPERVISOR_WEB_CONFIG_PATH
@@ -279,7 +279,7 @@ spec:
               value: "1"
 {% endif %}
 {% if task_extra_env -%}
-            {{ task_extra_env | indent(width=12, indentfirst=True) }}
+            {{ task_extra_env | indent(width=12, first=True) }}
 {% endif %}
           resources: {{ task_resource_requirements }}
         - image: '{{ _control_plane_ee_image }}'
@@ -305,7 +305,7 @@ spec:
             - name: "{{ ansible_operator_meta.name }}-projects"
               mountPath: "/var/lib/awx/projects"
 {% if ee_extra_volume_mounts -%}
-            {{ ee_extra_volume_mounts | indent(width=12, indentfirst=True) }}
+            {{ ee_extra_volume_mounts | indent(width=12, first=True) }}
 {% endif %}
           env:
 {% if development_mode | bool %}
@@ -315,7 +315,7 @@ spec:
                   fieldPath: status.podIP
 {% endif %}
 {% if ee_extra_env -%}
-            {{ ee_extra_env | indent(width=12, indentfirst=True) }}
+            {{ ee_extra_env | indent(width=12, first=True) }}
 {% endif %}
 {% if node_selector %}
       nodeSelector:
@@ -436,5 +436,5 @@ spec:
             path: /awx_devel
 {% endif %}
 {% if extra_volumes -%}
-        {{ extra_volumes | indent(width=8, indentfirst=True) }}
+        {{ extra_volumes | indent(width=8, first=True) }}
 {% endif %}

--- a/roles/installer/templates/networking/ingress.yaml.j2
+++ b/roles/installer/templates/networking/ingress.yaml.j2
@@ -61,12 +61,12 @@ spec:
     termination: {{ route_tls_termination_mechanism | lower }}
 {% if route_tls_termination_mechanism | lower == 'edge' and route_tls_secret != '' %}
     key: |-
-{{ route_tls_key | indent(width=6, indentfirst=True) }}
+{{ route_tls_key | indent(width=6, first=True) }}
     certificate: |-
-{{ route_tls_crt | indent(width=6, indentfirst=True) }}
+{{ route_tls_crt | indent(width=6, first=True) }}
 {% if route_ca_crt is defined %}
     caCertificate: |-
-{{ route_ca_crt | indent(width=6, indentfirst=True) }}
+{{ route_ca_crt | indent(width=6, first=True) }}
 {% endif %}
 {% endif %}
   to:

--- a/roles/restore/templates/management-pod.yml.j2
+++ b/roles/restore/templates/management-pod.yml.j2
@@ -22,7 +22,7 @@ spec:
       readOnly: false
 {% if restore_resource_requirements is defined %}
     resources:
-      {{ restore_resource_requirements | to_nice_yaml(indent=2) | indent(width=6, indentfirst=False) }}
+      {{ restore_resource_requirements | to_nice_yaml(indent=2) | indent(width=6, first=False) }}
 {%- endif %}
   volumes:
     - name: {{ ansible_operator_meta.name }}-backup


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Latest release changed base image the operator was sourcing from in Docker. The new base image has Jinja 3.X and the earlier image had a 2.X release The format for that filter has changed in 3.x.

[Jinja change](https://github.com/pallets/jinja/blob/main/src/jinja2/filters.py#L800)
[Caused by](https://github.com/ansible/awx-operator/pull/1001)
[Change of base image](https://github.com/ansible/awx-operator/pull/1001/files#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R1)
<!---
If you are fixing an existing issue, please include "fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
