### PR TITLE
Add back project persistence so Manual projects SCM type have path

### DIFF
--- a/roles/installer/templates/deployments/web.yaml.j2
+++ b/roles/installer/templates/deployments/web.yaml.j2
@@ -62,7 +62,7 @@ spec:
       priorityClassName: '{{ control_plane_priority_class }}'
 {% endif %}
       initContainers:
-{% if bundle_ca_crt or init_container_extra_commands %}
+{% if bundle_ca_crt or projects_persistence|bool or init_container_extra_commands %}
         - name: init
           image: '{{ _init_container_image }}'
           imagePullPolicy: '{{ image_pull_policy }}'
@@ -89,6 +89,25 @@ spec:
 {% if init_container_extra_volume_mounts -%}
             {{ init_container_extra_volume_mounts | indent(width=12, first=True) }}
 {% endif %}
+{% endif %}
+{% if projects_persistence|bool and is_k8s|bool %}
+        - name: init-projects
+          image: '{{ _init_projects_container_image }}'
+          imagePullPolicy: '{{ image_pull_policy }}'
+          command:
+            - /bin/sh
+            - -c
+            - |
+              chmod 775 /var/lib/awx/projects
+              chgrp 1000 /var/lib/awx/projects
+          env:
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+          volumeMounts:
+            - name: "{{ ansible_operator_meta.name }}-projects"
+              mountPath: "/var/lib/awx/projects"
 {% endif %}
       containers:
         - image: '{{ _redis_image }}'
@@ -172,6 +191,10 @@ spec:
               mountPath: "/var/run/redis"
             - name: rsyslog-socket
               mountPath: "/var/run/awx-rsyslog"
+{% if projects_persistence|bool %}
+            - name: "{{ ansible_operator_meta.name }}-projects"
+              mountPath: "/var/lib/awx/projects"
+{% endif %}
             - name: "{{ ansible_operator_meta.name }}-receptor-ca"
               mountPath: "/etc/receptor/tls/ca/receptor-ca.crt"
               subPath: "tls.crt"
@@ -362,10 +385,19 @@ spec:
             items:
               - key: receptor_conf
                 path: receptor.conf
+{% if projects_persistence|bool %}
+        - name: "{{ ansible_operator_meta.name }}-projects"
+          persistentVolumeClaim:
+{% if projects_existing_claim %}
+            claimName: {{ projects_existing_claim }}
+{% else %}
+            claimName: '{{ ansible_operator_meta.name }}-projects-claim'
+{% endif %}
 {% if development_mode | bool %}
         - name: awx-devel
           hostPath:
             path: /awx_devel
+{% endif %}
 {% endif %}
 {% if extra_volumes -%}
         {{ extra_volumes | indent(width=8, first=True) }}


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
In the latest release, we removed project persistence which created fallout for manual project users in how they could store local projects and use them in awx. This reverts that change and restores manual project path selection.

fixes #1323 
<!---
If you are fixing an existing issue, please include "fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->
**test case**
- build and deploy operator from my branch or with changes included 
- create awx CR and deploy from devel/latest
- create a new project and select "Manual" for source control type

**result**
- the default path or other configured path will be displayed and playbook directories under the path can be selected
