### PR TITLE
Stage and push helm index where gitconfig is set

### DIFF
--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -33,11 +33,6 @@ jobs:
           docker push quay.io/${{ github.repository }}:${{ github.event.release.tag_name }}
           docker push quay.io/${{ github.repository }}:latest
 
-      - name: Configure git
-        run: |
-          git config user.name "$GITHUB_ACTOR"
-          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
-
       - name: Release Helm chart
         run: |
           ansible-playbook ansible/helm-release.yml -v \
@@ -45,3 +40,4 @@ jobs:
             -e chart_owner=${{ github.repository_owner }} \
             -e tag=${{ github.event.release.tag_name }} \
             -e gh_token=${{ secrets.GITHUB_TOKEN }}
+            -e gh_user=${{ github.actor }}

--- a/Makefile
+++ b/Makefile
@@ -395,9 +395,3 @@ helm-index:
 	$(HELM) repo index .cr-release-packages --url https://github.com/$(CHART_OWNER)/$(CHART_REPO)/releases/download/ --merge gh-pages/index.yaml
 
 	mv .cr-release-packages/index.yaml gh-pages/index.yaml
-
-	@echo "== PUSH INDEX FILE =="
-	cd gh-pages;\
-	git add index.yaml;\
-	git commit -m "Updated index.yaml latest release";\
-	git push;\

--- a/ansible/helm-release.yml
+++ b/ansible/helm-release.yml
@@ -37,6 +37,11 @@
       register: asset_upload
       changed_when: asset_upload.json.state == "uploaded"
 
+    - name: Configure git config
+      run: |
+        git config user.name "{{ gh_user }}"
+        git config user.email "{{ gh_user }}@users.noreply.github.com"
+
     - name: Publish helm index
       command: |
         make helm-index
@@ -45,3 +50,11 @@
         CR_TOKEN: "{{ gh_token }}"
       args:
         chdir: "{{ playbook_dir }}/../"
+
+    - name: Stage and Push commit to gh-pages branch
+      command: |
+        git add index.yaml
+        git commit -m "Updated index.yaml latest release"
+        git push
+      args:
+        chdir: "{{ playbook_dir }}/../gh-pages"


### PR DESCRIPTION
##### SUMMARY

Fixes: https://github.com/ansible/awx-operator/issues/1246
Related stop-gap fix: https://github.com/ansible/awx-operator/pull/1250

The git config was not being set in the nested `gh-pages` clone of the awx-operator repo.  So when the  `git push` command was run, if [failed in the last 1.2.0 release](https://github.com/ansible/awx-operator/actions/runs/4166664596/jobs/7211282683). 

This was the error when pushing the index.yaml:

```
"stderr_lines": ["Author identity unknown", "", "*** Please tell me who you are.", "", "Run", "", "  git config --global user.email \"you@example.com\"", "  git config --global user.name \"Your Name\"", "", "to set your account's default identity.", "Omit --global to set the identity only in this repository.", "", "fatal: empty ident name (for <runner@fv-az575-24.4axca1wo35oulg5iw0gfp2lodh.dx.internal.cloudapp.net>) not allowed"
```

This also moves the git steps to the helm-release.yml playbook rather than the Makefile.  

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bug, Docs Fix or other nominal change
