### PR TITLE
Fixes #1370 - slash at variable end

### DIFF
--- a/roles/installer/templates/networking/ingress.yaml.j2
+++ b/roles/installer/templates/networking/ingress.yaml.j2
@@ -34,7 +34,7 @@ spec:
                 port:
                   number: 80
 {% if ingress_controller|lower == "contour" %}
-          - path: '{{ ingress_path }}/websocket'
+          - path: '{{ ingress_path.rstrip("/") }}/websocket'
             pathType: '{{ ingress_path_type }}'
             backend:
               service:


### PR DESCRIPTION
##### SUMMARY
This PR adds a trim for the `ingress_path` variable to make sure there are never double slashes at the end of this variable.
And then fixes #1370.

About the test, I would love to run it but I'm not sure how, as the molecule configuration doesn't look to work.
(maybe my next thing to do if not already someone else is working on it :) )

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION
This issue was introduced with the feature in the #1320 PR.

I'm sorry that I didn't notice this in the last PR.