### PR TITLE
[chore] restore use k8s_cp module to read backup files

### DIFF
--- a/roles/restore/tasks/import_vars.yml
+++ b/roles/restore/tasks/import_vars.yml
@@ -2,24 +2,19 @@
 
 - name: Import awx_object variables
   block:
-  - name: Get AWX object definition from pvc
-    k8s_exec:
-      namespace: "{{ backup_pvc_namespace }}"
-      pod: "{{ ansible_operator_meta.name }}-db-management"
-      command: >-
-        bash -c "cat '{{ backup_dir }}/awx_object'"
-    register: awx_object
 
   - name: Create temp file for spec dict
     tempfile:
       state: file
     register: tmp_spec
 
-  - name: Write spec vars to temp file
-    copy:
-      content: "{{ awx_object.stdout }}"
-      dest: "{{ tmp_spec.path }}"
-      mode: '0644'
+  - name: Get AWX object definition from pvc
+    k8s_cp:
+      namespace: "{{ backup_pvc_namespace }}"
+      pod: "{{ ansible_operator_meta.name }}-db-management"
+      remote_path: "{{ backup_dir  }}/awx_object"
+      local_path: "{{ tmp_spec.path }}"
+      state: from_pod
 
   - name: Include spec vars to save them as a dict
     include_vars: "{{ tmp_spec.path }}"

--- a/roles/restore/tasks/secrets.yml
+++ b/roles/restore/tasks/secrets.yml
@@ -1,25 +1,18 @@
 ---
 
-- name: Get secret definition from pvc
-  k8s_exec:
-    namespace: "{{ backup_pvc_namespace }}"
-    pod: "{{ ansible_operator_meta.name }}-db-management"
-    command: >-
-      bash -c "cat '{{ backup_dir }}/secrets.yml'"
-  register: _secrets
-  no_log: "{{ no_log }}"
-
 - name: Create Temporary secrets file
   tempfile:
     state: file
     suffix: .json
   register: tmp_secrets
 
-- name: Write vars to file locally
-  copy:
-    dest: "{{ tmp_secrets.path }}"
-    content: "{{ _secrets.stdout }}"
-    mode: 0640
+- name: Get secret definition from pvc
+  k8s_cp:
+    namespace: "{{ backup_pvc_namespace }}"
+    pod: "{{ ansible_operator_meta.name }}-db-management"
+    remote_path: "{{ backup_dir  }}/secrets.yml"
+    local_path: "{{ tmp_secrets.path }}"
+    state: from_pod
   no_log: "{{ no_log }}"
 
 - name: Include secret vars from backup


### PR DESCRIPTION
##### SUMMARY
Use the `k8s_cp` Ansible module to read the backup files if we restore AWX.
This simplifies the role.

As proposed from @rooftopcellist in #1111 

##### ISSUE TYPE
 - New or Enhanced Feature

##### ADDITIONAL INFORMATION
My restore test was successful.