### PR TITLE
use dedicated image for projects persistence PVC init tasks

### DIFF
--- a/roles/installer/defaults/main.yml
+++ b/roles/installer/defaults/main.yml
@@ -164,6 +164,8 @@ _control_plane_ee_image: quay.io/ansible/awx-ee:latest
 _init_container_image: "{{ _control_plane_ee_image.split(':')[0] }}"
 _init_container_image_version: "{{ _control_plane_ee_image.split(':')[1] }}"
 
+_init_projects_container_image: quay.io/centos/centos:stream9
+
 create_preload_data: true
 
 replicas: "1"

--- a/roles/installer/templates/deployments/deployment.yaml.j2
+++ b/roles/installer/templates/deployments/deployment.yaml.j2
@@ -54,10 +54,6 @@ spec:
               mkdir -p /etc/pki/ca-trust/extracted/{java,pem,openssl,edk2}
               update-ca-trust
 {% endif %}
-{% if projects_persistence|bool and is_k8s|bool %}
-              chmod 775 /var/lib/awx/projects
-              chgrp 1000 /var/lib/awx/projects
-{% endif %}
 {% if init_container_extra_commands %}
               {{ init_container_extra_commands | indent(width=14) }}
 {% endif %}
@@ -85,12 +81,27 @@ spec:
               subPath: bundle-ca.crt
               readOnly: true
 {% endif %}
-{% if projects_persistence|bool and is_k8s|bool %}
-            - name: "{{ ansible_operator_meta.name }}-projects"
-              mountPath: "/var/lib/awx/projects"
-{% endif %}
 {% if init_container_extra_volume_mounts -%}
             {{ init_container_extra_volume_mounts | indent(width=12, first=True) }}
+{% endif %}
+{% if projects_persistence|bool and is_k8s|bool %}
+        - name: init-projects
+          image: '{{ _init_projects_container_image }}'
+          imagePullPolicy: '{{ image_pull_policy }}'
+          command:
+            - /bin/sh
+            - -c
+            - |
+              chmod 775 /var/lib/awx/projects
+              chgrp 1000 /var/lib/awx/projects
+          env:
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+          volumeMounts:
+            - name: "{{ ansible_operator_meta.name }}-projects"
+              mountPath: "/var/lib/awx/projects"
 {% endif %}
       containers:
         - image: '{{ _redis_image }}'


### PR DESCRIPTION
Delegate `chmod` and `chgrp` tasks to a dedicated init container running as root.

Fixes #1055

##### SUMMARY

On some storage provisioners, owner of mounted PVCs will not be mapped to the `fsGroup` security context setting.

So directory modifications at the mount point level like `chmod`, `chown` or `chgrp` will not be possible for a non-root running container.

Solution : modify deployment template `roles/installer/templates/deployments/deployment.yaml.j2` to create a second init container dedicated to running tasks related to projects persistence volume

##### ISSUE TYPE

 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION

Tested with operator `0.30.0`