### PR TITLE
Fix helm 1.3.0

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -3,16 +3,6 @@ entries:
   awx-operator:
   - apiVersion: v2
     appVersion: 1.3.0
-    created: "2023-03-06T15:01:11.053864328-05:00"
-    description: A Helm chart for the AWX Operator
-    digest: a8dcb6028aa358983d932b645b1dcbceaa0f1e67797cc54cad5c4c9563606c53
-    name: awx-operator
-    type: application
-    urls:
-    - https://github.com/ansible/awx-operator/releases/download/awx-operator-1.3.0.tgz
-    version: 1.3.0
-  - apiVersion: v2
-    appVersion: 1.3.0
     created: "2023-03-06T15:01:11.070402791-05:00"
     description: A Helm chart for the AWX Operator
     digest: 281f720b8d4d4d05a22bb290f83a4c5219cdccc65b358331fb0c7854a64dc774


### PR DESCRIPTION
##### SUMMARY
This entry got added by mistake.  Fixes a mistake I introduced here:
* https://github.com/ansible/awx-operator/pull/1269/files

##### ISSUE TYPE

 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION

Tested with:

```
$ ansible-playbook ansible/helm-release.yml -v  -e operator_image=quay.io/ansible  -e chart_owner=ansible  -e tag=1.3.0  -e gh_token=$GH_TOKEN  -e gh_user=rooftopcellist
```