### PR TITLE
remove any reference to project persistance in web deployment

### DIFF
--- a/roles/installer/templates/deployments/web.yaml.j2
+++ b/roles/installer/templates/deployments/web.yaml.j2
@@ -62,7 +62,7 @@ spec:
       priorityClassName: '{{ control_plane_priority_class }}'
 {% endif %}
       initContainers:
-{% if bundle_ca_crt or projects_persistence|bool or init_container_extra_commands %}
+{% if bundle_ca_crt or init_container_extra_commands %}
         - name: init
           image: '{{ _init_container_image }}'
           imagePullPolicy: '{{ image_pull_policy }}'
@@ -73,10 +73,6 @@ spec:
 {% if bundle_ca_crt  %}
               mkdir -p /etc/pki/ca-trust/extracted/{java,pem,openssl,edk2}
               update-ca-trust
-{% endif %}
-{% if projects_persistence|bool %}
-              chmod 775 /var/lib/awx/projects
-              chgrp 1000 /var/lib/awx/projects
 {% endif %}
 {% if init_container_extra_commands %}
               {{ init_container_extra_commands | indent(width=14) }}
@@ -89,10 +85,6 @@ spec:
               mountPath: /etc/pki/ca-trust/source/anchors/bundle-ca.crt
               subPath: bundle-ca.crt
               readOnly: true
-{% endif %}
-{% if projects_persistence|bool %}
-            - name: "{{ ansible_operator_meta.name }}-projects"
-              mountPath: "/var/lib/awx/projects"
 {% endif %}
 {% if init_container_extra_volume_mounts -%}
             {{ init_container_extra_volume_mounts | indent(width=12, first=True) }}
@@ -180,8 +172,6 @@ spec:
               mountPath: "/var/run/redis"
             - name: rsyslog-socket
               mountPath: "/var/run/awx-rsyslog"
-            - name: "{{ ansible_operator_meta.name }}-projects"
-              mountPath: "/var/lib/awx/projects"
 {% if development_mode | bool %}
             - name: awx-devel
               mountPath: "/awx_devel"
@@ -350,17 +340,6 @@ spec:
             items:
               - key: receptor_conf
                 path: receptor.conf
-        - name: "{{ ansible_operator_meta.name }}-projects"
-{% if projects_persistence|bool %}
-          persistentVolumeClaim:
-{% if projects_existing_claim %}
-            claimName: {{ projects_existing_claim }}
-{% else %}
-            claimName: '{{ ansible_operator_meta.name }}-projects-claim'
-{% endif %}
-{% else %}
-          emptyDir: {}
-{% endif %}
 {% if development_mode | bool %}
         - name: awx-devel
           hostPath:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #1266 
The project directory and associated persistence is not needed in the web container for the application to work as intended. 
<!---
If you are fixing an existing issue, please include "fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - New or Enhanced Feature


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
-->

**Test Case 1**
- Build operator and deploy from PR branch. From root of operator `make docker-build deploy`
- Once the operator is deployed, you will need to deploy an awx image that has the feature work for web/task split. You can use the instantiate playbook to do this with the appropriate images. 
```
ansible-playbook ansible/instantiate-awx-deployment.yml \
    -e development_mode=yes \
    -e image=ghcr.io/ansible/awx \
    -e image_version=feature_web-task-split \
    -e image_pull_policy=Always \
    -e service_type=nodeport \
    -e namespace=$NAMESPACE
```
- Once the awx resource is created and you can navigate to the web UI, login and run the demo job template. 
- This will yield a successful run 
![image](https://user-images.githubusercontent.com/24478650/224375040-455e6b33-eb8a-4d62-8845-96161dabb403.png)



