### PR TITLE
Document the need for quotes on pg secret port value

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -34,7 +34,7 @@ metadata:
   namespace: <target namespace>
 stringData:
   host: <external ip or url resolvable by the cluster>
-  port: <external port, this usually defaults to 5432>
+  port: "<external port, this usually defaults to 5432>"    # quotes are required
   database: <desired database name>
   username: <username to connect as>
   password: <password to connect with>


### PR DESCRIPTION
##### SUMMARY
Quotes are needed on the port value for the old_postgres_configuration_secret` or else the k8s validator will reject it upon creation.  This is an attempt to make that clearer. 

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bug, Docs Fix or other nominal change
