### PR TITLE
Add loadbalancerip

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,12 +403,14 @@ The following variables are customizable only when `service_type=LoadBalancer`
 | --------------------- | ---------------------------------------- | ------- |
 | loadbalancer_protocol | Protocol to use for Loadbalancer ingress | http    |
 | loadbalancer_port     | Port used for Loadbalancer ingress       | 80      |
+| loadbalancerip        | Assign Loadbalancer IP                   | ''      |  
 
 ```yaml
 ---
 spec:
   ...
   service_type: LoadBalancer
+  loadbalanserip: '192.168.10.25'
   loadbalancer_protocol: https
   loadbalancer_port: 443
   service_annotations: |

--- a/README.md
+++ b/README.md
@@ -403,14 +403,14 @@ The following variables are customizable only when `service_type=LoadBalancer`
 | --------------------- | ---------------------------------------- | ------- |
 | loadbalancer_protocol | Protocol to use for Loadbalancer ingress | http    |
 | loadbalancer_port     | Port used for Loadbalancer ingress       | 80      |
-| loadbalancerip        | Assign Loadbalancer IP                   | ''      |  
+| loadbalancer_ip        | Assign Loadbalancer IP                   | ''      |  
 
 ```yaml
 ---
 spec:
   ...
   service_type: LoadBalancer
-  loadbalancerip: '192.168.10.25'
+  loadbalancer_ip: '192.168.10.25'
   loadbalancer_protocol: https
   loadbalancer_port: 443
   service_annotations: |

--- a/README.md
+++ b/README.md
@@ -410,7 +410,7 @@ The following variables are customizable only when `service_type=LoadBalancer`
 spec:
   ...
   service_type: LoadBalancer
-  loadbalanserip: '192.168.10.25'
+  loadbalancerip: '192.168.10.25'
   loadbalancer_protocol: https
   loadbalancer_port: 443
   service_annotations: |

--- a/config/crd/bases/awx.ansible.com_awxs.yaml
+++ b/config/crd/bases/awx.ansible.com_awxs.yaml
@@ -132,7 +132,7 @@ spec:
                 description: Port to use for the loadbalancer
                 type: integer
                 default: 80
-              loadbalancerip:
+              loadbalancer_ip:
                 description: Assign LoadBalancer IP address
                 type: string
                 default: ''

--- a/config/crd/bases/awx.ansible.com_awxs.yaml
+++ b/config/crd/bases/awx.ansible.com_awxs.yaml
@@ -132,6 +132,10 @@ spec:
                 description: Port to use for the loadbalancer
                 type: integer
                 default: 80
+              loadbalancerip:
+                description: Assign LoadBalancer IP address
+                type: string
+                default: ''
               route_host:
                 description: The DNS to use to points to the instance
                 type: string

--- a/config/manifests/bases/awx-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/awx-operator.clusterserviceversion.yaml
@@ -270,6 +270,12 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:number
         - urn:alm:descriptor:com.tectonic.ui:fieldDependency:service_type:LoadBalancer
+      - displayName: LoadBalancer IP
+        path: loadbalancer_ip
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:string
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:service_type:LoadBalancer
       - displayName: Route API Version
         path: route_api_version
         x-descriptors:

--- a/roles/installer/templates/networking/service.yaml.j2
+++ b/roles/installer/templates/networking/service.yaml.j2
@@ -54,7 +54,7 @@ spec:
 {% elif service_type | lower == "loadbalancer" %}
   type: LoadBalancer
 {% if variable is defined and variable|length %}
-  loadbalancerip: '{{ loadbalancerip }}'
+  loadbalancerip: '{{ loadbalancer_ip }}'
 {% endif %}
 {% else %}
   type: ClusterIP

--- a/roles/installer/templates/networking/service.yaml.j2
+++ b/roles/installer/templates/networking/service.yaml.j2
@@ -53,6 +53,9 @@ spec:
   type: NodePort
 {% elif service_type | lower == "loadbalancer" %}
   type: LoadBalancer
+{% if variable is defined and variable|length %}
+  loadbalancerip: '{{ loadbalancerip }}'
+{% endif %}
 {% else %}
   type: ClusterIP
 {% endif %}


### PR DESCRIPTION
##### SUMMARY
Added ability to assign loadbalancerip when AWX instance with service type 'LoadBalancer' is created.

##### ISSUE TYPE
 - New or Enhanced Feature

##### ADDITIONAL INFORMATION

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
Before:  
spec:
  ...
  service_type: LoadBalancer
  loadbalancer_protocol: https
  loadbalancer_port: 443

---
After:  
spec:
  ...
  service_type: LoadBalancer
  loadbalancer_ip: '192.168.10.25'
  loadbalancer_protocol: https
  loadbalancer_port: 443

```
