### PR TITLE
Customization of the init_projects_container_image is now possible

### DIFF
--- a/config/crd/bases/awx.ansible.com_awxs.yaml
+++ b/config/crd/bases/awx.ansible.com_awxs.yaml
@@ -758,6 +758,9 @@ spec:
               init_container_extra_volume_mounts:
                 description: Specify volume mounts to be added to the init container
                 type: string
+              init_projects_container_image:
+                description: Registry path to the init projects container to use
+                type: string
               postgres_image:
                 description: Registry path to the PostgreSQL container to use
                 type: string

--- a/config/manifests/bases/awx-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/awx-operator.clusterserviceversion.yaml
@@ -687,6 +687,12 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Init Projects Container image to use
+        displayName: Init Projects Container Image
+        path: init_projects_container_image
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:hidden
       - description: Secret where can be found the trusted Certificate Authority Bundle
         path: bundle_cacert_secret
         x-descriptors:

--- a/roles/installer/tasks/set_images.yml
+++ b/roles/installer/tasks/set_images.yml
@@ -17,3 +17,20 @@
       {{ _custom_init_container_image |
          default(lookup('env', 'RELATED_IMAGE_AWX_INIT_CONTAINER')) |
          default(_default_init_container_image, true) }}
+
+- name: Set default awx init projects container image
+  set_fact:
+    _default_init_projects_container_image: "{{ _init_projects_container_image }}"
+
+- name: Set user provided awx init projects image
+  set_fact:
+    _custom_init_projects_container_image: "{{ init_projects_container_image }}"
+  when:
+    - init_projects_container_image | default([]) | length
+
+- name: Set Init projects image URL
+  set_fact:
+    _init_projects_container_image: >-
+      {{ _custom_init_projects_container_image |
+         default(lookup('env', 'RELATED_IMAGE_AWX_INIT_PROJECTS_CONTAINER')) |
+         default(_default_init_projects_container_image, true) }}


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
When working in a closed (with no direct internet access) environment, you can override some Docker images, but there was still a hardcoded reference (_init_projects_container_image_ which was referencing a centos9 image on quay.io).
I simply extended the existing mechanism for _init_container_image_ var to the _init_projects_container_image_ var.

<!---
If you are fixing an existing issue, please include "fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
fixes #1162 

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
-->
Should be clear with the summary.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
