### PR TITLE
[web/task split] Add web and task replicas to the CRD 

### DIFF
--- a/config/crd/bases/awx.ansible.com_awxs.yaml
+++ b/config/crd/bases/awx.ansible.com_awxs.yaml
@@ -1441,12 +1441,10 @@ spec:
               web_replicas:
                 description: Number of web instance replicas
                 type: integer
-                default: 1
                 format: int32
               task_replicas:
                 description: Number of task instance replicas
                 type: integer
-                default: 1
                 format: int32
               garbage_collect_secrets:
                 description: Whether or not to remove secrets upon instance removal

--- a/config/crd/bases/awx.ansible.com_awxs.yaml
+++ b/config/crd/bases/awx.ansible.com_awxs.yaml
@@ -1433,6 +1433,11 @@ spec:
               service_account_annotations:
                 description: ServiceAccount annotations
                 type: string
+              replicas:
+                description: Number of instance replicas
+                type: integer
+                default: 1
+                format: int32
               web_replicas:
                 description: Number of web instance replicas
                 type: integer

--- a/roles/installer/defaults/main.yml
+++ b/roles/installer/defaults/main.yml
@@ -237,8 +237,8 @@ _init_projects_container_image: quay.io/centos/centos:stream9
 create_preload_data: true
 
 replicas: "1"
-web_replicas: "1"
-task_replicas: "1"
+web_replicas: ''
+task_replicas: ''
 
 task_args:
   - /usr/bin/launch_awx_task.sh

--- a/roles/installer/defaults/main.yml
+++ b/roles/installer/defaults/main.yml
@@ -236,6 +236,7 @@ _init_projects_container_image: quay.io/centos/centos:stream9
 
 create_preload_data: true
 
+replicas: "1"
 web_replicas: "1"
 task_replicas: "1"
 

--- a/roles/installer/templates/deployments/task.yaml.j2
+++ b/roles/installer/templates/deployments/task.yaml.j2
@@ -8,7 +8,11 @@ metadata:
     {{ lookup("template", "../common/templates/labels/common.yaml.j2")  | indent(width=4) | trim }}
     {{ lookup("template", "../common/templates/labels/version.yaml.j2") | indent(width=4) | trim }}
 spec:
+{% if task_replicas %}
   replicas: {{ task_replicas }}
+{% elif replicas %}
+  replicas: {{ replicas }}
+{% endif %}
   selector:
     matchLabels:
       app.kubernetes.io/name: '{{ ansible_operator_meta.name }}-task'

--- a/roles/installer/templates/deployments/web.yaml.j2
+++ b/roles/installer/templates/deployments/web.yaml.j2
@@ -9,7 +9,11 @@ metadata:
     {{ lookup("template", "../common/templates/labels/common.yaml.j2")  | indent(width=4) | trim }}
     {{ lookup("template", "../common/templates/labels//version.yaml.j2") | indent(width=4) | trim }}
 spec:
+{% if web_replicas %}
   replicas: {{ web_replicas }}
+{% elif replicas %}
+  replicas: {{ replicas }}
+{% endif %}
   selector:
     matchLabels:
       app.kubernetes.io/name: '{{ ansible_operator_meta.name }}-web'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Add the ability to toggle replica count for web and task separately with `web_replica` `task_replica` or set the count as the same with `replicas`
<!---
If you are fixing an existing issue, please include "fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Portion of #1182 
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New or Enhanced Feature
##### TESTING
The expectation of how the changes should work is that if desired, the user should be able to scale the numbers web and task replicas independently from each other or scale all replicas across all pods at the same rate. 

test case 1: 1 task replica and 2 web replicas
CRD change: 
```
  replicas: 1 
  web_replicas: 2
``` 
result 
```
➜  awx-operator git:(add_replicas) ✗ kubectl get pods -w
NAME                                               READY   STATUS    RESTARTS   AGE
awx-operator-controller-manager-6ddd8c4bf7-bvnfq   2/2     Running   0          3m29s
awx-postgres-13-0                                  1/1     Running   0          4m21s
awx-task-9896478bd-qzwrc                           4/4     Running   0          4m22s
awx-web-56966cb4d5-bcbf6                           3/3     Running   0          12s
awx-web-56966cb4d5-hk78m                           3/3     Running   0          4m22s
```
test case 2: 2 task replicas and 1 web replica
CRD change: 
```
  replicas: 1 
  task_replicas: 2
``` 
result
```
➜  awx-operator git:(add_replicas) ✗ kubectl get pods
NAME                                               READY   STATUS    RESTARTS   AGE
awx-operator-controller-manager-6ddd8c4bf7-bvnfq   2/2     Running   0          11m
awx-postgres-13-0                                  1/1     Running   0          12m
awx-task-9896478bd-mqs5d                           4/4     Running   0          15s
awx-task-9896478bd-qzwrc                           4/4     Running   0          12m
awx-web-56966cb4d5-hk78m                           3/3     Running   0          12m
```
test case 3: all replicas scaled to 3
CRD change: 
```
  replicas: 3
``` 
result 
```
➜  awx-operator git:(add_replicas) ✗ kubectl get pods
NAME                                               READY   STATUS    RESTARTS   AGE
awx-operator-controller-manager-6ddd8c4bf7-bvnfq   2/2     Running   0          17m
awx-postgres-13-0                                  1/1     Running   0          18m
awx-task-9896478bd-mqs5d                           4/4     Running   0          6m42s
awx-task-9896478bd-qzwrc                           4/4     Running   0          18m
awx-task-9896478bd-r9rjc                           4/4     Running   0          33s
awx-web-56966cb4d5-7dwr6                           3/3     Running   0          39s
awx-web-56966cb4d5-hk78m                           3/3     Running   0          18m
awx-web-56966cb4d5-mv6dk                           3/3     Running   0          39s
```
test case 4: set replicas to 0 to test default behavior
CRD change:
```
replicas: 0
```
result
```
➜  awx-operator git:(add_replicas) ✗ kubectl get pods
NAME                                               READY   STATUS    RESTARTS   AGE
awx-operator-controller-manager-697d47bcdb-x5bzb   2/2     Running   0          12m
awx-postgres-13-0                                  1/1     Running   0          8m27s
awx-task-9896478bd-g8h8k                           4/4     Running   0          7m41s
awx-web-56966cb4d5-5xk9w                           3/3     Running   0          8m7s
```