### PR TITLE
Fix helm index.yaml generation error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -377,10 +377,11 @@ helm-index:
 	for tag in $(TAGS); do\
 		dl_url="https://github.com/$(CHART_OWNER)/$(CHART_REPO)/releases/download/$${tag}/$(CHART_REPO)-$${tag}.tgz";\
 		echo "Downloading $${tag} from $${dl_url}";\
-		curl -RLOs -z ".cr-release-packages/$(CHART_REPO)-$${tag}.tgz" --fail $${dl_url};\
+		curl -RLOs -z "$(CHART_REPO)-$${tag}.tgz" --fail $${dl_url};\
 		result=$$?;\
 		if [ $${result} -eq 0 ]; then\
 			echo "Downloaded $${dl_url}";\
+			mv ./$(CHART_REPO)-$${tag}.tgz .cr-release-packages/;\
 		else\
 			echo "Skipping release $${tag}; No helm chart present";\
 			rm -rf ".cr-release-packages/$(CHART_REPO)-$${tag}.tgz";\


### PR DESCRIPTION
##### SUMMARY

Follow-up for: https://github.com/ansible/awx-operator/pull/1183

Issue described here: https://github.com/ansible/awx-operator/pull/1183#issuecomment-1402922278

index.yaml is not properly generated because the tar.gz's were not getting curled into the .cr-release-packages directory properly.  This is a quick hack, there is probably a better way, but this works.  

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bug, Docs Fix or other nominal change
