### PR TITLE
Added flag to disable ipv6 listener

### DIFF
--- a/config/crd/bases/awx.ansible.com_awxs.yaml
+++ b/config/crd/bases/awx.ansible.com_awxs.yaml
@@ -524,6 +524,10 @@ spec:
                 description: Maintain some of the recommended `app.kubernetes.io/*` labels on the resource (self)
                 type: boolean
                 default: true
+              ipv6_disabled:
+                description: Disable web container's nginx ipv6 listener
+                type: boolean
+                default: false
             type: object
           status:
             properties:

--- a/config/manifests/bases/awx-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/awx-operator.clusterserviceversion.yaml
@@ -702,6 +702,11 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - displayName: Disable IPv6 listener?
+        path: ipv6_disabled
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       statusDescriptors:
       - description: Route to access the instance deployed
         displayName: URL

--- a/roles/installer/defaults/main.yml
+++ b/roles/installer/defaults/main.yml
@@ -303,3 +303,6 @@ auto_upgrade: true
 
 # Maintain some of the recommended `app.kubernetes.io/*` labels on the resource (self)
 set_self_labels: true
+
+# Disable web container's nginx ipv6 listener
+ipv6_disabled: false

--- a/roles/installer/templates/configmaps/config.yaml.j2
+++ b/roles/installer/templates/configmaps/config.yaml.j2
@@ -132,7 +132,9 @@ data:
         {% if route_tls_termination_mechanism | lower == 'passthrough' %}
         server {
             listen 8052 default_server;
+            {% if not ipv6_disabled %}
             listen [::]:8052 default_server;
+            {% endif %}
             server_name _;
 
             # Redirect all HTTP links to the matching HTTPS page
@@ -143,7 +145,9 @@ data:
         server {
         {% if route_tls_termination_mechanism | lower == 'passthrough' %}
             listen 8053 ssl;
+            {% if not ipv6_disabled %}
             listen [::]:8053 ssl;
+            {% endif %}
 
             ssl_certificate /etc/nginx/pki/web.crt;
             ssl_certificate_key /etc/nginx/pki/web.key;
@@ -154,7 +158,9 @@ data:
             ssl_prefer_server_ciphers on;
         {% else %}
             listen 8052 default_server;
+            {% if not ipv6_disabled %}
             listen [::]:8052 default_server;
+            {% endif %}
         {% endif %}
 
             # If you have a domain name, this is where to add it


### PR DESCRIPTION
Copy of https://github.com/ansible/awx-operator/pull/1024.  Apologies for the redundancy, but my team is looking to see this change made and I was tired of waiting for the update to the other PR

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

Introducing flag to disable nginx IPv6 listener, for environments that are not IPv6-enabled

<!---
If you are fixing an existing issue, please include "fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION

Flag named ipv6_disabled, defaults to false
