### PR TITLE
use awx-ee tag that matches awx version

### DIFF
--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -23,6 +23,7 @@ provisioner:
       localhost:
         awx_image: ${AWX_TEST_IMAGE:-""}
         awx_version: ${AWX_TEST_VERSION:-""}
+        awx_ee_image: ${AWX_EE_TEST_IMAGE:-""}
         default_awx_version: "{{ lookup('url', 'https://api.github.com/repos/ansible/awx/releases/latest') | from_json | json_query('tag_name') }}"
         ansible_python_interpreter: '{{ ansible_playbook_python }}'
         config_dir: ${MOLECULE_PROJECT_DIRECTORY}/config

--- a/molecule/default/templates/awx_cr_molecule.yml.j2
+++ b/molecule/default/templates/awx_cr_molecule.yml.j2
@@ -27,6 +27,12 @@ spec:
       cpu: 50m
       memory: 16M
   no_log: false
+{% if awx_ee_image %}
+  ee_images:
+    - name: AWX EE (latest)
+      image: {{ awx_ee_image }}
+  control_plane_ee_image: {{ awx_ee_image }}
+{% endif %}
   postgres_resource_requirements: {}
   postgres_init_container_resource_requirements: {}
   redis_resource_requirements: {}

--- a/molecule/kind/molecule.yml
+++ b/molecule/kind/molecule.yml
@@ -25,6 +25,7 @@ provisioner:
       localhost:
         awx_image: ${AWX_TEST_IMAGE:-""}
         awx_version: ${AWX_TEST_VERSION:-""}
+        awx_ee_image: ${AWX_EE_TEST_IMAGE:-""}
         ansible_python_interpreter: '{{ ansible_playbook_python }}'
         default_awx_version: "{{ lookup('url', 'https://api.github.com/repos/ansible/awx/releases/latest') | from_json | json_query('tag_name') }}"
         config_dir: ${MOLECULE_PROJECT_DIRECTORY}/config

--- a/roles/installer/defaults/main.yml
+++ b/roles/installer/defaults/main.yml
@@ -159,9 +159,9 @@ init_container_extra_volume_mounts: ''
 
 ee_images:
   - name: AWX EE (latest)
-    image: quay.io/ansible/awx-ee:latest
+    image: "quay.io/ansible/awx-ee:{{ lookup('env', 'DEFAULT_AWX_VERSION') or 'latest' }}"
 
-_control_plane_ee_image: quay.io/ansible/awx-ee:latest
+_control_plane_ee_image: "quay.io/ansible/awx-ee:{{ lookup('env', 'DEFAULT_AWX_VERSION') or 'latest' }}"
 
 _init_container_image: "{{ _control_plane_ee_image.split(':')[0] }}"
 _init_container_image_version: "{{ _control_plane_ee_image.split(':')[1] }}"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
pairs with https://github.com/ansible/awx/pull/13338

when AWX is released, awx-ee:latest will be tagged with the AWX release tag
e.g. `quay.io/ansible/awx-ee:21.10.2`

operator will use the awx-ee image that corresponds to the specified AWX image, which set by the `DEFAULT_AWX_VERSION` environment variable
<!---
If you are fixing an existing issue, please include "fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New or Enhanced Feature

