### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ An [Ansible AWX](https://github.com/ansible/awx) operator for Kubernetes built w
             * [Cluster-scope to Namespace-scope considerations](#cluster-scope-to-namespace-scope-considerations)
             * [Project is now based on v1.x of the operator-sdk project](#project-is-now-based-on-v1x-of-the-operator-sdk-project)
             * [Steps to upgrade](#steps-to-upgrade)
-       * [Ipv6](#ipv6-disable-new-installs)
+       * [Disable IPV6 for install and upgrade](#ipv6-disable-new-installs)
       * [Add Execution Nodes](#adding-execution-nodes)
           * [Custom Receptor CA](#custom-receptor-ca)
    * [Contributing](#contributing)
@@ -1286,7 +1286,7 @@ Then install the new AWX Operator by following the instructions in [Basic Instal
 
 Once the new AWX Operator is up and running, your AWX deployment will also be upgraded.
 
-# Disable IPV6 for install and upgrade
+#### Disable IPV6 for install and upgrade
 Starting with  AWX Operator release 0.24.0 ipv6 had been enabled in ngnix configuration which caused upgrades/new install's to fail.
 As a work around until AWX Operator release 1.1.1 and AWX v21.10.0 it is suggested to enable ipv6 on worker nodes from 1.1.1 release
 a flag to disable ipv6 had been added.Inorder to disable ipv6 on ngnix configuration(awx-web container) it is recommended to add following

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ An [Ansible AWX](https://github.com/ansible/awx) operator for Kubernetes built w
             * [Cluster-scope to Namespace-scope considerations](#cluster-scope-to-namespace-scope-considerations)
             * [Project is now based on v1.x of the operator-sdk project](#project-is-now-based-on-v1x-of-the-operator-sdk-project)
             * [Steps to upgrade](#steps-to-upgrade)
-       * [Disable IPV6 for install and upgrade](#ipv6-disable-new-installs)
+      * [Disable IPV6](#IPV6)
       * [Add Execution Nodes](#adding-execution-nodes)
           * [Custom Receptor CA](#custom-receptor-ca)
    * [Contributing](#contributing)
@@ -1286,11 +1286,13 @@ Then install the new AWX Operator by following the instructions in [Basic Instal
 
 Once the new AWX Operator is up and running, your AWX deployment will also be upgraded.
 
-#### Disable IPV6 for install and upgrade
-Starting with  AWX Operator release 0.24.0 ipv6 had been enabled in ngnix configuration which caused upgrades/new install's to fail.
-As a work around until AWX Operator release 1.1.1 and AWX v21.10.0 it is suggested to enable ipv6 on worker nodes from 1.1.1 release
-a flag to disable ipv6 had been added.Inorder to disable ipv6 on ngnix configuration(awx-web container) it is recommended to add following
-spec.
+### Disable IPV6 ###
+Starting with AWX Operator release 0.24.0,[IPV6 was enabled in ngnix configuration](https://github.com/ansible/awx-operator/pull/950) which causes
+upgrades and installs to fail in environments where IPv6 is not allowed. Starting in 1.1.1 release, tou can set the `ipv6_disabled` flag on the AWX
+spec. If you need to use an AWX operator version between 0.24.0 and 1.1.1 in an IPv6 disabled environment, it is suggested to enabled ipv6 on worker
+nodes.
+
+In order to disable ipv6 on ngnix configuration (awx-web container), add following to the AWX spec.
 
 The following variables are customizable 
 
@@ -1299,10 +1301,10 @@ The following variables are customizable
 | ipv6_disabled | Flag to disable ipv6   | false   |
 
 ```yaml
----
 spec:
   ...
   ipv6_disabled: true
+```
 
 ### Adding Execution Nodes
 Starting with AWX Operator v0.30.0 and AWX v21.7.0, standalone execution nodes can be added to your deployments.

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ An [Ansible AWX](https://github.com/ansible/awx) operator for Kubernetes built w
             * [Cluster-scope to Namespace-scope considerations](#cluster-scope-to-namespace-scope-considerations)
             * [Project is now based on v1.x of the operator-sdk project](#project-is-now-based-on-v1x-of-the-operator-sdk-project)
             * [Steps to upgrade](#steps-to-upgrade)
+       * [Ipv6](#ipv6-disable-new-installs)
       * [Add Execution Nodes](#adding-execution-nodes)
           * [Custom Receptor CA](#custom-receptor-ca)
    * [Contributing](#contributing)
@@ -1284,6 +1285,24 @@ $ kubectl -n default delete clusterrole awx-operator
 Then install the new AWX Operator by following the instructions in [Basic Install](#basic-install-on-existing-cluster). The `NAMESPACE` environment variable have to be the name of the namespace in which your old AWX instance resides.
 
 Once the new AWX Operator is up and running, your AWX deployment will also be upgraded.
+
+# Disable IPV6 for install and upgrade
+Starting with  AWX Operator release 0.24.0 ipv6 had been enabled in ngnix configuration which caused upgrades/new install's to fail.
+As a work around until AWX Operator release 1.1.1 and AWX v21.10.0 it is suggested to enable ipv6 on worker nodes from 1.1.1 release
+a flag to disable ipv6 had been added.Inorder to disable ipv6 on ngnix configuration(awx-web container) it is recommended to add following
+spec.
+
+The following variables are customizable 
+
+| Name          | Description            | Default |
+| ------------- | ---------------------- | ------- |
+| ipv6_disabled | Flag to disable ipv6   | false   |
+
+```yaml
+---
+spec:
+  ...
+  ipv6_disabled: true
 
 ### Adding Execution Nodes
 Starting with AWX Operator v0.30.0 and AWX v21.7.0, standalone execution nodes can be added to your deployments.

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ An [Ansible AWX](https://github.com/ansible/awx) operator for Kubernetes built w
             * [Cluster-scope to Namespace-scope considerations](#cluster-scope-to-namespace-scope-considerations)
             * [Project is now based on v1.x of the operator-sdk project](#project-is-now-based-on-v1x-of-the-operator-sdk-project)
             * [Steps to upgrade](#steps-to-upgrade)
-      * [Disable IPV6](#IPV6)
+      * [Disable IPV6](#disable-ipv6)
       * [Add Execution Nodes](#adding-execution-nodes)
           * [Custom Receptor CA](#custom-receptor-ca)
    * [Contributing](#contributing)
@@ -1286,9 +1286,9 @@ Then install the new AWX Operator by following the instructions in [Basic Instal
 
 Once the new AWX Operator is up and running, your AWX deployment will also be upgraded.
 
-### Disable IPV6 ###
+### Disable IPV6
 Starting with AWX Operator release 0.24.0,[IPV6 was enabled in ngnix configuration](https://github.com/ansible/awx-operator/pull/950) which causes
-upgrades and installs to fail in environments where IPv6 is not allowed. Starting in 1.1.1 release, tou can set the `ipv6_disabled` flag on the AWX
+upgrades and installs to fail in environments where IPv6 is not allowed. Starting in 1.1.1 release, you can set the `ipv6_disabled` flag on the AWX
 spec. If you need to use an AWX operator version between 0.24.0 and 1.1.1 in an IPv6 disabled environment, it is suggested to enabled ipv6 on worker
 nodes.
 
@@ -1302,7 +1302,6 @@ The following variables are customizable
 
 ```yaml
 spec:
-  ...
   ipv6_disabled: true
 ```
 


### PR DESCRIPTION
Added procedure to disable ipv6 during install or upgrade which was was not mentioned in the doc.

SUMMARY


ISSUE TYPE

Bug, Docs Fix or other nominal change

##### SUMMARY

By Default deployment tries to enable ipv6 for new install and upgrade.Recently flag was introduced to disable ipv6 but its not mentioned in the README. This will mainly help for people who are trying to upgrade or install awx from AWX 1.1.1


##### ISSUE TYPE

Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION

Users are running into errors with new install and upgrade ever since ipv6 had been introduced to enable 