### PR TITLE
Add check for cluster type & improve projects_persistence templating

### DIFF
--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -1,0 +1,8 @@
+---
+deployment_type: awx
+kind: 'AWX'
+api_version: '{{ deployment_type }}.ansible.com/v1beta1'
+
+# Used to determine some cluster specific logic regarding projects_persistence pvc permissions
+is_k8s: false
+is_openshift: false

--- a/roles/common/meta/main.yml
+++ b/roles/common/meta/main.yml
@@ -25,8 +25,7 @@ galaxy_info:
     - cd
     - deployment
 
-dependencies:
-  - role: common
+dependencies: []
 
 collections:
   - kubernetes.core

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -1,0 +1,20 @@
+---
+
+- name: Get information about the cluster
+  set_fact:
+    api_groups: "{{ lookup('k8s', cluster_info='api_groups') }}"
+  when:
+  - not is_openshift | bool
+  - not is_k8s | bool
+
+- name: Determine the cluster type
+  set_fact:
+    is_openshift: "{{ True if 'route.openshift.io' in api_groups else False }}"
+    is_k8s: "{{ False if 'route.openshift.io' in api_groups else True }}"
+  when:
+  - not is_openshift | bool
+  - not is_k8s | bool
+
+# Indicate what kind of cluster we are in (OpenShift or Kubernetes).
+- debug:
+    msg: "CLUSTER TYPE: is_openshift={{ is_openshift }}; is_k8s={{ is_k8s }}"

--- a/roles/installer/templates/deployments/deployment.yaml.j2
+++ b/roles/installer/templates/deployments/deployment.yaml.j2
@@ -53,7 +53,7 @@ spec:
               mkdir -p /etc/pki/ca-trust/extracted/{java,pem,openssl,edk2}
               update-ca-trust
 {% endif %}
-{% if projects_persistence|bool %}
+{% if projects_persistence|bool and is_k8s|bool %}
               chmod 775 /var/lib/awx/projects
               chgrp 1000 /var/lib/awx/projects
 {% endif %}
@@ -79,7 +79,7 @@ spec:
               subPath: bundle-ca.crt
               readOnly: true
 {% endif %}
-{% if projects_persistence|bool %}
+{% if projects_persistence|bool and is_k8s|bool %}
             - name: "{{ ansible_operator_meta.name }}-projects"
               mountPath: "/var/lib/awx/projects"
 {% endif %}
@@ -361,9 +361,9 @@ spec:
       tolerations:
         {{ tolerations | indent(width=8) }}
 {% endif %}
-{% if projects_persistence|bool or (security_context_settings|length) %}
+{% if (projects_persistence|bool and is_k8s|bool) or (security_context_settings|length) %}
       securityContext:
-{% if projects_persistence|bool %}
+{% if projects_persistence|bool and is_k8s|bool %}
         fsGroup: 1000
 {% endif %}
 {% if security_context_settings|length %}


### PR DESCRIPTION
##### SUMMARY

Project Persistence requires a PVC which can be written to by the awx user.  Certain types of PVC's will default to all of the files in the mount being owned by root.  More details on this are included in this PR which introduced this templating logic - https://github.com/ansible/awx-operator/pull/413

This logic seeks to dynamically check what cluster type awx is deployed on to appropriately template the fsGroup only when applicable.  

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bug, Docs Fix or other nominal change
