### PR TITLE
Version 4.0.3 still not fixed, pin to before

### DIFF
--- a/molecule/requirements.txt
+++ b/molecule/requirements.txt
@@ -1,4 +1,4 @@
-molecule!=4.0.2
+molecule<4.0.2
 molecule-docker
 yamllint
 ansible-lint


### PR DESCRIPTION
##### SUMMARY
This was pinned to not use 4.0.2, but 4.0.3 came out, and automatically it was used by AWX CI, which of course promptly failed checks.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change


