### PR TITLE
Fix version label truncating

### DIFF
--- a/roles/installer/templates/labels/version.yaml.j2
+++ b/roles/installer/templates/labels/version.yaml.j2
@@ -1,1 +1,1 @@
-app.kubernetes.io/version: '{{ _image.split(':')[-1] | truncate(63, True, '') }}'
+app.kubernetes.io/version: '{{ _image.split(':')[-1] | truncate(63, True, '', 0) }}'


### PR DESCRIPTION
Signed-off-by: Julen Landa Alustiza <jlanda@redhat.com>

If we use a sha256 hash for version, `truncate` filter receives a 64 chars long string to truncate, which will not be truncated with the default leeway of 5, failing to deploy due to a too long label

Bug, Docs Fix or other nominal change
