### PR TITLE
fix: add quotes for PGPASSWORD in upgrade_postgres.yml (fixes #1166)

### DIFF
--- a/roles/installer/tasks/upgrade_postgres.yml
+++ b/roles/installer/tasks/upgrade_postgres.yml
@@ -93,7 +93,7 @@
     command: |
       bash -c """
       set -e -o pipefail
-      PGPASSWORD={{ awx_postgres_pass }} {{ pgdump }} | PGPASSWORD={{ awx_postgres_pass }} {{ pg_restore }}
+      PGPASSWORD='{{ awx_postgres_pass }}' {{ pgdump }} | PGPASSWORD='{{ awx_postgres_pass }}' {{ pg_restore }}
       echo 'Successful'
       """
   no_log: "{{ no_log }}"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
<!---
If you are fixing an existing issue, please include "fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

Closes #1166
Wrap `PGPASSWORD` with single quotes for `pg_dump` and `pg_restore` for the task to upgrade PostgreSQL.


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
-->

Tested as follows:

<!--- Paste verbatim command output below, e.g. before and after your change -->

1. Deploy old AWX

   ```bash
   # Deploy Operator 0.25.0
   $ git clone https://github.com/ansible/awx-operator.git -b 0.25.0
   $ cd awx-operator
   $ NAMESPACE=awx make deploy
   
   # Create manifest file includes secret with special characters and AWX
   $ cat awx.yml
   ---
   apiVersion: v1
   kind: Secret
   metadata:
     name: awx-postgres-configuration
     namespace: awx
   stringData:
     host: awx-postgres
     port: "5432"
     database: awx
     username: awx
     # Password with lots of special characters
     password: a b!c#d$e%f&g(h)i*j+k,l-m.n/o:p+q<r=s>t?u@v[w]x^y_z`a{b|c}d~e
     type: managed
   type: Opaque
   ---
   apiVersion: awx.ansible.com/v1beta1
   kind: AWX
   metadata:
     name: awx
     namespace: awx
   spec:
     ingress_type: ingress
     hostname: awx.example.com
     postgres_configuration_secret: awx-postgres-configuration
     no_log: "false"
   
   # Create secret and AWX
   $ kubectl apply -f awx.yml 
   secret/awx-postgres-configuration created
   awx.awx.ansible.com/awx created
   
   # Ensure deployment has been completed
   $ kubectl -n awx logs deployments/awx-operator-controller-manager -c awx-manager --tail=10
   ...
   PLAY RECAP *********************************************************************
   localhost                  : ok=66   changed=0    unreachable=0    failed=0    skipped=45   rescued=0    ignored=0   
   
   # Ensure AWX is working
   $ curl -s http://awx.example.com/api/v2/ping/ | jq '.version'
   "21.3.0"
   
   # Ensure password has been configured as expected
   $ kubectl -n awx exec -it deployment/awx -c awx-web -- cat /etc/tower/conf.d/credentials.py | grep PASSWORD
           'PASSWORD': "a b!c#d$e%f&g(h)i*j+k,l-m.n/o:p+q<r=s>t?u@v[w]x^y_z`a{b|c}d~e",
   $ kubectl -n awx exec -it statefulset/awx-postgres -c postgres -- env | grep PASSWORD
   POSTGRES_PASSWORD=a b!c#d$e%f&g(h)i*j+k,l-m.n/o:p+q<r=s>t?u@v[w]x^y_z`a{b|c}d~e
   POSTGRESQL_PASSWORD=a b!c#d$e%f&g(h)i*j+k,l-m.n/o:p+q<r=s>t?u@v[w]x^y_z`a{b|c}d~e
   ```

2. Upgrade AWX using this PR

   ```bash
   # Build and push customized Operator image
   BUILD_ARGS="--build-arg DEFAULT_AWX_VERSION=21.10.2 \
               --build-arg OPERATOR_VERSION=1.1.4" \
   IMAGE_TAG_BASE=registry.example.com/awx/awx-operator \
   VERSION=1.1.4 make docker-build docker-push

   # Deploy customized Operator
   IMG=registry.example.com/awx/awx-operator:1.1.4 make deploy

   # Patch AWX (Change string to bool for spec.no_log)
   $ kubectl -n awx patch awx awx --type merge -p '{"spec":{"no_log":false}}'
   awx.awx.ansible.com/awx patched
   
   # Follow logs
   $ kubectl -n awx logs -f deployments/awx-operator-controller-manager
   ```

3. Ensure AWX has been upgraded and is working

   ```bash
   $ kubectl -n awx logs -f deployments/awx-operator-controller-manager
   ...
   TASK [installer : Stream backup from pg_dump to the new postgresql container] ***
   task path: /opt/ansible/roles/installer/tasks/upgrade_postgres.yml:89
   ...
   PLAY RECAP *********************************************************************
   localhost                  : ok=76   changed=0    unreachable=0    failed=0    skipped=69   rescued=0    ignored=1   
   
   $ kubectl -n awx get pod
   NAME                                               READY   STATUS    RESTARTS   AGE
   awx-operator-controller-manager-65797cd766-jbgtw   2/2     Running   0          4m16s
   awx-postgres-13-0                                  1/1     Running   0          3m20s
   awx-54d4898466-qb5qc                               4/4     Running   0          2m50s
   
   $ curl -s http://awx.example.com/api/v2/ping/ | jq '.version'
   "21.10.2"
   
   $ kubectl -n awx exec -it deployment/awx -c awx-web -- cat /etc/tower/conf.d/credentials.py | grep PASSWORD
           'PASSWORD': "a b!c#d$e%f&g(h)i*j+k,l-m.n/o:p+q<r=s>t?u@v[w]x^y_z`a{b|c}d~e",
   
   $ kubectl -n awx exec -it statefulset/awx-postgres-13 -c postgres -- env | grep PASSWORD
   POSTGRES_PASSWORD=a b!c#d$e%f&g(h)i*j+k,l-m.n/o:p+q<r=s>t?u@v[w]x^y_z`a{b|c}d~e
   POSTGRESQL_PASSWORD=a b!c#d$e%f&g(h)i*j+k,l-m.n/o:p+q<r=s>t?u@v[w]x^y_z`a{b|c}d~e
   ```
