### PR TITLE
add startupProbe for web

### DIFF
--- a/roles/installer/templates/deployments/web.yaml.j2
+++ b/roles/installer/templates/deployments/web.yaml.j2
@@ -152,6 +152,13 @@ spec:
         - image: '{{ _image }}'
           name: '{{ ansible_operator_meta.name }}-web'
           imagePullPolicy: '{{ image_pull_policy }}'
+          startupProbe:
+            httpGet:
+              path: /api/v2/ping/
+              port: 8052
+              scheme: HTTP
+            periodSeconds: 10
+            failureThreshold: 60
 {% if web_command %}
           command: {{ web_command }}
 {% endif %}


### PR DESCRIPTION
##### SUMMARY
Wen controlplane scale the container is go to ready fastly and the web/api is not ready, so client has 503 response

The startupProbe allows to protect time for starting web/api in autoscale scenario

##### ISSUE TYPE
503 in autoscale scenario

##### ADDITIONAL INFORMATION

Maybe the value of failureThreshold is incorrect, the django migration can put more time in update or initial scenario 


