### PR TITLE
Adding missing \ in promote workflow

### DIFF
--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -39,5 +39,5 @@ jobs:
             -e operator_image=quay.io/${{ github.repository }} \
             -e chart_owner=${{ github.repository_owner }} \
             -e tag=${{ github.event.release.tag_name }} \
-            -e gh_token=${{ secrets.GITHUB_TOKEN }}
+            -e gh_token=${{ secrets.GITHUB_TOKEN }} \
             -e gh_user=${{ github.actor }}


### PR DESCRIPTION
##### SUMMARY
Release failed with:
```
TASK [Configure git config] ****************************************************
fatal: [localhost]: FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: 'gh_user' is undefined. 'gh_user' is undefined\n\nThe error appears to be in '/home/runner/work/awx-operator/awx-operator/ansible/helm-release.yml': line 40, column 7, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n    - name: Configure git config\n      ^ here\n"}
```

Looks like it could be a missing `\` in the workflows yaml file.

<!---
If you are fixing an existing issue, please include "fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
