### PR TITLE
[fix] backup role use k8s_cp module to write large files

### DIFF
--- a/roles/backup/tasks/awx-cro.yml
+++ b/roles/backup/tasks/awx-cro.yml
@@ -27,8 +27,8 @@
       spec: "{{ _awx }}"
 
 - name: Write awx object to pvc
-  k8s_exec:
+  k8s_cp:
     namespace: "{{ backup_pvc_namespace }}"
     pod: "{{ ansible_operator_meta.name }}-db-management"
-    command: >-
-      bash -c 'echo "$0" > {{ backup_dir  }}/awx_object' {{ awx_spec | to_yaml | quote  }}
+    remote_path: "{{ backup_dir  }}/awx_object"
+    content: "{{ awx_spec | to_yaml }}"

--- a/roles/backup/tasks/secrets.yml
+++ b/roles/backup/tasks/secrets.yml
@@ -42,9 +42,9 @@
   no_log: "{{ no_log }}"
 
 - name: Write postgres configuration to pvc
-  k8s_exec:
+  k8s_cp:
     namespace: "{{ backup_pvc_namespace }}"
     pod: "{{ ansible_operator_meta.name }}-db-management"
-    command: >-
-      bash -c "echo '{{ secrets | to_yaml }}' > {{ backup_dir }}/secrets.yml"
+    remote_path: "{{ backup_dir }}/secrets.yml"
+    content: "{{ secrets | to_yaml }}"
   no_log: "{{ no_log }}"


### PR DESCRIPTION
##### SUMMARY

fixes #566 

The backup role now uses the `k8s_cp` ansible module to write the backup files:

- secrets.yml
- awx_object

instead to use the k8s_exec module with shell redirecting + jinja templating magic.

Previously, the backup roll failed when large files were written.
Now big files will be handled properly.

##### ISSUE TYPE
- New or Enhanced Feature