### PR TITLE
Helm Release: Need to use shell, not command for multi-line

### DIFF
--- a/ansible/helm-release.yml
+++ b/ansible/helm-release.yml
@@ -54,7 +54,7 @@
         chdir: "{{ playbook_dir }}/../"
 
     - name: Stage and Push commit to gh-pages branch
-      command: |
+      shell: |
         git add index.yaml
         git commit -m "Updated index.yaml latest release"
         git push


### PR DESCRIPTION
##### SUMMARY
For the helm release automation, when running this playbook again today I found another bug.  We need to use shell, not command for multi-line commands here.  

Similar and related to:
* https://github.com/ansible/awx-operator/pull/1267

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bug, Docs Fix or other nominal change
