### PR TITLE
Fix awx-manager-role bad match between some apiGroups and resources

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -20,7 +20,6 @@ rules:
       - watch
   - apiGroups:
       - ""
-      - "rbac.authorization.k8s.io"
     resources:
       - pods
       - services
@@ -31,6 +30,17 @@ rules:
       - events
       - configmaps
       - secrets
+    verbs:
+      - get
+      - list
+      - create
+      - delete
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - "rbac.authorization.k8s.io"
+    resources:
       - roles
       - rolebindings
     verbs:
@@ -43,12 +53,22 @@ rules:
       - watch
   - apiGroups:
       - apps
-      - networking.k8s.io
     resources:
       - deployments
       - daemonsets
       - replicasets
       - statefulsets
+    verbs:
+      - get
+      - list
+      - create
+      - delete
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
       - ingresses
     verbs:
       - get


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
There are some bad match between ApiGroups and Resources. This caused rights to be given to non existing resources (like APIGroup: "apps", Resource: ingress) and makes the role not creatable for an user without the `escalate` permission for Roles.
With this PR, the resources are matched with only one apiGroup so the mismatched are fixed and mismatchs can be more easily avoided in the future.
<!---
If you are fixing an existing issue, please include "fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Fixes #1261 
##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

