### PR TITLE
Enable configuration of route and ingress api versions

### DIFF
--- a/config/crd/bases/awx.ansible.com_awxs.yaml
+++ b/config/crd/bases/awx.ansible.com_awxs.yaml
@@ -103,6 +103,9 @@ spec:
                 - ingress
                 - Route
                 - route
+              ingress_api_version:
+                description: The Ingress API version to use
+                type: string
               ingress_path:
                 description: The ingress path used to reach the deployed service
                 type: string
@@ -141,6 +144,9 @@ spec:
                 - edge
                 - Passthrough
                 - passthrough
+              route_api_version:
+                description: The route API version to use
+                type: string
               route_tls_secret:
                 description: Secret where the TLS related credentials are stored
                 type: string

--- a/config/manifests/bases/awx-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/awx-operator.clusterserviceversion.yaml
@@ -222,6 +222,11 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:text
         - urn:alm:descriptor:com.tectonic.ui:fieldDependency:ingress_type:Ingress
+      - displayName: Ingress API Version
+        path: ingress_api_version
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:text 
       - displayName: Ingress Path
         path: ingress_path
         x-descriptors:
@@ -265,6 +270,11 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:number
         - urn:alm:descriptor:com.tectonic.ui:fieldDependency:service_type:LoadBalancer
+      - displayName: Route API Version
+        path: route_api_version
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:text
       - displayName: Route DNS host
         path: route_host
         x-descriptors:

--- a/roles/installer/defaults/main.yml
+++ b/roles/installer/defaults/main.yml
@@ -12,6 +12,7 @@ ingress_type: none
 ingress_class_name: ''
 ingress_path: '/'
 ingress_path_type: 'Prefix'
+ingress_api_version: 'networking.k8s.io/v1'
 # Add annotations to the service account. Specify as literal block. E.g.:
 # service_account_annotations: |
 #   eks.amazonaws.com/role-arn: arn:aws:iam::<ACCOUNT_ID>:role/<IAM_ROLE_NAME>
@@ -49,6 +50,9 @@ route_tls_termination_mechanism: edge
 # credentials to deploy
 #
 route_tls_secret: ''
+
+# Route API Version to use
+route_api_version: 'route.openshift.io/v1'
 
 # Host to create the root with.
 # If not specific will default to <instance-name>-<namespace>-<routerCanonicalHostname>

--- a/roles/installer/defaults/main.yml
+++ b/roles/installer/defaults/main.yml
@@ -51,7 +51,8 @@ route_tls_termination_mechanism: edge
 #
 route_tls_secret: ''
 
-# Route API Version to use
+# Route API Version to support older version
+# of the kubernetes services
 route_api_version: 'route.openshift.io/v1'
 
 # Host to create the root with.

--- a/roles/installer/templates/networking/ingress.yaml.j2
+++ b/roles/installer/templates/networking/ingress.yaml.j2
@@ -1,6 +1,8 @@
 {% if ingress_type|lower == "ingress" %}
 ---
-apiVersion: networking.k8s.io/v1
+{% if ingress_api_version is defined %}
+apiVersion: '{{ ingress_api_version }}'
+{% endif %}
 kind: Ingress
 metadata:
   name: '{{ ansible_operator_meta.name }}-ingress'
@@ -42,7 +44,9 @@ spec:
 
 {% if ingress_type|lower == "route" %}
 ---
-apiVersion: route.openshift.io/v1
+{% if route_api_version is defined %}
+apiVersion: '{{ route_api_version }}'
+{% endif %}
 kind: Route
 metadata:
   name: '{{ ansible_operator_meta.name }}'


### PR DESCRIPTION
##### SUMMARY

Current version of the operator restricts the installation only on the versions of Kubernetes that use "v1". The new variables "ingress_api_version" and "route_api_version" are introduced to enhance the AWX operator features that provides a better control over the Kubernetes ingress API resources which are running on older versions as well.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New or Enhanced Feature

