### PR TITLE
Set Minimum K8s cluster version we expect to work

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/default-container: manager
+        kubectl.kubernetes.io/default-container: awx-manager
       labels:
         control-plane: controller-manager
     spec:

--- a/config/manifests/bases/awx-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/awx-operator.clusterserviceversion.yaml
@@ -777,6 +777,7 @@ spec:
   - email: awx-project@googlegroups.com
     name: AWX Team
   maturity: alpha
+  MinKubeVersion: 1.22.15
   provider:
     name: Ansible
     url: github.com/ansible/awx-operator


### PR DESCRIPTION
##### SUMMARY
A minimum csv.Spec.minKubeVersion needs to be set.  

```
$ operator-sdk bundle validate ./bundle --select-optional suite=operatorframework
WARN[0000] Warning: Value : (awx-operator.v1.0.0) csv.Spec.minKubeVersion is not informed. It is recommended you provide this information. Otherwise, it would mean that your operator project can be distributed and installed in any cluster version available, which is not necessarily the case for all projects. 
```

References:
* https://github.com/operator-framework/operator-lifecycle-manager/blob/master/doc/design/building-your-csv.md




##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bug, Docs Fix or other nominal change

##### Additional Information

After making this change, the operator-sdk validation tests pass:

```
$ operator-sdk bundle validate ./bundle --select-optional suite=operatorframework
INFO[0000] All validation tests have completed successfully 
```

This is needed for publishing the operator on OperatorHub:
* https://github.com/k8s-operatorhub/community-operators/pull/1898