### PR TITLE
Unset k8s secret ownerRefs earlier in reconciliation loop

### DIFF
--- a/ansible/instantiate-awx-deployment.yml
+++ b/ansible/instantiate-awx-deployment.yml
@@ -27,6 +27,7 @@
             development_mode: "{{ development_mode | default(omit) | bool }}"
             image_pull_policy: "{{ image_pull_policy | default(omit) }}"
             nodeport_port: "{{ nodeport_port | default(omit) }}"
+            no_log: "{{ no_log | default(omit) | bool }}"
             # ee_images:
             #   - name: test-ee
             #     image: quay.io/<user>/awx-ee

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -39,6 +39,12 @@ rules:
       - update
       - watch
   - apiGroups:
+      - ""
+    resources:
+      - secrets/last-applied-configuration
+    verbs:
+      - get
+  - apiGroups:
       - "rbac.authorization.k8s.io"
     resources:
       - roles

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -39,12 +39,6 @@ rules:
       - update
       - watch
   - apiGroups:
-      - ""
-    resources:
-      - secrets/last-applied-configuration
-    verbs:
-      - get
-  - apiGroups:
       - "rbac.authorization.k8s.io"
     resources:
       - roles

--- a/roles/installer/tasks/admin_password_configuration.yml
+++ b/roles/installer/tasks/admin_password_configuration.yml
@@ -40,7 +40,7 @@
 
 - name: Set admin password secret
   set_fact:
-    __admin_password_secret: '{{ _generated_admin_password["resources"] | default([]) | length | ternary(_generated_admin_password, _admin_password_secret) }}'
+    __admin_password_secret: "{{ admin_password_secret | length | ternary(_admin_password_secret, _generated_admin_password) }}"
   no_log: "{{ no_log }}"
 
 - name: Store admin password
@@ -58,4 +58,6 @@
         namespace: "{{ ansible_operator_meta.namespace }}"
         ownerReferences: null
   no_log: "{{ no_log }}"
-  when: not garbage_collect_secrets | bool
+  when:
+    - not garbage_collect_secrets | bool
+    - _generated_admin_password["resources"] | default([]) | length

--- a/roles/installer/tasks/admin_password_configuration.yml
+++ b/roles/installer/tasks/admin_password_configuration.yml
@@ -47,3 +47,15 @@
   set_fact:
     admin_password: "{{ __admin_password_secret['resources'][0]['data']['password'] | b64decode }}"
   no_log: "{{ no_log }}"
+
+- name: Remove ownerReferences
+  k8s:
+    definition:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: "{{ __admin_password_secret }}"
+        namespace: "{{ ansible_operator_meta.namespace }}"
+        ownerReferences: null
+  no_log: "{{ no_log }}"
+  when: not garbage_collect_secrets | bool

--- a/roles/installer/tasks/broadcast_websocket_configuration.yml
+++ b/roles/installer/tasks/broadcast_websocket_configuration.yml
@@ -42,7 +42,7 @@
 - name: Set broadcast websocket secret
   set_fact:
     # yamllint disable-line rule:line-length
-    __broadcast_websocket_secret: '{{ _generated_broadcast_websocket["resources"] | default([]) | length | ternary(_generated_broadcast_websocket, _broadcast_websocket_secret)  }}'  # noqa 204
+    __broadcast_websocket_secret: "{{ broadcast_websocket_secret | length | ternary(_broadcast_websocket_secret, _generated_broadcast_websocket) }}"
   no_log: "{{ no_log }}"
 
 - name: Store broadcast websocket secret name
@@ -60,4 +60,6 @@
         namespace: "{{ ansible_operator_meta.namespace }}"
         ownerReferences: null
   no_log: "{{ no_log }}"
-  when: not garbage_collect_secrets | bool
+  when:
+    - not garbage_collect_secrets | bool
+    - _generated_broadcast_websocket["resources"] | default([]) | length

--- a/roles/installer/tasks/broadcast_websocket_configuration.yml
+++ b/roles/installer/tasks/broadcast_websocket_configuration.yml
@@ -49,3 +49,15 @@
   set_fact:
     broadcast_websocket_secret_value: "{{ __broadcast_websocket_secret['resources'][0]['data']['secret'] | b64decode }}"
   no_log: "{{ no_log }}"
+
+- name: Remove ownerReferences
+  k8s:
+    definition:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: "{{ __broadcast_websocket_secret }}"
+        namespace: "{{ ansible_operator_meta.namespace }}"
+        ownerReferences: null
+  no_log: "{{ no_log }}"
+  when: not garbage_collect_secrets | bool

--- a/roles/installer/tasks/cleanup.yml
+++ b/roles/installer/tasks/cleanup.yml
@@ -1,30 +1,15 @@
 ---
