### PR TITLE
Avoid molecule 4.0.2

### DIFF
--- a/molecule/requirements.txt
+++ b/molecule/requirements.txt
@@ -1,4 +1,4 @@
-molecule
+molecule!=4.0.2
 molecule-docker
 yamllint
 ansible-lint


### PR DESCRIPTION
Signed-off-by: Julen Landa Alustiza <jlanda@redhat.com>

`molecule` test runs are failing with 4.0.2:

Tested locally on my box
```
["Additional properties are not allowed ('lint' was unexpected)"]
```

No idea how to align with this breaking change yet, but for now avoid 4.0.2 version

Bug, Docs Fix or other nominal change