### PR TITLE
add permission to get openshift version

### DIFF
--- a/config/rbac/cluster_operator_viewer_clusterrole.yaml
+++ b/config/rbac/cluster_operator_viewer_clusterrole.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cluster-operator-viewer-clusterrole
+rules:
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - clusteroperators
+  verbs:
+  - get

--- a/roles/installer/templates/rbac/service_account.yaml.j2
+++ b/roles/installer/templates/rbac/service_account.yaml.j2
@@ -33,7 +33,6 @@ rules:
 - apiGroups: [""]
   resources: ["secrets"]
   verbs: ["get", "create", "delete"]
-
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -47,3 +46,16 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: '{{ ansible_operator_meta.name }}'
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: '{{ ansible_operator_meta.name }}-clusterrole'
+  namespace: '{{ ansible_operator_meta.namespace }}'
+subjects:
+- kind: ServiceAccount
+  name: '{{ ansible_operator_meta.name }}'
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-operator-viewer-clusterrole


### PR DESCRIPTION
Signed-off-by: Hao Liu <haoli@redhat.com>

##### SUMMARY
add permission to get config.openshift.io/clusteroperator resource on a openshift cluster to determine openshift-apiserver version 

openshift apiserver version will be used in https://github.com/ansible/receptor/pull/693 for determine if to use --timestamp to resume when log stream is disconnected

##### ISSUE TYPE
 - New or Enhanced Feature

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
