### PR TITLE
Add docs for ingress resource apiVersion configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,6 +463,7 @@ The following variables are customizable when `ingress_type=ingress`. The `ingre
 | hostname            | Define the FQDN                          | {{ meta.name }}.example.com |
 | ingress_path        | Define the ingress path to the service   | /                           |
 | ingress_path_type   | Define the type of the path (for LBs)    | Prefix                      |
+| ingress_api_version | Define the Ingress resource apiVersion   | 'networking.k8s.io/v1'      |
 
 ```yaml
 ---
@@ -483,6 +484,7 @@ The following variables are customizable when `ingress_type=route`
 | route_host                      | Common name the route answers for             | `<instance-name>-<namespace>-<routerCanonicalHostname>` |
 | route_tls_termination_mechanism | TLS Termination mechanism (Edge, Passthrough) | Edge                                                    |
 | route_tls_secret                | Secret that contains the TLS information      | Empty string                                            |
+| route_api_version               | Define the Route resource apiVersion          | 'route.openshift.io/v1'                                 |
 
 ```yaml
 ---


### PR DESCRIPTION
##### SUMMARY

When the ingress_api_version parameter was added, no docs note was added for how to use it.  This PR adds that.

This is the PR that originally added that parameter:
* https://github.com/ansible/awx-operator/pull/1098

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bug, Docs Fix or other nominal change
