### PR TITLE
fix: use sha1 instead of md5 to make the installer work in FIPS

### DIFF
--- a/roles/installer/templates/deployments/deployment.yaml.j2
+++ b/roles/installer/templates/deployments/deployment.yaml.j2
@@ -27,7 +27,7 @@ spec:
     "secrets/app_credentials",
     "storage/persistent",
   ] %}
-        checksum-{{ template | replace('/', '-') }}: "{{ lookup('template', template + '.yaml.j2') | md5 }}"
+        checksum-{{ template | replace('/', '-') }}: "{{ lookup('template', template + '.yaml.j2') | sha1 }}"
 {% endfor %}
 {% for secret in [
     "bundle_cacert",
@@ -37,7 +37,7 @@ spec:
     "receptor_ca",
     "receptor_work_signing",
   ] %}
-        checksum-secret-{{ secret }}: "{{ lookup('ansible.builtin.vars', secret, default='')["resources"][0]["data"] | default('') | md5 }}"
+        checksum-secret-{{ secret }}: "{{ lookup('ansible.builtin.vars', secret, default='')["resources"][0]["data"] | default('') | sha1 }}"
 {% endfor %}
 {% if annotations %}
         {{ annotations | indent(width=8) }}


### PR DESCRIPTION
##### SUMMARY

New or Enhanced Feature

##### ISSUE TYPE
Use `SHA1` instead of `md5` to make the installer work in FIPS mode.

##### ADDITIONAL INFORMATION

Related to a new annotation added here:
* https://github.com/ansible/awx-operator/pull/1222/commits/94d68bf382ec8dc4ce28d7d8d154663afd00b7fe
