### PR TITLE
add uwsgi.ini in configmap and deployment awx

### DIFF
--- a/roles/installer/templates/configmaps/config.yaml.j2
+++ b/roles/installer/templates/configmaps/config.yaml.j2
@@ -232,6 +232,27 @@ data:
             }
         }
     }
+  uwsgi.ini: |
+    [uwsgi]
+    socket = 127.0.0.1:8050
+    processes = 5
+    master = true
+    vacuum = true
+    no-orphans = true
+    lazy-apps = true
+    manage-script-name = true
+    master-fifo = /var/lib/awx/awxfifo
+    max-requests = 1000
+    buffer-size = 32768
+
+    if-env = UWSGI_MOUNT_PATH
+    mount = %(_)=awx.wsgi:application
+    endif =
+
+    if-not-env = UWSGI_MOUNT_PATH
+    mount = /=awx.wsgi:application
+    endif =
+
   redis_conf: |
     unixsocket /var/run/redis/redis.sock
     unixsocketperm 777

--- a/roles/installer/templates/deployments/deployment.yaml.j2
+++ b/roles/installer/templates/deployments/deployment.yaml.j2
@@ -191,6 +191,10 @@ spec:
               mountPath: "/var/lib/awx/rsyslog"
             - name: "{{ ansible_operator_meta.name }}-projects"
               mountPath: "/var/lib/awx/projects"
+            - name: {{ ansible_operator_meta.name }}-uwsgi-config
+              readOnly: true
+              mountPath: /etc/tower/uwsgi.ini
+              subPath: uwsgi.ini
             - name: "{{ ansible_operator_meta.name }}-receptor-work-signing"
               mountPath: "/etc/receptor/signing/work-public-key.pem"
               subPath: "work-public-key.pem"
@@ -487,6 +491,12 @@ spec:
             items:
               - key: receptor_conf
                 path: receptor.conf
+        - name: {{ ansible_operator_meta.name }}-uwsgi-config
+          configMap:
+            name: '{{ ansible_operator_meta.name }}-{{ deployment_type }}-configmap'
+            items:
+              - key: uwsgi.ini 
+                path: uwsgi.ini
         - name: "{{ ansible_operator_meta.name }}-projects"
 {% if projects_persistence|bool %}
           persistentVolumeClaim:


### PR DESCRIPTION
##### SUMMARY
The uwsgi configuration has been added to config map. Allows you to change the uwsgi settings without rebuilding the image. For example, to limit memory using limit-as or reload-on-as. Enable stats-server, etc.

##### ISSUE TYPE
Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION