### PR TITLE
[web/task split] add topology constraints for each deployment

### DIFF
--- a/config/crd/bases/awx.ansible.com_awxs.yaml
+++ b/config/crd/bases/awx.ansible.com_awxs.yaml
@@ -166,6 +166,12 @@ spec:
               topology_spread_constraints:
                 description: topology rule(s) for the pods
                 type: string
+              task_topology_spread_constraints:
+                description: topology rule(s) for the task pods
+                type: string
+              web_topology_spread_constraints:
+                description: topology rule(s) for the web pods
+                type: string
               annotations:
                 description: annotations for the pods
                 type: string

--- a/roles/installer/defaults/main.yml
+++ b/roles/installer/defaults/main.yml
@@ -97,6 +97,28 @@ task_node_selector: ''
 #         app.kubernetes.io/name: "<resourcename>"
 topology_spread_constraints: ''
 
+# Add a topologySpreadConstraints for the task pods.
+# Specify as literal block. E.g.:
+# task_topology_spread_constraints: |
+#   - maxSkew: 100
+#     topologyKey: "topology.kubernetes.io/zone"
+#     whenUnsatisfiable: "ScheduleAnyway"
+#     labelSelector:
+#       matchLabels:
+#         app.kubernetes.io/name: "<resourcename>""
+task_topology_spread_constraints: ''
+
+# Add a topologySpreadConstraints for the web pods.
+# Specify as literal block. E.g.:
+# web_topology_spread_constraints: |
+#   - maxSkew: 100
+#     topologyKey: "topology.kubernetes.io/zone"
+#     whenUnsatisfiable: "ScheduleAnyway"
+#     labelSelector:
+#       matchLabels:
+#         app.kubernetes.io/name: "<resourcename>"
+web_topology_spread_constraints: ''
+
 # Add node tolerations for the AWX pods. Specify as literal block. E.g.:
 # tolerations: |
 #   - key: "dedicated"

--- a/roles/installer/templates/deployments/task.yaml.j2
+++ b/roles/installer/templates/deployments/task.yaml.j2
@@ -313,7 +313,10 @@ spec:
       nodeSelector:
         {{ node_selector | indent(width=8) }}
 {% endif %}
-{% if topology_spread_constraints %}
+{% if task_topology_spread_constraints %}
+      topologySpreadConstraints:
+        {{ task_topology_spread_constraints | indent(width=8) }}
+{% elif topology_spread_constraints %}
       topologySpreadConstraints:
         {{ topology_spread_constraints | indent(width=8) }}
 {% endif %}

--- a/roles/installer/templates/deployments/web.yaml.j2
+++ b/roles/installer/templates/deployments/web.yaml.j2
@@ -234,6 +234,13 @@ spec:
       nodeSelector:
         {{ node_selector | indent(width=8) }}
 {% endif %}
+{% if web_topology_spread_constraints %}
+      topologySpreadConstraints:
+        {{ web_topology_spread_constraints | indent(width=8) }}
+{% elif topology_spread_constraints %}
+      topologySpreadConstraints:
+        {{ topology_spread_constraints | indent(width=8) }}
+{% endif %}
 {% if web_tolerations %}
       tolerations:
         {{ web_tolerations| indent(width=8) }}


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes a portion of #1182. 

Add the ability for users to add topology spread constraints across the web and task deployments or set a specific one for the whole deployment
<!---
If you are fixing an existing issue, please include "fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New or Enhanced Feature


##### TESTING
Expected results will be similar in how the previous iterations of adding these types of features go in that there is the default `topology_spread_constraints` key which will apply to the whole deployment and then can be overwritten by `web_topology_spread_constraints` or `task_topology_spread_constraints` for their respective deployments

