### PR TITLE
[web/task split] fix scale down bug 

### DIFF
--- a/roles/installer/tasks/scale_down_deployment.yml
+++ b/roles/installer/tasks/scale_down_deployment.yml
@@ -12,8 +12,11 @@
   kubernetes.core.k8s_scale:
     api_version: v1
     kind: Deployment
-    name: "{{ ansible_operator_meta.name }}"
+    name: "{{ item }}"
     namespace: "{{ ansible_operator_meta.namespace }}"
     replicas: 0
     wait: yes
+  loop:
+    - "{{ ansible_operator_meta.name }}-task"
+    - "{{ ansible_operator_meta.name }}-web"
   when: this_deployment['resources'] | length

--- a/roles/restore/tasks/postgres.yml
+++ b/roles/restore/tasks/postgres.yml
@@ -50,7 +50,7 @@
   k8s_info:
     api_version: v1
     kind: Deployment
-    name: "{{ deployment_name }}"
+    name: "{{ ansible_operator_meta.namespace }}-task"
     namespace: "{{ ansible_operator_meta.namespace }}"
   register: this_deployment
 
@@ -58,10 +58,13 @@
   k8s_scale:
     api_version: v1
     kind: Deployment
-    name: "{{ deployment_name }}"
+    name: "{{ item }}"
     namespace: "{{ ansible_operator_meta.namespace }}"
     replicas: 0
     wait: yes
+  loop:
+    - "{{ ansible_operator_meta.name }}-task"
+    - "{{ ansible_operator_meta.name }}-web"
   when: this_deployment['resources'] | length
 
 - name: Set full resolvable host name for postgres pod


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
fixes #1255 

While working on cleanup, the scale down playbook didn't have the new naming conventions for the pods and would currently scale down nothing during any type of db upgrade etc. 

This adds a simple list loop to scale down both pods during any db upgrade/migration/configuration in the operator. 
<!---
If you are fixing an existing issue, please include "fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
-->
**test case**
To test this properly, we will need to either provoke the rescue block or do a db migration or upgrade. I think there is also a way to provoke it if there is no DB specified but I need to investigate this. 

If anyone has any pointers or thoughts on how we can approach this, please share as I am running low on ideas.
<!--- Paste verbatim command output below, e.g. before and after your change -->

