### PR TITLE
[web-task-split] update auto_upgrade logic

### DIFF
--- a/roles/installer/tasks/main.yml
+++ b/roles/installer/tasks/main.yml
@@ -1,13 +1,36 @@
 ---
-- name: Check for presence of Deployment
+- name: Check for presence of old awx Deployment
   k8s_info:
     api_version: v1
     kind: Deployment
     name: "{{ ansible_operator_meta.name }}"
     namespace: "{{ ansible_operator_meta.namespace }}"
-  register: tower_deployment
+  register: awx_deployment
 
-# Just execute deployment steps when auto_upgrade is true or when no deployment exists
-- name: Start installation
+- name: Check for presence of awx-task Deployment
+  k8s_info:
+    api_version: v1
+    kind: Deployment
+    name: "{{ ansible_operator_meta.name }}-task"
+    namespace: "{{ ansible_operator_meta.namespace }}"
+  register: awx_task_deployment
+
+- name: Check for presence of awx-web Deployment
+  k8s_info:
+    api_version: v1
+    kind: Deployment
+    name: "{{ ansible_operator_meta.name }}-web"
+    namespace: "{{ ansible_operator_meta.namespace }}"
+  register: awx_web_deployment
+
+- name: Start installation if auto_upgrade is true
   include_tasks: install.yml
-  when: (tower_deployment['resources'] | length > 0 and auto_upgrade | bool ) or (tower_deployment['resources'] | length == 0)
+  when:
+    - auto_upgrade | bool
+
+- name: Start installation if auto_upgrade is false and deployment is missing
+  include_tasks: install.yml
+  when:
+    - not (auto_upgrade | bool)
+    - not (awx_deployment['resources'] | length > 0)
+    - not (awx_web_deployment['resources'] | length > 0 and awx_task_deployment['resources'] | length > 0)

--- a/roles/installer/tasks/resources_configuration.yml
+++ b/roles/installer/tasks/resources_configuration.yml
@@ -1,6 +1,5 @@
 ---
-
-- name: Get the current resource pod information.
+- name: Get the current resource task pod information.
   k8s_info:
     api_version: v1
     kind: Pod
@@ -11,11 +10,20 @@
       - "app.kubernetes.io/component={{ deployment_type }}"
     field_selectors:
       - status.phase=Running
-  register: tower_pod
+  register: awx_task_pod
 
-- name: Set the resource pod name as a variable.
+- name: Initialize the resource pod name variable.
   set_fact:
-    tower_pod_name: "{{ tower_pod['resources'][0]['metadata']['name'] | default('') }}"
+    tower_pod_name: ""
+  when:
+    - tower_pod_name is not defined
+
+- name: Set the resource pod name to task pod name.
+  set_fact:
+    tower_pod_name: "{{ awx_task_pod['resources'][0]['metadata']['name'] | default('') }}"
+  when:
+    - awx_task_pod['resources'] | length > 0
+    - tower_pod_name == ""
 
 - name: Set user provided control plane ee image
   set_fact:


### PR DESCRIPTION
related to [[web/task split] AWX operator change to split web and task into separate deployment](https://github.com/ansible/awx-operator/issues/1182)

update logic for determining if install.yml task should be run to respect the auto_upgrade field in awx resource

conditions and expected behavior
```
  auto_upgrade   awx   awx-web   awx-task   run install.yml
 -------------- ----- --------- ---------- -----------------
  T              -     -         -          T
  F              T     -         -          F
  F              -     T         T          F
  F              -     T         F          T
  F              -     F         T          T
  F              -     F         F          T
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Breaking Change 
 - New or Enhanced Feature
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
