### PR TITLE
restore: Set deployment_name as required

### DIFF
--- a/config/crd/bases/awx.ansible.com_awxrestores.yaml
+++ b/config/crd/bases/awx.ansible.com_awxrestores.yaml
@@ -39,6 +39,8 @@ spec:
           spec:
             type: object
             x-kubernetes-preserve-unknown-fields: true
+            required:
+            - deployment_name
             properties:
               backup_source:
                 description: Backup source


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

The `deployment_name` from the AWXRestore CR doesn't requires to set a value for this parameter.
That parameter is already required for the AWXBackup CR so it should be the same for AWXRestore.

Creating an AWXRestore CR without deployment_name set results in a failure during the Secrets restoration.

```console
"reason":"FieldValueInvalid","message":"Invalid value: \\"-receptor-ca\\": a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, \'-\' or \'.\', and must start and end with an alphanumeric character (e.g. \'example.com\', regex used for validation is \'[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\')"
```

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change
