### PR TITLE
Specify sslrootcert in database options conditionally (fixes #1215)

### DIFF
--- a/roles/installer/templates/settings/credentials.py.j2
+++ b/roles/installer/templates/settings/credentials.py.j2
@@ -8,7 +8,9 @@ DATABASES = {
         'HOST': '{{ awx_postgres_host }}',
         'PORT': "{{ awx_postgres_port }}",
         'OPTIONS': { 'sslmode': '{{ awx_postgres_sslmode }}',
+                     {%- if awx_postgres_sslmode == 'verify-ca' or awx_postgres_sslmode == 'verify-full' %}
                      'sslrootcert': '{{ ca_trust_bundle }}',
+                     {%- endif %}
         },
     }
 }

--- a/roles/installer/templates/settings/credentials.py.j2
+++ b/roles/installer/templates/settings/credentials.py.j2
@@ -8,9 +8,9 @@ DATABASES = {
         'HOST': '{{ awx_postgres_host }}',
         'PORT': "{{ awx_postgres_port }}",
         'OPTIONS': { 'sslmode': '{{ awx_postgres_sslmode }}',
-                     {%- if awx_postgres_sslmode == 'verify-ca' or awx_postgres_sslmode == 'verify-full' %}
+{% if awx_postgres_sslmode in ['verify-ca', 'verify-full'] %}
                      'sslrootcert': '{{ ca_trust_bundle }}',
-                     {%- endif %}
+{% endif %}
         },
     }
 }


### PR DESCRIPTION
##### SUMMARY
Conditionally set `sslrootcert` option only when `sslmode` is set to `veriify-ca` or `verify-full` mode.
Setting `sslmode` to `require` or `prefer` will not validate certificate against CA cert.
More information in issue #1215.
 
##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
-->

When PostgreSQL is using self-signed certificate, there is no straight-forward way to allow connectivity from AWX.

Currently setting the `ssmode` to `require` still validates certificate. According to [documentation](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNECT-SSLMODE) it should not, unless CA certificate is explicitly specified (that turns it to `verify-ca` mode). This happens because `sslrootcert` is always added to the configuration file.

This small changeset adds `sslrootcert` conditionally.

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before:
```
        'OPTIONS': { 'sslmode': 'require',
                     'sslrootcert': '/etc/pki/tls/certs/ca-bundle.crt',
        },
```

After:
```
        'OPTIONS': { 'sslmode': 'require',
        },
```
```
        'OPTIONS': { 'sslmode': 'verify-ca',
                     'sslrootcert':  '/etc/pki/tls/certs/ca-bundle.crt',
        },

```