### PR TITLE
Stop creating empty k8s secrets during restore role cleanup

### DIFF
--- a/roles/restore/tasks/cleanup.yml
+++ b/roles/restore/tasks/cleanup.yml
@@ -8,22 +8,6 @@
     state: absent
     force: true
 
-- name: Remove ownerReferences from secrets to avoid garbage collection
-  k8s:
-    definition:
-      apiVersion: v1
-      kind: Secret
-      metadata:
-        name: '{{ item }}'
-        namespace: '{{ ansible_operator_meta.namespace }}'
-        ownerReferences: null
-  loop:
-    - '{{ secret_key_secret }}'
-    - '{{ admin_password_secret }}'
-    - '{{ broadcast_websocket_secret }}'
-    - '{{ postgres_configuration_secret }}'
-  no_log: "{{ no_log }}"
-
 - name: Cleanup temp spec file
   file:
     path: "{{ tmp_spec.path }}"

--- a/roles/restore/vars/main.yml
+++ b/roles/restore/vars/main.yml
@@ -7,9 +7,4 @@ _postgres_image_version: 13
 backup_api_version: '{{ deployment_type }}.ansible.com/v1beta1'
 backup_kind: 'AWXBackup'
 
-# set default secret names to be used if a backup dir and claim are provided (not a backup_name)
-secret_key_secret: '{{ deployment_name }}-secret-key'
-admin_password_secret: '{{ deployment_name }}-admin-password'
-broadcast_websocket_secret: '{{ deployment_name }}-broadcast-websocket'
-postgres_configuration_secret: '{{ deployment_name }}-postgres-configuration'
 supported_pg_version: 13


### PR DESCRIPTION
##### SUMMARY

Resolves:
* https://github.com/ansible/awx-operator/issues/1293

During a restore, some of the generated secrets are duplicated, but with empty data/values.  This is because the task the remove ownerReferences is being run with the wrong secret names

We can also remove the defaults as they are no longer needed.  

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bug, Docs Fix or other nominal change
