### PR TITLE
Change ansible k8s_info tasks api_version for Deployment kind to apps/v1

### DIFF
--- a/roles/installer/tasks/main.yml
+++ b/roles/installer/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: Check for presence of Deployment
   k8s_info:
-    api_version: v1
+    api_version: apps/v1
     kind: Deployment
     name: "{{ ansible_operator_meta.name }}"
     namespace: "{{ ansible_operator_meta.namespace }}"

--- a/roles/installer/tasks/scale_down_deployment.yml
+++ b/roles/installer/tasks/scale_down_deployment.yml
@@ -2,7 +2,7 @@
 
 - name: Check for presence of Deployment
   k8s_info:
-    api_version: v1
+    api_version: apps/v1
     kind: Deployment
     name: "{{ ansible_operator_meta.name }}"
     namespace: "{{ ansible_operator_meta.namespace }}"
@@ -10,7 +10,7 @@
 
 - name: Scale down Deployment for migration
   kubernetes.core.k8s_scale:
-    api_version: v1
+    api_version: apps/v1
     kind: Deployment
     name: "{{ ansible_operator_meta.name }}"
     namespace: "{{ ansible_operator_meta.namespace }}"

--- a/roles/restore/tasks/postgres.yml
+++ b/roles/restore/tasks/postgres.yml
@@ -48,7 +48,7 @@
 
 - name: Check for presence of AWX Deployment
   k8s_info:
-    api_version: v1
+    api_version: apps/v1
     kind: Deployment
     name: "{{ deployment_name }}"
     namespace: "{{ ansible_operator_meta.namespace }}"
@@ -56,7 +56,7 @@
 
 - name: Scale down Deployment for migration
   k8s_scale:
-    api_version: v1
+    api_version: apps/v1
     kind: Deployment
     name: "{{ deployment_name }}"
     namespace: "{{ ansible_operator_meta.namespace }}"


### PR DESCRIPTION
##### SUMMARY
Switch `api_version` from **v1** to **apps/v1** for all `k8s_info` tasks using `Kind: Deployment`
fixes #1282 

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION
The API version of Deployment in all recent version of Kubernetes is:
```bash
❯ kubectl api-resources | grep deployment
deployments        deploy        apps/v1        true        Deployment
```
The deployment of the AWX kind was failing on our internal k8s cluster and since then we do use a custom image using the changes in this PR with no issues. As it did not cause any issues on our side we are proposing to have the updated api version merged in the main branch to reflect the correct api version of the Deployment kind.
