### PR TITLE
remove helm chart version from labels

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -296,8 +296,8 @@ helm-chart: helm-chart-generate
 helm-chart-generate: kustomize helm kubectl-slice yq charts
 	@echo "== KUSTOMIZE: Set image and chart label =="
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
-	cd config/manager && $(KUSTOMIZE) edit set label helm.sh/chart:$(CHART_NAME)-$(VERSION)
-	cd config/default && $(KUSTOMIZE) edit set label helm.sh/chart:$(CHART_NAME)-$(VERSION)
+	cd config/manager && $(KUSTOMIZE) edit set label helm.sh/chart:$(CHART_NAME)
+	cd config/default && $(KUSTOMIZE) edit set label helm.sh/chart:$(CHART_NAME)
 
 	@echo "== Gather Helm Chart Metadata =="
 	# remove the existing chart if it exists


### PR DESCRIPTION
##### SUMMARY
Remove the Helm chart version from `helm.sh/chart` labels in all Helm templates.

Fixes #1057 

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION
Including chart version in the `matchLabel` selector of the AWX deployment template causes problem during the `helm upgrade` of the AWX operator. Indeed this field is now immutable for deployments in recent versions of Kubernetes (https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#label-selector-updates). So running a `helm upgrade` with a chart containing a deployment template with a different content in the `spec.selector.matchLabels` field is not allowed and causes an error.

An acceptable solution when using `kustomize` is to remove chart version in labels. This will allow to continue to adhere to Helm best practices by having a relationship between `metadata.labels` and `selector.matchLabels` fields.

Tested on `devel` with `make helm-chart` and executing multiple `helm upgrade`