### PR TITLE
Fix helm-release task to work in ansible, not GHA env

### DIFF
--- a/ansible/helm-release.yml
+++ b/ansible/helm-release.yml
@@ -38,9 +38,11 @@
       changed_when: asset_upload.json.state == "uploaded"
 
     - name: Configure git config
-      run: |
-        git config user.name "{{ gh_user }}"
-        git config user.email "{{ gh_user }}@users.noreply.github.com"
+      shell: |
+        git config user.name {{ gh_user }}
+        git config user.email {{ gh_user }}@users.noreply.github.com
+      args:
+        chdir: "{{ playbook_dir }}/../gh-pages"
 
     - name: Publish helm index
       command: |


### PR DESCRIPTION
##### SUMMARY

@john-westcott-iv found a bug in the helm-release changes I made to generate the index.yaml.  These are the changes originally made:
* https://github.com/ansible/awx-operator/commit/edf01f009eebe65644081d5b94aaf30e09c654dc
Since we are running this as an ansible playbook, not a GHA, it needs to be  `command:`, not  `run:`

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bug, Docs Fix or other nominal change


##### Additional Info

Tested with:

```
$ ansible-playbook ansible/helm-release.yml -v  -e operator_image=quay.io/ansible  -e chart_owner=ansible  -e tag=1.3.0  -e gh_token=$GH_TOKEN  -e gh_user=rooftopcellist
```