### PR TITLE
Fix typo in rsyslog var

### DIFF
--- a/roles/installer/defaults/main.yml
+++ b/roles/installer/defaults/main.yml
@@ -283,7 +283,7 @@ task_command: []
 web_args:
   - /usr/bin/launch_awx_web.sh
 web_command: []
-ryslog_args:
+rsyslog_args:
   - /usr/bin/launch_awx_rsyslog.sh
 rsyslog_command: []
 

--- a/roles/installer/templates/deployments/task.yaml.j2
+++ b/roles/installer/templates/deployments/task.yaml.j2
@@ -337,8 +337,8 @@ spec:
 {% if rsyslog_command %}
           command: {{ rsyslog_command }}
 {% endif %}
-{% if ryslog_args %}
-          args: {{ ryslog_args }}
+{% if rsyslog_args %}
+          args: {{ rsyslog_args }}
 {% endif %}
           imagePullPolicy: '{{ image_pull_policy }}'
           volumeMounts:

--- a/roles/installer/templates/deployments/web.yaml.j2
+++ b/roles/installer/templates/deployments/web.yaml.j2
@@ -244,8 +244,8 @@ spec:
 {% if rsyslog_command %}
           command: {{ rsyslog_command }}
 {% endif %}
-{% if ryslog_args %}
-          args: {{ ryslog_args }}
+{% if rsyslog_args %}
+          args: {{ rsyslog_args }}
 {% endif %}
           imagePullPolicy: '{{ image_pull_policy }}'
           volumeMounts:


### PR DESCRIPTION
Rename all references: `ryslog_args` -> `rsyslog_args`

##### SUMMARY
This commit fixes a typo occurring in all references of `ryslog_args`, which is meant to provide arguments to the rsyslog command in the web and task pods.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION
N/A
