### PR TITLE
K8s cpu value example in README.md needs quotes to be valid

### DIFF
--- a/README.md
+++ b/README.md
@@ -576,7 +576,7 @@ spec:
       cpu: 500m
       memory: 2Gi
     limits:
-      cpu: 1
+      cpu: '1'
       memory: 4Gi
   postgres_storage_requirements:
     requests:


### PR DESCRIPTION
##### SUMMARY
For resource requirements entries in the AWX spec, cpu core values need quotes or else you get this error when applying it:

```
The AWX "awx-demo" is invalid: spec.postgres_resource_requirements.limits.cpu: Invalid value: "integer": spec.postgres_resource_requirements.limits.cpu in body must be of type string: "integer"
```

> Note: values like this are fine though: `cpu: 500m`

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bug, Docs Fix or other nominal change
