### PR TITLE
Update CI test and fix awx-operator CI failure in awx repo

### DIFF
--- a/molecule/default/tasks/awx_test.yml
+++ b/molecule/default/tasks/awx_test.yml
@@ -25,7 +25,7 @@
         kind: Pod
         label_selectors:
           - app.kubernetes.io/name = example-awx-web
-      register: awx_pod
+      register: awx_web_pod
       when: not awx_version
 
     - name: Get task pod details
@@ -37,10 +37,18 @@
       register: awx_task_pod
       when: not awx_version
 
-    - name: Extract tags from images
+    - name: Extract tags from images from web pod
       set_fact:
-        image_tags: |
-          {{ awx_pod.resources[0].spec.containers |
+        web_image_tags: |
+          {{ awx_web_pod.resources[0].spec.containers |
+             map(attribute='image') |
+             map('regex_search', default_awx_version) }}
+      when: not awx_version
+
+    - name: Extract tags from images from task pod
+      set_fact:
+        task_image_tags: |
+          {{ awx_task_pod.resources[0].spec.containers |
              map(attribute='image') |
              map('regex_search', default_awx_version) }}
       when: not awx_version
@@ -51,7 +59,8 @@
           This is an environment variable that is set via build arg when releasing awx-operator.
       when:
         - not awx_version
-        - default_awx_version not in image_tags
+        - default_awx_version not in web_image_tags
+        - default_awx_version not in task_image_tags
 
     - name: Launch Demo Job Template
       awx.awx.job_launch:
@@ -102,13 +111,21 @@
         name: example-awx
       register: this_awx
 
-    - name: Get pod details
+    - name: Get web pod details
       k8s_info:
         namespace: '{{ namespace }}'
         kind: Pod
         label_selectors:
           - app.kubernetes.io/name = example-awx-web
-      register: awx_pod
+      register: awx_web_pod
+
+    - name: Get task pod details
+      k8s_info:
+        namespace: '{{ namespace }}'
+        kind: Pod
+        label_selectors:
+          - app.kubernetes.io/name = example-awx-task
+      register: awx_task_pod
 
     - name: Extract additional_labels from AWX spec
       set_fact:
@@ -117,51 +134,59 @@
              | dict2items | selectattr('key', 'in', this_awx.resources[0].spec.additional_labels)
              | list
           }}
-    - name: Extract additional_labels from AWX Task spec
+
+    - name: Extract additional_labels from AWX web Pod
       set_fact:
-        awx_task_pod_additional_labels: >-
-          {{ this_awx.resources[0].metadata.labels
-              | dict2items | selectattr('key', 'in', this_awx.resources[0].spec.additional_labels)
-              | list
-          }}
-    - name: Extract additional_labels from AWX Web Pod
-      set_fact:
-        pod_additional_labels: >-
-          {{ awx_pod.resources[0].metadata.labels
+        awx_web_pod_additional_labels: >-
+          {{ awx_web_pod.resources[0].metadata.labels
              | dict2items | selectattr('key', 'in', this_awx.resources[0].spec.additional_labels)
              | list
           }}
 
-    - name: Extract additional_labels from AWX Task Pod
+    - name: Extract additional_labels from AWX task Pod
       set_fact:
-        task_pod_additional_labels: >-
+        awx_task_pod_additional_labels: >-
           {{ awx_task_pod.resources[0].metadata.labels
               | dict2items | selectattr('key', 'in', this_awx.resources[0].spec.additional_labels)
               | list
           }}
 
-    - name: AWX Web Pod contains additional_labels
+    - name: Assert AWX web Pod contains additional_labels
       ansible.builtin.assert:
         that:
-          - pod_additional_labels == awx_additional_labels
+          - awx_web_pod_additional_labels == awx_additional_labels
 
-    - name: AWX Task Pod contains additional_labels
+    - name: Assert AWX task Pod contains additional_labels
       ansible.builtin.assert:
         that:
-          - task_pod_additional_labels == awx_task_pod_additional_labels
+          - awx_task_pod_additional_labels == awx_additional_labels
 
-    - name: Extract Pod labels which shouldn't have been propagated to it from AWX
+    - name: Extract web Pod labels which shouldn't have been propagated to it from AWX
       set_fact:
-        pod_extra_labels: >-
-          {{ awx_pod.resources[0].metadata.labels
+        awx_web_pod_extra_labels: >-
+          {{ awx_web_pod.resources[0].metadata.labels
              | dict2items | selectattr('key', 'in', ["my/do-not-inherit"])
              | list
           }}
 
-    - name: AWX Pod doesn't contain AWX labels not in additional_labels
+    - name: AWX web Pod doesn't contain AWX labels not in additional_labels
       ansible.builtin.assert:
         that:
-          - pod_extra_labels == []
+          - awx_web_pod_extra_labels == []
+
+    - name: Extract task Pod labels which shouldn't have been propagated to it from AWX
+      set_fact:
+        awx_task_pod_extra_labels: >-
+          {{ awx_task_pod.resources[0].metadata.labels
+             | dict2items | selectattr('key', 'in', ["my/do-not-inherit"])
+             | list
+          }}
+
+    - name: AWX task Pod doesn't contain AWX labels not in additional_labels
+      ansible.builtin.assert:
+        that:
+          - awx_task_pod_extra_labels == []
+
   rescue:
     - name: Re-emit failure
       vars:


### PR DESCRIPTION
##### SUMMARY
- rename awx_pod to awx_web_pod to better reflect intention
- update `awx_version` block to also validate awx_task_pod
- add get awx_task_pod in additional label check block (fix CI in awx repo which does not run the validate awx_version block)
- add assertion for awx_task_pod extra label

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
