### PR TITLE
add permission to get openshift version

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -45,6 +45,10 @@ spec:
           value: explicit
         - name: ANSIBLE_DEBUG_LOGS
           value: 'false'
+        - name: MY_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         - name: WATCH_NAMESPACE
           valueFrom:
             fieldRef:

--- a/config/rbac/cluster_operator_viewer_clusterrole.yaml
+++ b/config/rbac/cluster_operator_viewer_clusterrole.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cluster-operator-viewer-clusterrole
+rules:
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - clusteroperators
+  verbs:
+  - get

--- a/config/rbac/cluster_operator_viewer_role_binding.yaml
+++ b/config/rbac/cluster_operator_viewer_role_binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cluster-operator-viewer-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-operator-viewer-clusterrole
+subjects:
+- kind: ServiceAccount
+  name: controller-manager
+  namespace: system

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -9,6 +9,8 @@ resources:
 - role_binding.yaml
 - leader_election_role.yaml
 - leader_election_role_binding.yaml
+- cluster_operator_viewer_clusterrole.yaml
+- cluster_operator_viewer_role_binding.yaml
 # Comment the following 4 lines if you want to disable
 # the auth proxy (https://github.com/brancz/kube-rbac-proxy)
 # which protects your /metrics endpoint.
@@ -16,3 +18,4 @@ resources:
 - auth_proxy_role.yaml
 - auth_proxy_role_binding.yaml
 - auth_proxy_client_clusterrole.yaml
+

--- a/roles/installer/tasks/resources_configuration.yml
+++ b/roles/installer/tasks/resources_configuration.yml
@@ -1,4 +1,11 @@
 ---
+- name: Get operator pod name
+  set_fact:
+    operator_pod_name: "{{ lookup('ansible.builtin.env', 'MY_POD_NAME') }}"
+
+- name: Get operator name prefix
+  set_fact:
+    operator_name_prefix: "{{ operator_pod_name.split('controller-manager') | first }}"
 
 - name: Get the current resource pod information.
   k8s_info:

--- a/roles/installer/templates/rbac/service_account.yaml.j2
+++ b/roles/installer/templates/rbac/service_account.yaml.j2
@@ -33,7 +33,6 @@ rules:
 - apiGroups: [""]
   resources: ["secrets"]
   verbs: ["get", "create", "delete"]
-
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -47,3 +46,16 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: '{{ ansible_operator_meta.name }}'
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: '{{ ansible_operator_meta.name }}-clusterrole'
+  namespace: '{{ ansible_operator_meta.namespace }}'
+subjects:
+- kind: ServiceAccount
+  name: '{{ ansible_operator_meta.name }}'
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: '{{ operator_name_prefix }}cluster-operator-viewer-clusterrole'


### PR DESCRIPTION
Signed-off-by: Hao Liu <haoli@redhat.com>

##### SUMMARY
add permission to get config.openshift.io/clusteroperator resource on a openshift cluster to determine openshift-apiserver version

openshift apiserver version will be used in https://github.com/ansible/receptor/pull/693 for determine if to use --timestamp to resume when log stream is disconnected

NOTE: since the ClusterRoe `config/rbac/cluster_operator_viewer_clusterrole.yaml` is added to the install bundle that means the name will be prefix by `namePrefix` in `config/default/kustomization.yaml`  we use the operator's pod name with some unfortunate string parsing to get this prefix

##### ISSUE TYPE
 - New or Enhanced Feature

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
