### PR TITLE
Set securityContext.capabilities for kube-rbac-proxy container

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -12,10 +12,9 @@ spec:
       - name: kube-rbac-proxy
         securityContext:
           allowPrivilegeEscalation: false
-        # TODO(user): uncomment for common cases that do not require escalating privileges
-        # capabilities:
-        #   drop:
-        #     - "ALL"
+          capabilities:
+            drop:
+              - "ALL"
         image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -51,7 +51,6 @@ spec:
               fieldPath: metadata.namespace
         securityContext:
           allowPrivilegeEscalation: false
-        # TODO(user): uncomment for common cases that do not require escalating privileges
           capabilities:
             drop:
             - "ALL"


### PR DESCRIPTION
##### SUMMARY

Depending on what version cluster you run on, some of you may have noticed the following warning when running `make deploy` or deploying the operator with kustomize:

```
Warning: would violate PodSecurity "restricted:v1.24": unrestricted capabilities (container "kube-rbac-proxy" must set securityContext.capabilities.drop=["ALL"]), seccompProfile (pod or containers "kube-rbac-proxy", "awx-manager" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
deployment.apps/awx-operator-controller-manager created
```

This is because we didn't have capabilities set on the kube-rbac-proxy container.  This PR fixes that. 


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bug, Docs Fix or other nominal change
