### PR TITLE
Amend permissions for backup dir

### DIFF
--- a/roles/backup/tasks/postgres.yml
+++ b/roles/backup/tasks/postgres.yml
@@ -75,7 +75,7 @@
     namespace: "{{ backup_pvc_namespace }}"
     pod: "{{ ansible_operator_meta.name }}-db-management"
     command: >-
-      bash -c "chmod 0600 {{ backup_dir }}/tower.db && chown postgres:root {{ backup_dir }}/tower.db"
+      bash -c "chmod 660 {{ backup_dir }}/tower.db && chown :root {{ backup_dir }}/tower.db"
 
 - name: Set full resolvable host name for postgres pod
   set_fact:


### PR DESCRIPTION
##### SUMMARY

Currently, on Backups, we are seeing:

```
 TASK [Set permissions on file for database dump] ********************************
fatal: [localhost]: FAILED! => {"changed": true, "rc": 1, "return_code": 1, "stderr": "chown: changing ownership of '/backups/tower-openshift-backup-2022-11-03-12:43:03/tower.db': Operation not permitted\n", "stderr_lines": ["chown: changing ownership of '/backups/tower-openshift-backup-2022-11-03-12:43:03/tower.db': Operation not permitted"]
```

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```

##### TESTING

I was able to deploy awx, create a backup, and restore from that backup using these changes.

```
$ oc get pods
NAME                                              READY   STATUS    RESTARTS   AGE
awx-2-6f9cc8f8cd-msh94                            4/4     Running   0          3m31s
awx-2-postgres-13-0                               1/1     Running   0          4m16s
awx-5c6c8889b8-fw7ks                              4/4     Running   0          20m
awx-operator-controller-manager-bd9598845-qtsxp   2/2     Running   0          21m
awx-postgres-13-0                                 1/1     Running   0          20m
```
