### PR TITLE
AWX.enable corrected to AWX.enabled

### DIFF
--- a/.helm/starter/README.md
+++ b/.helm/starter/README.md
@@ -5,7 +5,7 @@ This chart installs the AWX Operator resources configured in [this](https://gith
 ## Getting Started
 To configure your AWX resource using this chart, create your own `yaml` values file. The name is up to personal preference since it will explicitly be passed into the helm chart. Helm will merge whatever values you specify in your file with the default `values.yaml`, overriding any settings you've changed while allowing you to fall back on defaults. Because of this functionality, `values.yaml` should not be edited directly.
 
-In your values config, enable `AWX.enable` and add `AWX.spec` values based on the awx operator's [documentation](https://github.com/ansible/awx-operator/blob/devel/README.md). Consult the docs below for additional functionality.
+In your values config, enable `AWX.enabled` and add `AWX.spec` values based on the awx operator's [documentation](https://github.com/ansible/awx-operator/blob/devel/README.md). Consult the docs below for additional functionality.
 
 ### Installing
 The operator's [helm install](https://github.com/ansible/awx-operator/blob/devel/README.md#helm-install-on-existing-cluster) guide provides key installation instructions. 


### PR DESCRIPTION
##### ISSUE TYPE

- Bug, Docs Fix or other nominal change

##### SUMMARY

- AWX'S CR doesn't has any field for AWX.enable which mentioned in README.md . Updated the same to AWX.enabled

##### ADDITIONAL INFORMATION

- The README.md in helmchart for awx operator suggests enabling `AWX.enable` whereas the field in the values config is `AWX.enabled`. This PR contains the correction for the same.
Thank you.
