### PR TITLE
Implement extra sidecar support

### DIFF
--- a/config/crd/bases/awx.ansible.com_awxs.yaml
+++ b/config/crd/bases/awx.ansible.com_awxs.yaml
@@ -81,6 +81,9 @@ spec:
               extra_volumes:
                 description: Specify extra volumes to add to the application pod
                 type: string
+              extra_sidecars:
+                description: Specify extra sidecars to add to the application pod
+                type: string
               service_annotations:
                 description: Annotations to add to the service
                 type: string

--- a/config/manifests/bases/awx-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/awx-operator.clusterserviceversion.yaml
@@ -226,7 +226,7 @@ spec:
         path: ingress_api_version
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
-        - urn:alm:descriptor:com.tectonic.ui:text 
+        - urn:alm:descriptor:com.tectonic.ui:text
       - displayName: Ingress Path
         path: ingress_path
         x-descriptors:
@@ -594,6 +594,12 @@ spec:
       - description: Specify extra volumes to add to the application pod
         displayName: Extra Volumes
         path: extra_volumes
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Specify extra sidecars to add to the application pod
+        displayName: Extra Sidecars
+        path: extra_sidecars
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:hidden

--- a/roles/installer/defaults/main.yml
+++ b/roles/installer/defaults/main.yml
@@ -132,6 +132,14 @@ ee_pull_credentials_secret: ''
 #     emptyDir: {}
 extra_volumes: ''
 
+# Add extra sidecars to the AWX pod. Specify as literal block. E.g.:
+# extra_sidecars: |
+#   - name: my-sidecar
+#     image: my-sidecar-image
+#     imagePullPolicy: Always
+#     ...
+extra_sidecars: ''
+
 # Use these image versions for Ansible AWX.
 
 _image: quay.io/ansible/awx

--- a/roles/installer/templates/deployments/deployment.yaml.j2
+++ b/roles/installer/templates/deployments/deployment.yaml.j2
@@ -371,6 +371,10 @@ spec:
 {% if ee_extra_env -%}
             {{ ee_extra_env | indent(width=12, first=True) }}
 {% endif %}
+# Optional sidecars to be added to the deployment:
+{% if extra_sidecars %}
+        {{ extra_sidecars | indent(width=8, first=True) }}
+{% endif %}
 {% if node_selector %}
       nodeSelector:
         {{ node_selector | indent(width=8) }}

--- a/roles/installer/templates/deployments/deployment.yaml.j2
+++ b/roles/installer/templates/deployments/deployment.yaml.j2
@@ -372,7 +372,7 @@ spec:
             {{ ee_extra_env | indent(width=12, first=True) }}
 {% endif %}
 # Optional sidecars to be added to the deployment:
-{% if extra_sidecars %}
+{% if extra_sidecars -%}
         {{ extra_sidecars | indent(width=8, first=True) }}
 {% endif %}
 {% if node_selector %}


### PR DESCRIPTION
##### SUMMARY
This PR adds a new property that allows you to specify sidecars to add to the AWX pod as blocks within the config.

Fixes https://github.com/ansible/awx-operator/issues/1235

##### ISSUE TYPE
 - New or Enhanced Feature

##### ADDITIONAL INFORMATION
This is useful for people who might need to add a VPN or other extra functionality to awx while using the awx-operator.