### PR TITLE
Update receptor work signing key algo

### DIFF
--- a/roles/installer/tasks/resources_configuration.yml
+++ b/roles/installer/tasks/resources_configuration.yml
@@ -161,7 +161,7 @@
       register: _receptor_work_signing_private_key_file
     - name: Generate Receptor work signing private key
       command: |
-        openssl genrsa -out {{ _receptor_work_signing_private_key_file.path }} 4096
+        openssl genrsa -aes256 -out {{ _receptor_work_signing_private_key_file.path }} 4096
       no_log: "{{ no_log }}"
     - name: Create tempfile for receptor work signing public key
       tempfile:


### PR DESCRIPTION
##### SUMMARY
attempting to use remote execution node in FIPS complaint environment result in following error

```AssertionError: Job-4 has status of error, which is not in ['successful'].
execution_environment: 3
ee_image: brew.registry.redhat.io/rh-osbs/ansible-automation-platform-23-ee-supported-rhel8:latest
ee_credential: 1
ee_pull_option: 
ee_summary_fields: {'credential': {'id': 1, 'name': 'Default Execution Environment Registry Credential', 'description': '', 'kind': 'registry', 'cloud': False, 'kubernetes': False, 'credential_type_id': 17}, 'user_capabilities': {'edit': True, 'delete': True, 'copy': True}}
result_traceback:
Traceback (most recent call last):
  File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/awx/main/tasks/jobs.py", line 589, in run
    res = receptor_job.run()
  File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/awx/main/tasks/receptor.py", line 306, in run
    res = self._run_internal(receptor_ctl)
  File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/awx/main/tasks/receptor.py", line 333, in _run_internal
    result = receptor_ctl.submit_work(payload=sockout.makefile('rb'), **work_submit_kw)
  File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/receptorctl/socket_interface.py", line 242, in submit_work
    raise RuntimeError(f"Remote error: {text}")
RuntimeError: Remote error: ERROR: error sending stdin file: INTERNAL_ERROR: connInfo cancelled while forwarding message```

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Breaking Change 
 - New or Enhanced Feature
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
