### PR TITLE
Add possibility specifying affinity of AWX Pods.

### DIFF
--- a/README.md
+++ b/README.md
@@ -704,20 +704,20 @@ You can constrain the AWX pods created by the operator to run on a certain subse
 the AWX pods to run only on the nodes that match all the specified key/value pairs. `tolerations` and `postgres_tolerations` allow the AWX
 pods to be scheduled onto nodes with matching taints.
 The ability to specify topologySpreadConstraints is also allowed through `topology_spread_constraints`
-If you want to use affinity rules for your AWX pod you can use the `node_affinity` option.
+If you want to use affinity rules for your AWX pod you can use the `affinity` option.
 
 
-| Name                        | Description                         | Default |
-| --------------------------- | ----------------------------------- | ------- |
-| postgres_image              | Path of the image to pull           | postgres      |
-| postgres_image_version      | Image version to pull               | 13      |
-| node_selector               | AWX pods' nodeSelector              | ''      |
-| topology_spread_constraints | AWX pods' topologySpreadConstraints | ''      |
-| node_affinity                  | AWX pods' affinity rules    | ''      |
-| tolerations                 | AWX pods' tolerations               | ''      |
-| annotations                 | AWX pods' annotations               | ''      |
-| postgres_selector           | Postgres pods' nodeSelector         | ''      |
-| postgres_tolerations        | Postgres pods' tolerations          | ''      |
+| Name                        | Description                         | Default  |
+| --------------------------- | ----------------------------------- | -------  |
+| postgres_image              | Path of the image to pull           | postgres |
+| postgres_image_version      | Image version to pull               | 13       |
+| node_selector               | AWX pods' nodeSelector              | ''       |
+| topology_spread_constraints | AWX pods' topologySpreadConstraints | ''       |
+| affinity                    | AWX pods' affinity rules            | ''       |
+| tolerations                 | AWX pods' tolerations               | ''       |
+| annotations                 | AWX pods' annotations               | ''       |
+| postgres_selector           | Postgres pods' nodeSelector         | ''       |
+| postgres_tolerations        | Postgres pods' tolerations          | ''       |
 
 Example of customization could be:
 
@@ -760,6 +760,18 @@ spec:
             operator: In
             values:
             - another-node-label-value
+            - another-node-label-value
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          labelSelector:
+            matchExpressions:
+            - key: security
+              operator: In
+              values:
+              - S2
+          topologyKey: topology.kubernetes.io/zone
 ```
 
 #### Trusting a Custom Certificate Authority

--- a/README.md
+++ b/README.md
@@ -704,6 +704,7 @@ You can constrain the AWX pods created by the operator to run on a certain subse
 the AWX pods to run only on the nodes that match all the specified key/value pairs. `tolerations` and `postgres_tolerations` allow the AWX
 pods to be scheduled onto nodes with matching taints.
 The ability to specify topologySpreadConstraints is also allowed through `topology_spread_constraints`
+If you want to use affinity rules for your AWX pod you can use the `node_affinity` option.
 
 
 | Name                        | Description                         | Default |
@@ -712,6 +713,7 @@ The ability to specify topologySpreadConstraints is also allowed through `topolo
 | postgres_image_version      | Image version to pull               | 13      |
 | node_selector               | AWX pods' nodeSelector              | ''      |
 | topology_spread_constraints | AWX pods' topologySpreadConstraints | ''      |
+| node_affinity                  | AWX pods' affinity rules    | ''      |
 | tolerations                 | AWX pods' tolerations               | ''      |
 | annotations                 | AWX pods' annotations               | ''      |
 | postgres_selector           | Postgres pods' nodeSelector         | ''      |
@@ -748,6 +750,16 @@ spec:
       operator: "Equal"
       value: "AWX"
       effect: "NoSchedule"
