### PR TITLE
Fixes #1039, naming of clusterscoped resources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -334,6 +334,14 @@ helm-chart-generate: kustomize helm kubectl-slice yq charts
 	for file in charts/$(CHART_NAME)/raw-files/*rolebinding*; do\
 		$(YQ) -i '.subjects[0].namespace = "{{ .Release.Namespace }}"' $${file};\
 	done
+	# Correct .metadata.name for cluster scoped resources
+	cluster_scoped_files="charts/$(CHART_NAME)/raw-files/clusterrolebinding-awx-operator-proxy-rolebinding.yaml charts/$(CHART_NAME)/raw-files/clusterrole-awx-operator-metrics-reader.yaml charts/$(CHART_NAME)/raw-files/clusterrole-awx-operator-proxy-role.yaml";\
+	for file in $${cluster_scoped_files}; do\
+		$(YQ) -i '.metadata.name += "-{{ .Release.Name }}"' $${file};\
+	done
+
+	# Correct the reference for the clusterrolebinding
+	$(YQ) -i '.roleRef.name += "-{{ .Release.Name }}"' 'charts/$(CHART_NAME)/raw-files/clusterrolebinding-awx-operator-proxy-rolebinding.yaml'
 	# move all custom resource definitions to crds folder
 	mkdir charts/$(CHART_NAME)/crds
 	mv charts/$(CHART_NAME)/raw-files/customresourcedefinition*.yaml charts/$(CHART_NAME)/crds/.


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Append .Release.Name to metadata.name for the cluster scoped resources. This would enable us to rollout the operator to multiple namespaces on the same cluster. This fixes #1039 

<!---
If you are fixing an existing issue, please include "fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION

I'm not sure whether we would have to classify this as breaking, as the clusterroles are being renamed.

I'm not sure if this is the nicest way to fix this. Another option would be, to create an option in values.yml with which we could disable rolling out clusterroles. We would still need do this for the clusterrolebinding. Please let me know what you think would be the best way to fix this issue - I would be happy to rework the PR.
