### PR TITLE
[web/task split] Delete old deployment during upgrade

### DIFF
--- a/roles/installer/tasks/install.yml
+++ b/roles/installer/tasks/install.yml
@@ -1,4 +1,13 @@
 ---
+- name: Delete old deployment for before installing during upgrade
+  k8s:
+    kind: Deployment
+    api_version: v1
+    namespace: "{{ ansible_operator_meta.namespace }}"
+    name: "{{ ansible_operator_meta.name }}"
+    state: absent
+    wait: true
+
 - name: Patching labels to AWX kind
   k8s:
     state: present

--- a/roles/installer/tasks/install.yml
+++ b/roles/installer/tasks/install.yml
@@ -6,7 +6,6 @@
     namespace: "{{ ansible_operator_meta.namespace }}"
     name: "{{ ansible_operator_meta.name }}"
     state: absent
-    wait: true
 
 - name: Patching labels to AWX kind
   k8s:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
For the new deployment, we will need to remove the old deployment during upgrade. Fixes #1242 
<!---
If you are fixing an existing issue, please include "fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New or Enhanced Feature

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->
**Test Case 1** 
- Build and Deploy operator from devel and create the awx cr
```
➜  awx-operator git:(devel) ✗ kubectl get pods
NAME                                              READY   STATUS    RESTARTS   AGE
awx-cb99d9897-tnr7m                               4/4     Running   0          3m27s
awx-operator-controller-manager-f95bffc69-2qb2g   2/2     Running   0          16m
awx-postgres-13-0                                 1/1     Running   0          3m48s
```
create cr
```
ansible-playbook ansible/instantiate-awx-deployment.yml -e image_pull_policy=Always -e service_type=nodeport
```

- Confirm Awx from stable operator is working (login to UI)
- Edit awx CR to turn auto_upgrade to false
- Build and deploy operator from feature_web-task-split branch
- update awx CR with new awx-image and version (tag) for web-task-split
- turn auto_upgrade back to true
- wait for reconciler to run and delete the old instance + upgrade 
```
➜  awx-operator git:(upgrade_migration) ✗ kubectl get pods
NAME                                               READY   STATUS    RESTARTS   AGE
awx-operator-controller-manager-84b4f6946d-bdf4v   2/2     Running   0          14m
awx-postgres-13-0                                  1/1     Running   0          19m
awx-task-68d776449f-ffxf4                          4/4     Running   0          12m
awx-web-586c8fbf4f-vgh7c                           3/3     Running   0          12m
```
- test new web deployment is accesible and be logged into
![image](https://user-images.githubusercontent.com/24478650/222259659-eb94a4d8-372e-4d9a-ab3f-9ca1a9e2173e.png)

