### PR TITLE
csv: Use booleanSwitch for no_log parameter

### DIFF
--- a/config/crd/bases/awx.ansible.com_awxbackups.yaml
+++ b/config/crd/bases/awx.ansible.com_awxbackups.yaml
@@ -90,6 +90,7 @@ spec:
               no_log:
                 description: Configure no_log for no_log tasks
                 type: boolean
+                default: true
               set_self_labels:
                 description: Maintain some of the recommended `app.kubernetes.io/*` labels on the resource (self)
                 type: boolean

--- a/config/crd/bases/awx.ansible.com_awxrestores.yaml
+++ b/config/crd/bases/awx.ansible.com_awxrestores.yaml
@@ -92,6 +92,7 @@ spec:
               no_log:
                 description: Configure no_log for no_log tasks
                 type: boolean
+                default: true
               set_self_labels:
                 description: Maintain some of the recommended `app.kubernetes.io/*` labels on the resource (self)
                 type: boolean

--- a/config/crd/bases/awx.ansible.com_awxs.yaml
+++ b/config/crd/bases/awx.ansible.com_awxs.yaml
@@ -505,6 +505,7 @@ spec:
               no_log:
                 description: Configure no_log for no_log tasks
                 type: boolean
+                default: true
               security_context_settings:
                 description: Key/values that will be set under the pod-level securityContext field
                 type: object

--- a/config/manifests/bases/awx-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/awx-operator.clusterserviceversion.yaml
@@ -63,7 +63,7 @@ spec:
         path: no_log
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
-        - urn:alm:descriptor:com.tectonic.ui:hidden
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       statusDescriptors:
       - description: The persistent volume claim name used during backup
         displayName: Backup claim
@@ -131,7 +131,7 @@ spec:
         path: no_log
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
-        - urn:alm:descriptor:com.tectonic.ui:hidden
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       statusDescriptors:
       - description: The state of the restore
         displayName: Restore status
@@ -606,7 +606,7 @@ spec:
         path: no_log
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
-        - urn:alm:descriptor:com.tectonic.ui:hidden
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - displayName: Security Context Settings
         path: security_context_settings
         x-descriptors:


### PR DESCRIPTION
##### SUMMARY
Set the `no_log` default value in the CRDs and switch from hidden to boolean in the CSV file so this can be display properly in the UI.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change