### PR TITLE
change receptor ca secret to tls secret... with migration

### DIFF
--- a/roles/installer/tasks/resources_configuration.yml
+++ b/roles/installer/tasks/resources_configuration.yml
@@ -35,6 +35,50 @@
   register: _receptor_ca
   no_log: "{{ no_log }}"
 
+- name: Migrate Receptor CA Secret
+  when:
+    - _receptor_ca['resources'] | default([]) | length
+    - _receptor_ca['resources'][0]['type'] != "kubernetes.io/tls"
+  block:
+    - name: Delete old Receptor CA Secret
+      k8s:
+        state: absent
+        kind: Secret
+        namespace: '{{ ansible_operator_meta.namespace }}'
+        name: '{{ ansible_operator_meta.name }}-receptor-ca'
+    - name: Create tempfile for receptor-ca.key
+      tempfile:
+        state: file
+        suffix: .key
+      register: _receptor_ca_key_file
+    - name: Copy Receptor CA key from old secret to tempfile
+      copy:
+        content: "{{ _receptor_ca['resources'][0]['data']['receptor-ca.key'] | b64decode }}"
+        dest: "{{ _receptor_ca_key_file.path }}"
+      no_log: "{{ no_log }}"
+    - name: Create tempfile for receptor-ca.crt
+      tempfile:
+        state: file
+        suffix: .crt
+      register: _receptor_ca_crt_file
+    - name: Copy Receptor CA cert from old secret to tempfile
+      copy:
+        content: "{{ _receptor_ca['resources'][0]['data']['receptor-ca.crt'] | b64decode }}"
+        dest: "{{ _receptor_ca_crt_file.path }}"
+      no_log: "{{ no_log }}"
+    - name: Create New Receptor CA secret
+      k8s:
+        apply: true
+        definition: "{{ lookup('template', 'secrets/receptor_ca_secret.yaml.j2') }}"
+      no_log: "{{ no_log }}"
+    - name: Remove tempfiles
+      file:
+        path: "{{ item }}"
+        state: absent
+      loop:
+        - "{{ _receptor_ca_key_file.path }}"
+        - "{{ _receptor_ca_crt_file.path }}"
+
 - name: Create Receptor Mesh CA
   block:
     - name: Create tempfile for receptor-ca.key

--- a/roles/installer/templates/deployments/deployment.yaml.j2
+++ b/roles/installer/templates/deployments/deployment.yaml.j2
@@ -67,7 +67,12 @@ spec:
                   fieldPath: metadata.name
           volumeMounts:
             - name: "{{ ansible_operator_meta.name }}-receptor-ca"
-              mountPath: "/etc/receptor/tls/ca"
+              mountPath: "/etc/receptor/tls/ca/receptor-ca.crt"
+              subPath: "tls.crt"
+              readOnly: true
+            - name: "{{ ansible_operator_meta.name }}-receptor-ca"
+              mountPath: "/etc/receptor/tls/ca/receptor-ca.key"
+              subPath: "tls.key"
               readOnly: true
             - name: "{{ ansible_operator_meta.name }}-receptor-tls"
               mountPath: "/etc/receptor/tls/"
@@ -179,7 +184,12 @@ spec:
               subPath: "work-public-key.pem"
               readOnly: true
             - name: "{{ ansible_operator_meta.name }}-receptor-ca"
-              mountPath: "/etc/receptor/tls/ca"
+              mountPath: "/etc/receptor/tls/ca/receptor-ca.crt"
+              subPath: "tls.crt"
+              readOnly: true
+            - name: "{{ ansible_operator_meta.name }}-receptor-ca"
+              mountPath: "/etc/receptor/tls/ca/receptor-ca.key"
+              subPath: "tls.key"
               readOnly: true
 {% if development_mode | bool %}
             - name: awx-devel
@@ -324,7 +334,7 @@ spec:
               mountPath: "/etc/receptor/"
             - name: "{{ ansible_operator_meta.name }}-receptor-ca"
               mountPath: "/etc/receptor/tls/ca/receptor-ca.crt"
-              subPath: "receptor-ca.crt"
+              subPath: "tls.crt"
               readOnly: true
             - name: "{{ ansible_operator_meta.name }}-receptor-work-signing"
               mountPath: "/etc/receptor/signing/work-private-key.pem"

--- a/roles/installer/templates/secrets/receptor_ca_secret.yaml.j2
+++ b/roles/installer/templates/secrets/receptor_ca_secret.yaml.j2
@@ -10,6 +10,7 @@ metadata:
     app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
     app.kubernetes.io/component: '{{ deployment_type }}'
     app.kubernetes.io/operator-version: '{{ lookup("env", "OPERATOR_VERSION") }}'
+type: kubernetes.io/tls
 data:
-  receptor-ca.crt: '{{ lookup('file', '{{ _receptor_ca_crt_file.path }}') | b64encode }}'
-  receptor-ca.key: '{{ lookup('file', '{{ _receptor_ca_key_file.path }}') | b64encode }}'
+  tls.crt: '{{ lookup('file', '{{ _receptor_ca_crt_file.path }}') | b64encode }}'
+  tls.key: '{{ lookup('file', '{{ _receptor_ca_key_file.path }}') | b64encode }}'


### PR DESCRIPTION
##### SUMMARY
change the type of secret use for receptor ca to kubernetes.io/tls secret, to be more "proper"
... with migration

it seems that https://github.com/ansible/awx-operator/pull/1012 was included in release 0.29.0 

this means that people upgrading from 0.29.0 to future release will experience issue

this PR adds migration code for changing the secret 

supersedes https://github.com/ansible/awx-operator/pull/1062 

##### ISSUE TYPE
 - New or Enhanced Feature

##### ADDITIONAL INFORMATION
TODO: 
- [x] upgrade from 0.29.0 need to be tested

migration test 
- deploy awx v0.29.0 with 
```
make deploy VERSION=0.29.0
```
- instantiate awx with 
```
ansible-playbook ansible/instantiate-awx-deployment.yml \
    -e image=quay.io/haoliu/awx \
    -e image_version=devel \
    -e image_pull_policy=Always \
    -e namespace=$NAMESPACE \
    -e ingress_type=route
```
- validate that receptor ca secret is created and the content is the old format
```
awx-receptor-ca                                   Opaque                                2      13s
```
- add a remote execution node
- validate that remote execution node is functional by running demo job
- build and upgrade to the code in the PR with 
```
make docker-build docker-push deploy IMAGE_TAG_BASE=quay.io/haoliu/awx-operator
```
- validated that the secret is recreated with the same content in the tls format
```
awx-receptor-ca                                   kubernetes.io/tls                     2      52s
```
- validated that the awx deployment is updated
- validated that remote execution node remain functional after upgrade