-- block:
-    - name: Define secrets name
-      set_fact:
-        _admin_password: '{{ admin_password_secret | length | ternary(admin_password_secret, ansible_operator_meta.name + "-admin-password") }}'
-        _secret_key: '{{ secret_key_secret | length | ternary(secret_key_secret, ansible_operator_meta.name + "-secret-key") }}'
-        # yamllint disable-line rule:line-length
-        _broadcast_websocket_secret: '{{ broadcast_websocket_secret | length | ternary(broadcast_websocket_secret, ansible_operator_meta.name + "-broadcast-websocket") }}'  # noqa 204
-        # yamllint disable-line rule:line-length
-        _postgres_configuration: '{{ postgres_configuration_secret | length | ternary(postgres_configuration_secret, ansible_operator_meta.name + "-postgres-configuration") }}'  # noqa 204
-
-    - name: Remove ownerReferences reference
-      k8s:
-        definition:
-          apiVersion: v1
-          kind: Secret
-          metadata:
-            name: '{{ item }}'
-            namespace: '{{ ansible_operator_meta.namespace }}'
-            ownerReferences: null
-      loop:
-        - '{{ _admin_password }}'
-        - '{{ _secret_key }}'
-        - '{{ _postgres_configuration }}'
-        - '{{ _broadcast_websocket_secret }}'
-        - '{{ ansible_operator_meta.name }}-receptor-ca'
-        - '{{ ansible_operator_meta.name }}-receptor-work-signing'
-      no_log: "{{ no_log }}"
-
+- name: Remove ownerReferences
+  k8s:
+    definition:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: '{{ item }}'
+        namespace: '{{ ansible_operator_meta.namespace }}'
+        ownerReferences: null
+  loop:
+    - '{{ ansible_operator_meta.name }}-receptor-ca'
+    - '{{ ansible_operator_meta.name }}-receptor-work-signing'
+  no_log: "{{ no_log }}"
   when: not garbage_collect_secrets | bool

--- a/roles/installer/tasks/database_configuration.yml
+++ b/roles/installer/tasks/database_configuration.yml
@@ -85,7 +85,7 @@
 
 - name: Set PostgreSQL Configuration
   set_fact:
-    pg_config: '{{ _generated_pg_config_resources["resources"] | default([]) | length | ternary(_generated_pg_config_resources, _pg_config) }}'
+    pg_config: "{{ postgres_configuration_secret | length | ternary(_pg_config, _generated_pg_config_resources) }}"
   no_log: "{{ no_log }}"
 
 - name: Set actual postgres configuration secret used
@@ -102,8 +102,9 @@
         namespace: "{{ ansible_operator_meta.namespace }}"
         ownerReferences: null
   no_log: "{{ no_log }}"
-  when: not garbage_collect_secrets | bool
-
+  when:
+    - not garbage_collect_secrets | bool
+    - _generated_pg_config_resources["resources"] | default([]) | length
 - name: Store Database Configuration
   set_fact:
     awx_postgres_user: "{{ pg_config['resources'][0]['data']['username'] | b64decode }}"

--- a/roles/installer/tasks/database_configuration.yml
+++ b/roles/installer/tasks/database_configuration.yml
@@ -92,6 +92,18 @@
   set_fact:
     __postgres_configuration_secret: "{{ pg_config['resources'][0]['metadata']['name'] }}"
 
+- name: Remove ownerReferences
+  k8s:
+    definition:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: "{{ __postgres_configuration_secret }}"
+        namespace: "{{ ansible_operator_meta.namespace }}"
+        ownerReferences: null
+  no_log: "{{ no_log }}"
+  when: not garbage_collect_secrets | bool
+
 - name: Store Database Configuration
   set_fact:
     awx_postgres_user: "{{ pg_config['resources'][0]['data']['username'] | b64decode }}"

--- a/roles/installer/tasks/secret_key_configuration.yml
+++ b/roles/installer/tasks/secret_key_configuration.yml
@@ -47,3 +47,15 @@
   set_fact:
     secret_key_secret_name: "{{ secret_key['resources'][0]['metadata']['name'] }}"
   no_log: "{{ no_log }}"
+
+- name: Remove ownerReferences
+  k8s:
+    definition:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: "{{ secret_key_secret_name }}"
+        namespace: "{{ ansible_operator_meta.namespace }}"
+        ownerReferences: null
+  no_log: "{{ no_log }}"
+  when: not garbage_collect_secrets | bool

--- a/roles/installer/tasks/secret_key_configuration.yml
+++ b/roles/installer/tasks/secret_key_configuration.yml
@@ -40,7 +40,7 @@
 
 - name: Set secret key secret
   set_fact:
-    secret_key: '{{ _generated_secret_key["resources"] | default([]) | length | ternary(_generated_secret_key, _secret_key_secret)  }}'
+    secret_key: "{{ secret_key_secret | length | ternary(_secret_key_secret, _generated_secret_key) }}"
   no_log: "{{ no_log }}"
 
 - name: Store secret key secret name
@@ -58,4 +58,6 @@
         namespace: "{{ ansible_operator_meta.namespace }}"
         ownerReferences: null
   no_log: "{{ no_log }}"
-  when: not garbage_collect_secrets | bool
+  when:
+    - not garbage_collect_secrets | bool
+    - _generated_secret_key["resources"] | default([]) | length


### PR DESCRIPTION
  - Remove ownerRefs earlier in the reconciliation loop so that they always get removed, even if an error short-circuits the reconciliation loop before the cleanup playbook is run.

##### SUMMARY

Currently, if the AWX CR is deleted before the reconciliation loop completes, or if it errors before the cleanup task, it is possible to get in a state where the generated k8s secrets are deleted.  

This may sound innocuous at a glance, but when you consider that the postgres PVC _is_ left behind and has already created the `awx` postgres user with the original pg_password valued, you can see how a re-deploy witht he same deployment_name would result in an AWX instance that cannot connect to the database.  

This should make it much harder to get in to that state.  

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
-->

**Work-around**

Note: If you are already in this state, it is possible to get the pg_password value from the generated postgres_configuration_secret, exec into the postgresql pod, and change the `awx` user's password.  

