### PR TITLE
More no_log default updates

### DIFF
--- a/roles/backup/defaults/main.yml
+++ b/roles/backup/defaults/main.yml
@@ -12,7 +12,7 @@ backup_pvc_namespace: "{{ ansible_operator_meta.namespace }}"
 backup_storage_requirements: ''
 
 # Set no_log settings on certain tasks
-no_log: 'true'
+no_log: true
 
 # Variable to set when you want backups to be cleaned up when the CRD object is deleted
 clean_backup_on_delete: false


### PR DESCRIPTION
##### SUMMARY

Follow-up for https://github.com/ansible/awx-operator/pull/1068

I missed the backup/defaults/main.yml file when staging changes apparently.  This fixes the default no_log value.  


##### ISSUE TYPE

 - Bug, Docs Fix or other nominal change
