### PR TITLE
fix task deployment tolerations

### DIFF
--- a/roles/installer/templates/deployments/task.yaml.j2
+++ b/roles/installer/templates/deployments/task.yaml.j2
@@ -391,10 +391,10 @@ spec:
 {% endif %}
 {% if task_tolerations %}
       tolerations:
-        {{ task_tolerations | to_nice_yaml | indent(width=8) }}
+        {{ task_tolerations | indent(width=8) }}
 {% elif tolerations %}
       tolerations:
-        {{ tolerations | to_nice_yaml | indent(width=8) }}
+        {{ tolerations | indent(width=8) }}
 {% endif %}
 {% if task_affinity %}
       affinity:


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
The task deployment would render broken or malformed yaml for the `task_tolerations` and `tolerations` field due to the use of `to_nice_yaml`. 

For giggles, I also tested to make sure affinity (other parameter that uses to_nice_yaml) rendered correctly and it did so it is not being removed there.

After digging deeper, passing `to_nice_yaml` to a yaml object causes this problem so that is why we are removing them. Affinity etc works as intended as they are dict objects.

fixes #1337 
<!---
If you are fixing an existing issue, please include "fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION
**test case**
- deploy operator as is today with tolerations applied to the task container 
```
 task_tolerations: |
   - key: "dedicated"
     operator: "Equal"
     value: "AWXtask"
     effect: "NoSchedule"
```
- observe failed deployment of the task pod, will yield malformed tolerations which cannot be applied.
- now do same as above but build from this branch and apply task tolerations
- result will be correctly rendered tolerations
```
 task_tolerations: 
   - key: "dedicated"
     operator: "Equal"
     value: "AWXtask"
     effect: "NoSchedule"
```