### PR TITLE
Fix secret key

### DIFF
--- a/roles/installer/templates/deployments/deployment.yaml.j2
+++ b/roles/installer/templates/deployments/deployment.yaml.j2
@@ -377,6 +377,10 @@ spec:
               mountPath: "/etc/tower/conf.d/credentials.py"
               subPath: credentials.py
               readOnly: true
+            - name: "{{ secret_key_secret_name }}"
+              mountPath: /etc/tower/SECRET_KEY
+              subPath: SECRET_KEY
+              readOnly: true
             - name: {{ ansible_operator_meta.name }}-settings
               mountPath: "/etc/tower/settings.py"
               subPath: settings.py


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
update the deployment of the rsyslog sidecar container to have the tower secret key
<!---
If you are fixing an existing issue, please include "fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
2023-01-05 18:30:40 ERROR rsyslogd was unresponsive: FileNotFoundError: [Errno 2] No such file or directory
Starting task_manager Scheduler
2023-01-05 18:30:40 ERROR rsyslogd was unresponsive: FileNotFoundError: [Errno 2] No such file or directory
Starting dependency_manager Scheduler
2023-01-05 18:30:40 ERROR rsyslogd was unresponsive: FileNotFoundError: [Errno 2] No such file or directory
recording dependency_manager metrics, last recorded 20.049980401992798 seconds ago
2023-01-05 18:30:40 ERROR rsyslogd was unresponsive: FileNotFoundError: [Errno 2] No such file or directory
Finishing dependency_manager Scheduler
2023-01-05 18:30:40 ERROR rsyslogd was unresponsive: FileNotFoundError: [Errno 2] No such file or directory
recording task_manager metrics, last recorded 20.04824447631836 seconds ago
2023-01-05 18:30:40 ERROR rsyslogd was unresponsive: FileNotFoundError: [Errno 2] No such file or directory
Finishing task_manager Scheduler
```