+  affinity:
+    nodeAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 1
+        preference:
+          matchExpressions:
+          - key: another-node-label-key
+            operator: In
+            values:
+            - another-node-label-value
 ```
 
 #### Trusting a Custom Certificate Authority

--- a/config/crd/bases/awx.ansible.com_awxs.yaml
+++ b/config/crd/bases/awx.ansible.com_awxs.yaml
@@ -161,9 +161,371 @@ spec:
                 description: topology rule(s) for the pods
                 type: string
               affinity:
-                description: affinity rule(s) for the pods
+                description: If specified, the pod's scheduling constraints
+                properties:
+                  nodeAffinity:
+                    properties:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        items:
+                          properties:
+                            preference:
+                              properties:
+                                matchExpressions:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchFields:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            weight:
+                              format: int32
+                              type: integer
+                          required:
+                          - preference
+                          - weight
+                          type: object
+                        type: array
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        properties:
+                          nodeSelectorTerms:
+                            items:
+                              properties:
+                                matchExpressions:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchFields:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            type: array
+                        required:
+                        - nodeSelectorTerms
+                        type: object
+                        x-kubernetes-map-type: atomic
+                    type: object
+                  podAffinity:
+                    properties:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        items:
+                          properties:
+                            podAffinityTerm:
+                              properties:
+                                labelSelector:
+                                  properties:
+                                    matchExpressions:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                namespaceSelector:
+                                  properties:
+                                    matchExpressions:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                namespaces:
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            weight:
+                              format: int32
+                              type: integer
+                          required:
+                          - podAffinityTerm
+                          - weight
+                          type: object
+                        type: array
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        items:
+                          properties:
+                            labelSelector:
+                              properties:
+                                matchExpressions:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            namespaceSelector:
+                              properties:
+                                matchExpressions:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            namespaces:
+                              items:
+                                type: string
+                              type: array
+                            topologyKey:
+                              type: string
+                          required:
+                          - topologyKey
+                          type: object
+                        type: array
+                    type: object
+                  podAntiAffinity:
+                    properties:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        items:
+                          properties:
+                            podAffinityTerm:
+                              properties:
+                                labelSelector:
+                                  properties:
+                                    matchExpressions:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                namespaceSelector:
+                                  properties:
+                                    matchExpressions:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                namespaces:
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            weight:
+                              format: int32
+                              type: integer
+                          required:
+                          - podAffinityTerm
+                          - weight
+                          type: object
+                        type: array
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        items:
+                          properties:
+                            labelSelector:
+                              properties:
+                                matchExpressions:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            namespaceSelector:
+                              properties:
+                                matchExpressions:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            namespaces:
+                              items:
+                                type: string
+                              type: array
+                            topologyKey:
+                              type: string
+                          required:
+                          - topologyKey
+                          type: object
+                        type: array
+                    type: object
                 type: object
-                x-kubernetes-preserve-unknown-fields: true
               service_labels:
                 description: Additional labels to apply to the service
                 type: string

--- a/config/crd/bases/awx.ansible.com_awxs.yaml
+++ b/config/crd/bases/awx.ansible.com_awxs.yaml
@@ -160,6 +160,10 @@ spec:
               topology_spread_constraints:
                 description: topology rule(s) for the pods
                 type: string
+              node_affinity:
+                description: affinity rule(s) for the pods
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
               service_labels:
                 description: Additional labels to apply to the service
                 type: string

--- a/config/crd/bases/awx.ansible.com_awxs.yaml
+++ b/config/crd/bases/awx.ansible.com_awxs.yaml
@@ -160,7 +160,7 @@ spec:
               topology_spread_constraints:
                 description: topology rule(s) for the pods
                 type: string
-              node_affinity:
+              affinity:
                 description: affinity rule(s) for the pods
                 type: object
                 x-kubernetes-preserve-unknown-fields: true

--- a/config/manifests/bases/awx-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/awx-operator.clusterserviceversion.yaml
@@ -607,6 +607,11 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:hidden
+      - displayName: Affinity
+        path: affinity
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:hidden
       - displayName: Control Plane Priority Class
         path: control_plane_priority_class
         x-descriptors:

--- a/roles/installer/defaults/main.yml
+++ b/roles/installer/defaults/main.yml
@@ -81,6 +81,8 @@ node_selector: ''
 #         app.kubernetes.io/name: "<resourcename>"
 topology_spread_constraints: ''
 
+affinity: {}
+
 # Add node tolerations for the AWX pods. Specify as literal block. E.g.:
 # tolerations: |
 #   - key: "dedicated"

--- a/roles/installer/templates/deployments/deployment.yaml.j2
+++ b/roles/installer/templates/deployments/deployment.yaml.j2
@@ -379,9 +379,9 @@ spec:
       topologySpreadConstraints:
         {{ topology_spread_constraints | indent(width=8) }}
 {% endif %}
-{% if affinity %}
+{% if affinity | length %}
       affinity:
-        {{ affinity | to_yaml | indent(width=8) }}
+        {{ affinity | to_nice_yaml | indent(width=8) }}
 {% endif %}
 {% if tolerations %}
       tolerations:

--- a/roles/installer/templates/deployments/deployment.yaml.j2
+++ b/roles/installer/templates/deployments/deployment.yaml.j2
@@ -379,9 +379,9 @@ spec:
       topologySpreadConstraints:
         {{ topology_spread_constraints | indent(width=8) }}
 {% endif %}
-{% if node_affinity %}
+{% if affinity %}
       affinity:
-        {{ node_affinity | to_yaml | indent(width=8) }}
+        {{ affinity | to_yaml | indent(width=8) }}
 {% endif %}
 {% if tolerations %}
       tolerations:

--- a/roles/installer/templates/deployments/deployment.yaml.j2
+++ b/roles/installer/templates/deployments/deployment.yaml.j2
@@ -379,6 +379,10 @@ spec:
       topologySpreadConstraints:
         {{ topology_spread_constraints | indent(width=8) }}
 {% endif %}
+{% if node_affinity %}
+      affinity:
+        {{ node_affinity | to_yaml | indent(width=8) }}
+{% endif %}
 {% if tolerations %}
       tolerations:
         {{ tolerations | indent(width=8) }}


### PR DESCRIPTION
##### SUMMARY

Add possibility specifying affinity of AWX Pods.

* https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
* https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#affinity-v1-core

Resolves #691

##### ISSUE TYPE

 - New or Enhanced Feature

##### ADDITIONAL INFORMATION

The original PR #691 appears to be [abandoned](https://github.com/ansible/awx-operator/pull/691#pullrequestreview-1193341004). This PR also brings a couple of additions on top - I intentionally did not squash in order to be able to flexibly respond to feedback.