### PR TITLE
Remove broken duplicate 1.4.0 helm chart entry

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -3,16 +3,6 @@ entries:
   awx-operator:
   - apiVersion: v2
     appVersion: 1.4.0
-    created: "2023-03-28T01:10:43.291704398Z"
-    description: A Helm chart for the AWX Operator
-    digest: 9bf17eb8cc6901de43e9432deafec1b09db122916fd91e818da2280b08281d39
-    name: awx-operator
-    type: application
-    urls:
-    - https://github.com/ansible/awx-operator/releases/download/awx-operator-1.4.0.tgz
-    version: 1.4.0
-  - apiVersion: v2
-    appVersion: 1.4.0
     created: "2023-03-28T01:10:43.314779075Z"
     description: A Helm chart for the AWX Operator
     digest: 9bf17eb8cc6901de43e9432deafec1b09db122916fd91e818da2280b08281d39


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

fixes #1306

This removes a broken duplicate entry for the 1.4.0 Operator Helm Chart.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
Downloading awx-operator from repo https://ansible.github.io/awx-operator/
Save error occurred:  could not download https://github.com/ansible/awx-operator/releases/download/awx-operator-1.4.0.tgz: failed to fetch https://github.com/ansible/awx-operator/releases/download/awx-operator-1.4.0.tgz : 404 Not Found
Error: could not download https://github.com/ansible/awx-operator/releases/download/awx-operator-1.4.0.tgz: failed to fetch https://github.com/ansible/awx-operator/releases/download/awx-operator-1.4.0.tgz : 404 Not Found
```