- test case 1: specify default behavior of apply `topology_spread_constraints` for the whole deployment
CRD Change
```
 topology_spread_constraints: |
   - maxSkew: 100
     topologyKey: "topology.kubernetes.io/zone"
     whenUnsatisfiable: "ScheduleAnyway"
     labelSelector:
       matchLabels:
         app.kubernetes.io/part-of: 'awx'
```
result is toplogySpreadConstraints is applied to both deployments and set the same
```
➜  awx-operator git:(add_topology_spread) kubectl edit deployment awx-web 
...
      serviceAccountName: awx
      terminationGracePeriodSeconds: 30
      topologySpreadConstraints:
      - labelSelector:
          matchLabels:
            app.kubernetes.io/part-of: awx
        maxSkew: 100
        topologyKey: topology.kubernetes.io/zone
        whenUnsatisfiable: ScheduleAnyway
➜  awx-operator git:(add_topology_spread) kubectl edit deployment awx-task 
      serviceAccountName: awx
      terminationGracePeriodSeconds: 30
      topologySpreadConstraints:
      - labelSelector:
          matchLabels:
            app.kubernetes.io/part-of: awx
        maxSkew: 100
        topologyKey: topology.kubernetes.io/zone
        whenUnsatisfiable: ScheduleAnyway
```
- test case 2: apply a `web_topology_spread_constraints` to change the web deployment but leave the task deployment the same as above in tc1
CRD Change
```
  topology_spread_constraints: |
    - maxSkew: 100
      topologyKey: "topology.kubernetes.io/zone"
      whenUnsatisfiable: "ScheduleAnyway"
      labelSelector:
        matchLabels:
          app.kubernetes.io/part-of: 'awx'
  web_topology_spread_constraints: |
    - maxSkew: 100
      topologyKey: "topology.kubernetes.io/zone"
      whenUnsatisfiable: "ScheduleAnyway"
      labelSelector:
        matchLabels:
          app.kubernetes.io/name: 'awx-web'
```
result was awx-web deployment changed but task stayed the same
```
➜  awx-operator git:(add_topology_spread) kubectl edit deployment awx-web  
terminationGracePeriodSeconds: 30
      topologySpreadConstraints:
      - labelSelector:
          matchLabels:
            app.kubernetes.io/name: awx-web
        maxSkew: 100
        topologyKey: topology.kubernetes.io/zone
        whenUnsatisfiable: ScheduleAnyway
➜  awx-operator git:(add_topology_spread) kubectl edit deployment awx-task
      terminationGracePeriodSeconds: 30
      topologySpreadConstraints:
      - labelSelector:
          matchLabels:
            app.kubernetes.io/part-of: awx
        maxSkew: 100
        topologyKey: topology.kubernetes.io/zone
        whenUnsatisfiable: ScheduleAnyway
```
- test case 3: apply a `task_topology_spread_constraints` to change the task deployment while leaving the web deployment constraint in place (aka same as tc2)
CRD Change
```
  task_topology_spread_constraints: |
    - maxSkew: 100
      topologyKey: "topology.kubernetes.io/zone"
      whenUnsatisfiable: "ScheduleAnyway"
      labelSelector:
        matchLabels:
          app.kubernetes.io/name: 'awx-task'
  web_topology_spread_constraints: |
    - maxSkew: 100
      topologyKey: "topology.kubernetes.io/zone"
      whenUnsatisfiable: "ScheduleAnyway"
      labelSelector:
        matchLabels:
          app.kubernetes.io/name: 'awx-web'
```
result is the task deployment's previous spread constraint set in tc1 is overwritten with the new constraint and web remains the same
```
➜  awx-operator git:(add_topology_spread) kubectl edit deployment awx-task
      serviceAccountName: awx
      terminationGracePeriodSeconds: 30
      topologySpreadConstraints:
      - labelSelector:
          matchLabels:
            app.kubernetes.io/name: awx-task
        maxSkew: 100
        topologyKey: topology.kubernetes.io/zone
        whenUnsatisfiable: ScheduleAnyway
➜  awx-operator git:(add_topology_spread) kubectl edit deployment awx-web
      serviceAccount: awx
      serviceAccountName: awx
      terminationGracePeriodSeconds: 30
      topologySpreadConstraints:
      - labelSelector:
          matchLabels:
            app.kubernetes.io/name: awx-web
        maxSkew: 100
        topologyKey: topology.kubernetes.io/zone
        whenUnsatisfiable: ScheduleAnyway
```
- test case 4: remove all constraints and reset back to default behavior
CRD Change
`remove all previous topology_spread_constraints`
result is default behavior
```
➜  awx-operator git:(add_topology_spread) kubectl edit deployment awx-web
      securityContext: {}
      serviceAccount: awx
      serviceAccountName: awx
      terminationGracePeriodSeconds: 30
      volumes:
➜  awx-operator git:(add_topology_spread) kubectl edit deployment awx-task
      schedulerName: default-scheduler
      securityContext: {}
      serviceAccount: awx
      serviceAccountName: awx
      terminationGracePeriodSeconds: 30
```
