### PR TITLE
molecule: set no_log to false

### DIFF
--- a/molecule/default/templates/awx_cr_molecule.yml.j2
+++ b/molecule/default/templates/awx_cr_molecule.yml.j2
@@ -26,6 +26,7 @@ spec:
     requests:
       cpu: 50m
       memory: 16M
+  no_log: false
   postgres_resource_requirements: {}
   postgres_init_container_resource_requirements: {}
   redis_resource_requirements: {}


### PR DESCRIPTION
##### SUMMARY
In order to get information during CI debugging then turning off the no_log statement will help with non hidden output.

```console
FAILED! => {"censored": "the output has been hidden due to the fact that
            'no_log: true' was specified for this result"}
```

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change
