### PR TITLE
change receptor ca secret to tls secret

### DIFF
--- a/roles/installer/templates/deployments/deployment.yaml.j2
+++ b/roles/installer/templates/deployments/deployment.yaml.j2
@@ -67,7 +67,12 @@ spec:
                   fieldPath: metadata.name
           volumeMounts:
             - name: "{{ ansible_operator_meta.name }}-receptor-ca"
-              mountPath: "/etc/receptor/tls/ca"
+              mountPath: "/etc/receptor/tls/ca/receptor-ca.crt"
+              subPath: "tls.crt"
+              readOnly: true
+            - name: "{{ ansible_operator_meta.name }}-receptor-ca"
+              mountPath: "/etc/receptor/tls/ca/receptor-ca.key"
+              subPath: "tls.key"
               readOnly: true
             - name: "{{ ansible_operator_meta.name }}-receptor-tls"
               mountPath: "/etc/receptor/tls/"
@@ -179,7 +184,12 @@ spec:
               subPath: "work-public-key.pem"
               readOnly: true
             - name: "{{ ansible_operator_meta.name }}-receptor-ca"
-              mountPath: "/etc/receptor/tls/ca"
+              mountPath: "/etc/receptor/tls/ca/receptor-ca.crt"
+              subPath: "tls.crt"
+              readOnly: true
+            - name: "{{ ansible_operator_meta.name }}-receptor-ca"
+              mountPath: "/etc/receptor/tls/ca/receptor-ca.key"
+              subPath: "tls.key"
               readOnly: true
 {% if development_mode | bool %}
             - name: awx-devel
@@ -324,7 +334,7 @@ spec:
               mountPath: "/etc/receptor/"
             - name: "{{ ansible_operator_meta.name }}-receptor-ca"
               mountPath: "/etc/receptor/tls/ca/receptor-ca.crt"
-              subPath: "receptor-ca.crt"
+              subPath: "tls.crt"
               readOnly: true
             - name: "{{ ansible_operator_meta.name }}-receptor-work-signing"
               mountPath: "/etc/receptor/signing/work-private-key.pem"

--- a/roles/installer/templates/secrets/receptor_ca_secret.yaml.j2
+++ b/roles/installer/templates/secrets/receptor_ca_secret.yaml.j2
@@ -10,6 +10,7 @@ metadata:
     app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
     app.kubernetes.io/component: '{{ deployment_type }}'
     app.kubernetes.io/operator-version: '{{ lookup("env", "OPERATOR_VERSION") }}'
+type: kubernetes.io/tls
 data:
-  receptor-ca.crt: '{{ lookup('file', '{{ _receptor_ca_crt_file.path }}') | b64encode }}'
-  receptor-ca.key: '{{ lookup('file', '{{ _receptor_ca_key_file.path }}') | b64encode }}'
+  tls.crt: '{{ lookup('file', '{{ _receptor_ca_crt_file.path }}') | b64encode }}'
+  tls.key: '{{ lookup('file', '{{ _receptor_ca_key_file.path }}') | b64encode }}'


### PR DESCRIPTION
🔴 POTENTIAL BREAKING CHANGE 🔴 

##### SUMMARY
change the type of secret use for receptor ca to `kubernetes.io/tls` secret, to be more "proper"


##### ISSUE TYPE
 - New or Enhanced Feature

##### ADDITIONAL INFORMATION
this may be a breaking change! since secret type is immutable

if we have released AWX-operator from when we first introduced this secret in https://github.com/ansible/awx-operator/pull/1012

upgrade from that that version to after this PR merge will require 
- backing up the original secret
- delete the original secret
- modify the new operator created secret with the original secret's content (with no change to keys)
- issue a rollout restart to the awx deployment 

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
