### PR TITLE
Allow TLS 1.2 for Receptor connections

### DIFF
--- a/roles/installer/templates/configmaps/config.yaml.j2
+++ b/roles/installer/templates/configmaps/config.yaml.j2
@@ -269,6 +269,7 @@ data:
         key: /etc/receptor/tls/receptor.key
         name: tlsclient
         rootcas: /etc/receptor/tls/ca/receptor-ca.crt
+        mintls13: false
     - work-signing:
         privatekey: /etc/receptor/signing/work-private-key.pem
         tokenexpiration: 1m


### PR DESCRIPTION
goes with this awx PR https://github.com/ansible/awx/pull/13749
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
- Required for FIPS environment where TLS 1.3 is not supported
- TLS 1.3 can still be used if the nodes both agree to use during handshake.
<!---
If you are fixing an existing issue, please include "fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New or Enhanced Feature
