### PR TITLE
Updating awx_test.yml to respect both web and task deployments.

### DIFF
--- a/molecule/default/tasks/awx_test.yml
+++ b/molecule/default/tasks/awx_test.yml
@@ -19,13 +19,22 @@
   register: admin_pw_secret
 
 - block:
-    - name: Get pod details
+    - name: Get web pod details
       k8s_info:
         namespace: '{{ namespace }}'
         kind: Pod
         label_selectors:
           - app.kubernetes.io/name = example-awx-web
       register: awx_pod
+      when: not awx_version
+
+    - name: Get task pod details
+      k8s_info:
+        namespace: '{{ namespace }}'
+        kind: Pod
+        label_selectors:
+          - app.kubernetes.io/name = example-awx-task
+      register: awx_task_pod
       when: not awx_version
 
     - name: Extract tags from images
@@ -108,8 +117,14 @@
              | dict2items | selectattr('key', 'in', this_awx.resources[0].spec.additional_labels)
              | list
           }}
-
-    - name: Extract additional_labels from AWX Pod
+    - name: Extract additional_labels from AWX Task spec
+      set_fact:
+        awx_task_pod_additional_labels: >-
+          {{ this_awx.resources[0].metadata.labels
+              | dict2items | selectattr('key', 'in', this_awx.resources[0].spec.additional_labels)
+              | list
+          }}
+    - name: Extract additional_labels from AWX Web Pod
       set_fact:
         pod_additional_labels: >-
           {{ awx_pod.resources[0].metadata.labels
@@ -117,10 +132,23 @@
              | list
           }}
 
-    - name: AWX Pod contains additional_labels
+    - name: Extract additional_labels from AWX Task Pod
+      set_fact:
+        task_pod_additional_labels: >-
+          {{ awx_task_pod.resources[0].metadata.labels
+              | dict2items | selectattr('key', 'in', this_awx.resources[0].spec.additional_labels)
+              | list
+          }}
+
+    - name: AWX Web Pod contains additional_labels
       ansible.builtin.assert:
         that:
           - pod_additional_labels == awx_additional_labels
+
+    - name: AWX Task Pod contains additional_labels
+      ansible.builtin.assert:
+        that:
+          - task_pod_additional_labels == awx_task_pod_additional_labels
 
     - name: Extract Pod labels which shouldn't have been propagated to it from AWX
       set_fact:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Updated these tests: molecule/default/tasks/awx_test.yml to validate both web and task containers. With the split of web and task the name block needs to acknowledge each pod respectively.
<!---
If you are fixing an existing issue, please include "fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Fixes issue #1315 
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change


