### PR TITLE
Auto-assign NodePort port by default rather than hardcoding a default

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,8 +199,6 @@ metadata:
   name: awx-demo
 spec:
   service_type: nodeport
-  # default nodeport_port is 30080
-  nodeport_port: <nodeport_port>
 ```
 
 > It may make sense to create and specify your own secret key for your deployment so that if the k8s secret gets deleted, it can be re-created if needed.  If it is not provided, one will be auto-generated, but cannot be recovered if lost. Read more [here](#secret-key-configuration).

--- a/config/crd/bases/awx.ansible.com_awxs.yaml
+++ b/config/crd/bases/awx.ansible.com_awxs.yaml
@@ -153,7 +153,6 @@ spec:
               nodeport_port:
                 description: Port to use for the nodeport
                 type: integer
-                default: 30080
               node_selector:
                 description: nodeSelector for the pods
                 type: string

--- a/roles/installer/defaults/main.yml
+++ b/roles/installer/defaults/main.yml
@@ -40,7 +40,9 @@ loadbalancer_protocol: 'http'
 loadbalancer_port: '80'
 service_annotations: ''
 
-nodeport_port: '30080'
+# Port to be used for NodePort configuration, default is to auto-assign a port between 30000-32768
+#nodeport_port: '30080'
+
 # The TLS termination mechanism to use to access
 # the services. Supported mechanism are: edge, passthrough
 #

--- a/roles/installer/templates/networking/service.yaml.j2
+++ b/roles/installer/templates/networking/service.yaml.j2
@@ -19,7 +19,9 @@ spec:
       protocol: TCP
       targetPort: 8052
       name: http
+{% if nodeport_port is defined %}
       nodePort: {{ nodeport_port }}
+{% endif %}
 {% elif service_type | lower != 'loadbalancer' and loadbalancer_protocol | lower != 'https' %}
     - port: 80
       protocol: TCP


### PR DESCRIPTION


##### SUMMARY

 Previously, there was no way to auto-assign a port by default which led to conflicts with other deployments at times. The `nodeport_port` param can still be used to specify a port if desired

With these changes, you can apply a simple AWX CR like this:

```
---
apiVersion: awx.ansible.com/v1beta1
kind: AWX
metadata:
  name: awx-demo
spec:
  service_type: nodeport
```

And the nodeport gets auto-assigned:

```
[chadams@fedora awx-operator]$ oc get -n awx svc awx-demo-service -o yaml | grep nodePort
    nodePort: 30390
```

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New or Enhanced Feature


