### PR TITLE
Improve naming consistency

### DIFF
--- a/roles/installer/defaults/main.yml
+++ b/roles/installer/defaults/main.yml
@@ -268,7 +268,7 @@ task_args:
   - /usr/bin/launch_awx_task.sh
 task_command: []
 web_args:
-  - /usr/bin/launch_awx.sh
+  - /usr/bin/launch_awx_web.sh
 web_command: []
 ryslog_args:
   - /usr/bin/launch_awx_rsyslog.sh

--- a/roles/installer/templates/deployments/task.yaml.j2
+++ b/roles/installer/templates/deployments/task.yaml.j2
@@ -240,8 +240,8 @@ spec:
           env:
             - name: AWX_COMPONENT
               value: "task"
-            - name: SUPERVISOR_WEB_CONFIG_PATH
-              value: "/etc/supervisord.conf"
+            - name: SUPERVISOR_CONFIG_PATH
+              value: "/etc/supervisord_task.conf"
             - name: AWX_SKIP_MIGRATIONS
               value: "1"
             - name: MY_POD_UID
@@ -361,7 +361,7 @@ spec:
               mountPath: "/awx_devel"
 {% endif %}
           env:
-            - name: SUPERVISOR_WEB_CONFIG_PATH
+            - name: SUPERVISOR_CONFIG_PATH
               value: "/etc/supervisor_rsyslog.conf"
 {% if development_mode | bool %}
             - name: AWX_KUBE_DEVEL

--- a/roles/installer/templates/deployments/web.yaml.j2
+++ b/roles/installer/templates/deployments/web.yaml.j2
@@ -194,6 +194,8 @@ spec:
           env:
             - name: AWX_COMPONENT
               value: "web"
+            - name: SUPERVISOR_CONFIG_PATH
+              value: "/etc/supervisor_web.conf"
             - name: MY_POD_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -243,7 +245,7 @@ spec:
               mountPath: "/awx_devel"
 {% endif %}
           env:
-            - name: SUPERVISOR_WEB_CONFIG_PATH
+            - name: SUPERVISOR_CONFIG_PATH
               value: "/etc/supervisor_rsyslog.conf"
 {% if development_mode | bool %}
             - name: AWX_KUBE_DEVEL


### PR DESCRIPTION
##### SUMMARY
related to https://github.com/ansible/awx/pull/13777

- make sure that the launch script name reflect the component that its launching
- update SUPERVISOR_WEB_CONFIG_PATH to SUPERVISOR_CONFIG_PATH and point to proper supervisor_conf file
- add missing SUPERVISOR_CONFIG_PATH for web container

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
