### PR TITLE
Add websocket configuration for contour ingress

### DIFF
--- a/README.md
+++ b/README.md
@@ -477,6 +477,23 @@ spec:
     environment: testing
 ```
 
+##### Specialized Ingress Controller configuration
+
+Some Ingress Controllers need a special configuration to fully support AWX, add the following value with the `ingress_controller` variable, if you are using one of these:
+
+| Ingress Controller name               | value   |
+| ------------------------------------- | ------- |
+| [Contour](https://projectcontour.io/) | contour |
+
+```yaml
+---
+spec:
+  ...
+  ingress_type: ingress
+  hostname: awx-demo.example.com
+  ingress_controller: contour
+```
+
   * Route
 
 The following variables are customizable when `ingress_type=route`

--- a/config/crd/bases/awx.ansible.com_awxs.yaml
+++ b/config/crd/bases/awx.ansible.com_awxs.yaml
@@ -121,6 +121,9 @@ spec:
               ingress_class_name:
                 description: The name of ingress class to use instead of the cluster default.
                 type: string
+              ingress_controller:
+                description: Special configuration for specific Ingress Controllers
+                type: string
               loadbalancer_protocol:
                 description: Protocol to use for the loadbalancer
                 type: string

--- a/config/manifests/bases/awx-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/awx-operator.clusterserviceversion.yaml
@@ -251,6 +251,12 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:io.kubernetes:Secret
         - urn:alm:descriptor:com.tectonic.ui:fieldDependency:ingress_type:Ingress
+      - displayName: Ingress Controller
+        path: ingress_controller
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:text
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:ingress_type:Ingress
       - displayName: LoadBalancer Annotations
         path: service_annotations
         x-descriptors:

--- a/roles/installer/defaults/main.yml
+++ b/roles/installer/defaults/main.yml
@@ -36,6 +36,10 @@ ingress_annotations: ''
 # certificate and key.
 ingress_tls_secret: ''
 
+# Special configuration for specific Ingress Controllers. E.g.:
+# ingress_controller: contour
+ingress_controller: ''
+
 loadbalancer_protocol: 'http'
 loadbalancer_port: '80'
 service_annotations: ''

--- a/roles/installer/templates/networking/ingress.yaml.j2
+++ b/roles/installer/templates/networking/ingress.yaml.j2
@@ -9,9 +9,15 @@ metadata:
   namespace: '{{ ansible_operator_meta.namespace }}'
   labels:
     {{ lookup("template", "../common/templates/labels/common.yaml.j2") | indent(width=4) | trim }}
-{% if ingress_annotations %}
+{% if ingress_annotations or ingress_controller|lower == "contour" %}
   annotations:
+{% if ingress_annotations %}
     {{ ingress_annotations | indent(width=4) }}
+{% endif %}
+{% if ingress_controller|lower == "contour" %}
+    projectcontour.io/websocket-routes: "/websocket"
+    kubernetes.io/ingress.class: contour
+{% endif %}
 {% endif %}
 spec:
 {% if ingress_class_name %}
@@ -27,6 +33,15 @@ spec:
                 name: '{{ ansible_operator_meta.name }}-service'
                 port:
                   number: 80
+{% if ingress_controller|lower == "contour" %}
+          - path: '{{ ingress_path }}/websocket'
+            pathType: '{{ ingress_path_type }}'
+            backend:
+              service:
+                name: '{{ ansible_operator_meta.name }}-service'
+                port:
+                  number: 80
+{% endif %}
 {% if hostname %}      
       host: {{ hostname }}
 {% endif %}      


### PR DESCRIPTION
##### SUMMARY

As described in [this issue](https://github.com/ansible/awx/issues/9747#issuecomment-1440068816), the websocket is not available through contour, as this needs special configuration.
Here is also the [help page](https://projectcontour.io/docs/1.24/config/websockets/) from contour.

##### ISSUE TYPE

 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION

So this change basically implements a check if a contour ingress is installed on the cluster, and if yes, adds the websocket route, as well as the seperate path for that.

Unfortunately I wasn't able to spin up the tests, as it looks for be that these are broken somehow, if I can get these working somehow I will gladly run through them!
As well as, if any changes are wanted I will definitely try to improve the contribution.