### PR TITLE
Change no_log type to boolean

### DIFF
--- a/README.md
+++ b/README.md
@@ -1081,7 +1081,7 @@ Example configuration of `no_log` parameter
 
 ```yaml
   spec:
-    no_log: 'true'
+    no_log: true
 ```
 
 #### Auto upgrade

--- a/config/crd/bases/awx.ansible.com_awxbackups.yaml
+++ b/config/crd/bases/awx.ansible.com_awxbackups.yaml
@@ -89,7 +89,7 @@ spec:
                 type: string
               no_log:
                 description: Configure no_log for no_log tasks
-                type: string
+                type: boolean
               set_self_labels:
                 description: Maintain some of the recommended `app.kubernetes.io/*` labels on the resource (self)
                 type: boolean

--- a/config/crd/bases/awx.ansible.com_awxrestores.yaml
+++ b/config/crd/bases/awx.ansible.com_awxrestores.yaml
@@ -91,7 +91,7 @@ spec:
                 type: string
               no_log:
                 description: Configure no_log for no_log tasks
-                type: string
+                type: boolean
               set_self_labels:
                 description: Maintain some of the recommended `app.kubernetes.io/*` labels on the resource (self)
                 type: boolean

--- a/config/crd/bases/awx.ansible.com_awxs.yaml
+++ b/config/crd/bases/awx.ansible.com_awxs.yaml
@@ -504,7 +504,7 @@ spec:
                 type: array
               no_log:
                 description: Configure no_log for no_log tasks
-                type: string
+                type: boolean
               security_context_settings:
                 description: Key/values that will be set under the pod-level securityContext field
                 type: object

--- a/roles/installer/defaults/main.yml
+++ b/roles/installer/defaults/main.yml
@@ -288,7 +288,7 @@ development_mode: false
 security_context_settings: {}
 
 # Set no_log settings on certain tasks
-no_log: 'true'
+no_log: true
 
 # Should AWX instances be automatically upgraded when operator gets upgraded
 #

--- a/roles/restore/defaults/main.yml
+++ b/roles/restore/defaults/main.yml
@@ -12,7 +12,7 @@ backup_pvc_namespace: '{{ ansible_operator_meta.namespace }}'
 backup_dir: ''
 
 # Set no_log settings on certain tasks
-no_log: 'true'
+no_log: true
 
 # Default resource requirements
 restore_resource_requirements:


### PR DESCRIPTION
##### SUMMARY

I also noticed that no_log is a string currently, instead of a boolean on the CRD. This should be changed.

This is a breaking change, but it only only affect users who have no_log specified on their CRD.  We should make sure to communicate this on the Changelog.  

Previously, setting the following would have worked:

```
spec:
  no_log: "false"
```

Now you must set it with an actual boolean, so just lose the quotes.  

```
spec:
  no_log: false
```

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Breaking Change 


##### ADDITIONAL INFORMATION
Added description in the olm metadata for if we ever make this field not hidden.  
