### PR TITLE
Add support to specify different annotation for the task and web deployments in AWX operator

### DIFF
--- a/config/crd/bases/awx.ansible.com_awxs.yaml
+++ b/config/crd/bases/awx.ansible.com_awxs.yaml
@@ -186,7 +186,13 @@ spec:
                 description: Additional labels to apply to the service
                 type: string
               annotations:
-                description: annotations for the pods
+                description: Common annotations for both Web and Task deployments.
+                type: string
+              task_annotations:
+                description: Task deployment annotations. This will override the general annotations parameter for the Task deployment.
+                type: string
+              web_annotations:
+                description: Web deployment annotations. This will override the general annotations parameter for the Web deployment.
                 type: string
               tolerations:
                 description: node tolerations for the pods

--- a/config/manifests/bases/awx-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/awx-operator.clusterserviceversion.yaml
@@ -690,6 +690,16 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:hidden
+      - displayName: Task Annotations
+        path: task_annotations
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - displayName: Web Annotations
+        path: web_annotations
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:hidden
       - displayName: Tolerations
         path: tolerations
         x-descriptors:

--- a/roles/installer/defaults/main.yml
+++ b/roles/installer/defaults/main.yml
@@ -188,6 +188,18 @@ web_affinity: {}
 #   my.annotation/2: value2
 annotations: ''
 
+# Override annotations to awx task pods. Specify as literal block. E.g.:
+# task_annotations: |
+#   my.task-annotation/1: value
+#   my.task-annotation/2: value2
+task_annotations: ''
+
+# Override annotations to awx web pods. Specify as literal block. E.g.:
+# web_annotations: |
+#   my.web-annotation/1: value
+#   my.web-annotation/2: value2
+web_annotations: ''
+
 admin_user: admin
 admin_email: test@example.com
 

--- a/roles/installer/templates/deployments/task.yaml.j2
+++ b/roles/installer/templates/deployments/task.yaml.j2
@@ -43,7 +43,9 @@ spec:
   ] %}
         checksum-secret-{{ secret }}: "{{ lookup('ansible.builtin.vars', secret, default='')["resources"][0]["data"] | default('') | sha1 }}"
 {% endfor %}
-{% if annotations %}
+{% if task_annotations %}
+        {{ task_annotations | indent(width=8) }}
+{% elif annotations %}
         {{ annotations | indent(width=8) }}
 {% endif %}
     spec:

--- a/roles/installer/templates/deployments/web.yaml.j2
+++ b/roles/installer/templates/deployments/web.yaml.j2
@@ -44,7 +44,9 @@ spec:
   ] %}
         checksum-secret-{{ secret }}: "{{ lookup('ansible.builtin.vars', secret, default='')["resources"][0]["data"] | default('') | md5 }}"
 {% endfor %}
-{% if annotations %}
+{% if web_annotations %}
+        {{ web_annotations | indent(width=8) }}
+{% elif annotations %}
         {{ annotations | indent(width=8) }}
 {% endif %}
     spec:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #1331
<!---
If you are fixing an existing issue, please include "fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### Test-Case Scenarios
- 4 Test cases total
    - No annotations
        - Web and task should deploy successfully with no additional annotations
    - Just `web_annotations`
        - Only web deployment has custom annotations, matches what was set
           - Added example from defaults to spec, checked web deployment to ensure they were present, then checked other deployments to be sure they were not there. 
    - Just `task_annotations`
       - Only task deployment has  custom annotations, matches what was set
    - Common `annotations` for both deployments
       - Both deployments have common annotations 
    - Override scenario, have `web_annotations`, `task _annotations`, and `annotations`
       - Ensure these remain distinct
       