### PR TITLE
fix kubectl default container name in manifest

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/default-container: manager
+        kubectl.kubernetes.io/default-container: awx-manager
       labels:
         control-plane: controller-manager
     spec:


### PR DESCRIPTION
##### SUMMARY
This fixes the default container name for kubectl. Currently, kubectl will output the following when no container is selected

```
kubectl logs awx-operator-controller-manager-868bb969f6-mnssz
Default container name "manager" not found in pod awx-operator-controller-manager-868bb969f6-mnssz
Defaulted container "kube-rbac-proxy" out of: kube-rbac-proxy, awx-manager
```
Workaround:
`kubectl logs awx-operator-controller-manager-868bb969f6-mnssz -c awx-manager`

Name was originally changed in https://github.com/ansible/awx-operator/pull/617

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

