### PR TITLE
Remove duplicate 1.3.0 helm chart entry

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -12,16 +12,6 @@ entries:
     - https://github.com/ansible/awx-operator/releases/download/awx-operator-1.3.0.tgz
     version: 1.3.0
   - apiVersion: v2
-    appVersion: 1.3.0
-    created: "2023-03-08T14:25:05.222030122-05:00"
-    description: A Helm chart for the AWX Operator
-    digest: 20a5f41ccd3ca4cfb7bd2e2c0c341415852db1e3be964631a9f3ad045a05a62c
-    name: awx-operator
-    type: application
-    urls:
-    - https://github.com/ansible/awx-operator/releases/download/1.3.0/awx-operator-1.3.0.tgz
-    version: 1.3.0
-  - apiVersion: v2
     appVersion: 1.2.0
     created: "2023-03-08T14:25:05.220623929-05:00"
     description: A Helm chart for the AWX Operator


### PR DESCRIPTION
##### SUMMARY
Duplicate entry needed to be removed after re-run of helm chart generation & upload automation.

Part of the fix for:
* https://github.com/ansible/awx-operator/pull/1270

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bug, Docs Fix or other nominal change
