### PR TITLE
updated the default kube-rbac-proxy image from v0.11.0 to v0.13.0 (the latest)

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -16,7 +16,7 @@ spec:
         # capabilities:
         #   drop:
         #     - "ALL"
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.11.0
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"


### PR DESCRIPTION
##### SUMMARY
updated the default kube-rbac-proxy image to v0.13.0 (the latest)

##### ISSUE TYPE
Old version was v0.11.0 from Aug 10, 2021 this one is from Jun 29, 2022

##### ADDITIONAL INFORMATION
none
