### PR TITLE
restore: Fix enum value for backup_source

### DIFF
--- a/config/crd/bases/awx.ansible.com_awxrestores.yaml
+++ b/config/crd/bases/awx.ansible.com_awxrestores.yaml
@@ -44,7 +44,7 @@ spec:
                 description: Backup source
                 type: string
                 enum:
-                - CR
+                - Backup CR
                 - PVC
               deployment_name:
                 description: Name of the restored deployment. This should be different from the original deployment name


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

The choice for backup_source are:
- Backup CR
- PVC

This current prevents to create an AWXRestore CR with the Backup CR value from the OLM UI.

```console
Error "Unsupported value: "Backup CR": supported values: "CR", "PVC"" for field "spec.backup_source".
```

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change
