### PR TITLE
Backup and restore receptor tls secret with expected generated name

### DIFF
--- a/roles/backup/tasks/awx-cro.yml
+++ b/roles/backup/tasks/awx-cro.yml
@@ -25,6 +25,7 @@
   set_fact:
     awx_spec:
       spec: "{{ _awx }}"
+      previous_deployment_name: "{{ this_awx['resources'][0]['metadata']['name'] }}"
 
 - name: Write awx object to pvc
   k8s_exec:

--- a/roles/backup/tasks/dump_receptor_secrets.yml
+++ b/roles/backup/tasks/dump_receptor_secrets.yml
@@ -1,0 +1,24 @@
+---
+
+- name: Get secret
+  k8s_info:
+    version: v1
+    kind: Secret
+    namespace: '{{ ansible_operator_meta.namespace }}'
+    name: "{{ item }}"
+  register: _secret
+  no_log: "{{ no_log }}"
+
+- name: Backup secret if exists
+  block:
+    - name: Set secret key
+      set_fact:
+        _data: "{{ _secret['resources'][0]['data'] }}"
+        _type: "{{ _secret['resources'][0]['type'] }}"
+      no_log: "{{ no_log }}"
+
+    - name: Create and Add secret names and data to dictionary
+      set_fact:
+        secret_dict: "{{ secret_dict | default({}) | combine({item: { 'name': item, 'data': _data, 'type': _type }}) }}"
+      no_log: "{{ no_log }}"
+  when: _secret | length

--- a/roles/backup/tasks/secrets.yml
+++ b/roles/backup/tasks/secrets.yml
@@ -1,11 +1,5 @@
 ---
 
-- name: Create Temporary secrets file
-  tempfile:
-    state: file
-    suffix: .json
-  register: tmp_secrets
-
 - name: Dump (generated) secret names from statuses and data into file
   include_tasks: dump_generated_secret.yml
   with_items:
@@ -22,6 +16,12 @@
     - ldap_cacert_secret
     - bundle_cacert_secret
     - ee_pull_credentials_secret
+
+- name: Dump receptor secret names and data into file
+  include_tasks: dump_receptor_secrets.yml
+  loop:
+    - '{{ deployment_name }}-receptor-ca'
+    - '{{ deployment_name }}-receptor-work-signing'
 
 # image_pull_secret is deprecated in favor of image_pull_secrets
 - name: Dump image_pull_secret into file

--- a/roles/installer/tasks/cleanup.yml
+++ b/roles/installer/tasks/cleanup.yml
@@ -23,6 +23,8 @@
         - '{{ _secret_key }}'
         - '{{ _postgres_configuration }}'
         - '{{ _broadcast_websocket_secret }}'
+        - '{{ ansible_operator_meta.name }}-receptor-ca'
+        - '{{ ansible_operator_meta.name }}-receptor-work-signing'
       no_log: "{{ no_log }}"
 
   when: not garbage_collect_secrets | bool

--- a/roles/restore/tasks/deploy_awx.yml
+++ b/roles/restore/tasks/deploy_awx.yml
@@ -1,27 +1,5 @@
 ---
 
-- name: Get AWX object definition from pvc
-  k8s_exec:
-    namespace: "{{ backup_pvc_namespace }}"
-    pod: "{{ ansible_operator_meta.name }}-db-management"
-    command: >-
-      bash -c "cat '{{ backup_dir }}/awx_object'"
-  register: awx_object
-
-- name: Create temp file for spec dict
-  tempfile:
-    state: file
-  register: tmp_spec
-
-- name: Write spec vars to temp file
-  copy:
-    content: "{{ awx_object.stdout }}"
-    dest: "{{ tmp_spec.path }}"
-    mode: '0644'
-
-- name: Include spec vars to save them as a dict
-  include_vars: "{{ tmp_spec.path }}"
-
 - name: Deploy AWX
   k8s:
     state: "{{ state | default('present') }}"

--- a/roles/restore/tasks/import_vars.yml
+++ b/roles/restore/tasks/import_vars.yml
@@ -1,0 +1,25 @@
+---
+
+- name: Import awx_object variables
+  block:
+  - name: Get AWX object definition from pvc
+    k8s_exec:
+      namespace: "{{ backup_pvc_namespace }}"
+      pod: "{{ ansible_operator_meta.name }}-db-management"
+      command: >-
+        bash -c "cat '{{ backup_dir }}/awx_object'"
+    register: awx_object
+
+  - name: Create temp file for spec dict
+    tempfile:
+      state: file
+    register: tmp_spec
+
+  - name: Write spec vars to temp file
+    copy:
+      content: "{{ awx_object.stdout }}"
+      dest: "{{ tmp_spec.path }}"
+      mode: '0644'
+
+  - name: Include spec vars to save them as a dict
+    include_vars: "{{ tmp_spec.path }}"

--- a/roles/restore/tasks/main.yml
+++ b/roles/restore/tasks/main.yml
@@ -29,6 +29,8 @@
 - block:
     - include_tasks: init.yml
 
+    - include_tasks: import_vars.yml
+
     - include_tasks: secrets.yml
 
     - include_tasks: deploy_awx.yml

--- a/roles/restore/tasks/secrets.yml
+++ b/roles/restore/tasks/secrets.yml
@@ -54,6 +54,37 @@
       no_log: "{{ no_log }}"
   when: secrets['postgresConfigurationSecret']['data']['type'] | b64decode == 'managed'
 
+- name: Set new receptor secret names
+  set_fact:
+    previous_receptor_ca_name: "{{ previous_deployment_name }}-receptor-ca"
+    previous_receptor_tls_name: "{{ previous_deployment_name }}-receptor-work-signing"
+  no_log: "{{ no_log }}"
+
+- name: Set new name for receptor secrets using deployment_name
+  block:
+    - name: Set new receptor secret names
+      set_fact:
+        receptor_ca_name: "{{ deployment_name }}-receptor-ca"
+        receptor_work_signing_name: "{{ deployment_name }}-receptor-work-signing"
+      no_log: "{{ no_log }}"
+
+    - name: Set tmp dict for receptor secrets
+      set_fact:
+        _ca_secret: "{{ secrets[previous_receptor_ca_name] }}"
+        _work_signing_secret: "{{ secrets[previous_receptor_tls_name] }}"
+      no_log: "{{ no_log }}"
+
+    - name: Change receptor secret names in tmp dict
+      set_fact:
+        _ca_secret_name: "{{ _ca_secret | combine({ 'name': receptor_ca_name }) }}"
+        _work_signing_secret_name: "{{ _work_signing_secret | combine({ 'name': receptor_work_signing_name}) }}"
+      no_log: "{{ no_log }}"
+
+    - name: Create a new dict of receptor secrets with updated names
+      set_fact:
+        secrets: "{{ secrets | combine({previous_receptor_ca_name: _ca_secret_name, previous_receptor_tls_name: _work_signing_secret_name}) }}"
+      no_log: "{{ no_log }}"
+
 - name: Apply secret
   k8s:
     state: present


### PR DESCRIPTION
##### SUMMARY
Follow-up for https://github.com/ansible/awx-operator/pull/1012

The receptor TLS and Work Signing secrets get generated with expected names:
* `<deployment-name>-receptor-ca`
* `<deployment-name>-receptor-work-signing`

This logic backs up those secrets and restores them.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - New or Enhanced Feature


##### ADDITIONAL INFORMATION
The last problem to solve here is how to get the name of the old deployment in the context of the restore role.  May need to add that to the backup info.  
