### PR TITLE
[enhancement] restore postgres database if external db

### DIFF
--- a/roles/restore/tasks/postgres.yml
+++ b/roles/restore/tasks/postgres.yml
@@ -66,7 +66,7 @@
 
 - name: Set full resolvable host name for postgres pod
   set_fact:
-    resolvable_db_host: '{{ (awx_postgres_type == "managed") | ternary(awx_postgres_host + "." + ansible_operator_meta.namespace + ".svc.cluster.local", awx_postgres_host) }}'  # yamllint disable-line rule:line-length
+    resolvable_db_host: '{{ (awx_postgres_type == "managed") | ternary(awx_postgres_host + "." + ansible_operator_meta.namespace + ".svc." + cluster_name, awx_postgres_host) }}'  # yamllint disable-line rule:line-length
   no_log: "{{ no_log }}"
 
 - name: Set pg_restore command

--- a/roles/restore/tasks/postgres.yml
+++ b/roles/restore/tasks/postgres.yml
@@ -66,9 +66,8 @@
 
 - name: Set full resolvable host name for postgres pod
   set_fact:
-    resolvable_db_host: "{{ awx_postgres_host }}.{{ ansible_operator_meta.namespace }}.svc.{{ cluster_name }}"
+    resolvable_db_host: '{{ (awx_postgres_type == "managed") | ternary(awx_postgres_host + "." + ansible_operator_meta.namespace + ".svc.cluster.local", awx_postgres_host) }}'  # yamllint disable-line rule:line-length
   no_log: "{{ no_log }}"
-  when: awx_postgres_type == 'managed'
 
 - name: Set pg_restore command
   set_fact:


### PR DESCRIPTION
##### SUMMARY
This PR fixes the AWX restore if the postgres database is external managed.

I couln't find existing issues.

##### ISSUE TYPE
 - New or Enhanced Feature

##### ADDITIONAL INFORMATION
If you use a external postgres database and try to restore, it will fail because the variable `resolvable_db_host` is not set.
Error from playbook:
```
...
TASK [restore : Set full resolvable host name for postgres pod] ****************
task path: /opt/ansible/roles/restore/tasks/postgres.yml:67
skipping: [localhost] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Set pg_restore command] **************************************************
task path: /opt/ansible/roles/restore/tasks/postgres.yml:73
fatal: [localhost]: FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: 'resolvable_db_host' is undefined

The error appears to be in '/opt/ansible/roles/restore/tasks/postgres.yml': line 73, column 3, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:


- name: Set pg_restore command
  ^ here
"}

PLAY RECAP *********************************************************************
localhost                  : ok=36   changed=9    unreachable=0    failed=1    skipped=23   rescued=0    ignored=0   

```

This PR sets the `resolvable_db_host` in the same way as is already done in the backup role.
https://github.com/ansible/awx-operator/blob/devel/roles/backup/tasks/postgres.yml#L80
