### PR TITLE
Manage client SSL secrets for external DB connectivity (fixes #1088)

### DIFF
--- a/config/crd/bases/awx.ansible.com_awxs.yaml
+++ b/config/crd/bases/awx.ansible.com_awxs.yaml
@@ -1741,6 +1741,9 @@ spec:
               bundle_cacert_secret:
                 description: Secret where can be found the trusted Certificate Authority Bundle
                 type: string
+              postgres_client_ssl_secret:
+                description: Secret where can be found the postgres ssl related credentials
+                type: string
               projects_persistence:
                 description: Whether or not the /var/lib/projects directory will be persistent
                 default: false

--- a/config/manifests/bases/awx-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/awx-operator.clusterserviceversion.yaml
@@ -221,6 +221,11 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:io.kubernetes:Secret
+      - displayName: Database Client Certificate Secret
+        path: postgres_client_ssl_secret
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:io.kubernetes:Secret
       - displayName: Old Database Configuration Secret
         path: old_postgres_configuration_secret
         x-descriptors:

--- a/docs/user-guide/database-configuration.md
+++ b/docs/user-guide/database-configuration.md
@@ -46,6 +46,16 @@ spec:
   postgres_configuration_secret: <name-of-your-secret>
 ```
 
+In order to specify client SSL credentials to authenticate to the external database, put the certificate and private key in a secret. You can specify it on your spec :
+```yaml
+---
+spec:
+  ...
+  postgres_configuration_secret: <name-of-your-secret>
+  postgres_client_ssl_secret: <name-of-your-client-secret>
+```
+> Don't forget to add the CA certificate in the [`bundle_cacert_secret`](advanced-configuration/trusting-a-custom-certificate-authority.md).
+
 #### Migrating data from an old AWX instance
 
 For instructions on how to migrate from an older version of AWX, see [migration.md](../migration/migration.md).

--- a/roles/backup/tasks/secrets.yml
+++ b/roles/backup/tasks/secrets.yml
@@ -15,6 +15,7 @@
     - ingress_tls_secret
     - ldap_cacert_secret
     - bundle_cacert_secret
+    - postgres_client_ssl_secret
     - ee_pull_credentials_secret
 
 - name: Dump receptor secret names and data into file

--- a/roles/installer/defaults/main.yml
+++ b/roles/installer/defaults/main.yml
@@ -416,6 +416,14 @@ ldap_password_secret: ''
 # Secret to lookup that provides the custom CA trusted bundle
 bundle_cacert_secret: ''
 
+# Secret to lookup that provides the private key and certificate to connect
+# to an external database
+postgres_client_ssl_secret: ''
+
+postgres_client_certificate: /etc/postgresql/tls/client/client.crt
+
+postgres_client_key: /etc/postgresql/tls/client/client.key
+
 # Whether secrets should be garbage collected
 # on teardown
 #

--- a/roles/installer/templates/deployments/task.yaml.j2
+++ b/roles/installer/templates/deployments/task.yaml.j2
@@ -89,6 +89,11 @@ spec:
               mkdir -p /etc/pki/ca-trust/extracted/{java,pem,openssl,edk2}
               update-ca-trust
 {% endif %}
+{% if postgres_client_ssl_secret %}
+              cp /etc/postgresql/tls/secret/tls.crt /etc/postgresql/tls/client/client.crt
+              cp /etc/postgresql/tls/secret/tls.key /etc/postgresql/tls/client/client.key
+              chmod 0600 /etc/postgresql/tls/client/client.key
+{% endif %}
 {% if init_container_extra_commands %}
               {{ init_container_extra_commands | indent(width=14) }}
 {% endif %}
@@ -138,6 +143,13 @@ spec:
           volumeMounts:
             - name: "{{ ansible_operator_meta.name }}-projects"
               mountPath: "/var/lib/awx/projects"
+{% endif %}
+{% if postgres_client_ssl_secret %}
+            - name: "postgres-client-cert"
+              mountPath: "/etc/postgresql/tls/secret"
+              readOnly: true
+            - name: "{{ ansible_operator_meta.name }}-postgresql-client-tls"
+              mountPath: "/etc/postgresql/tls/client/"
 {% endif %}
       containers:
         - image: '{{ _redis_image }}'
@@ -197,6 +209,10 @@ spec:
               mountPath: /etc/pki/ca-trust/source/anchors/bundle-ca.crt
               subPath: bundle-ca.crt
               readOnly: true
+{% endif %}
+{% if postgres_client_ssl_secret %}
+            - name: "{{ ansible_operator_meta.name }}-postgresql-client-tls"
+              mountPath: "/etc/postgresql/tls/client/"
 {% endif %}
             - name: "{{ ansible_operator_meta.name }}-application-credentials"
               mountPath: "/etc/tower/conf.d/execution_environments.py"
@@ -379,6 +395,10 @@ spec:
               subPath: bundle-ca.crt
               readOnly: true
 {% endif %}
+{% if postgres_client_ssl_secret %}
+            - name: "{{ ansible_operator_meta.name }}-postgresql-client-tls"
+              mountPath: "/etc/postgresql/tls/client/"
+{% endif %}
 {% if development_mode | bool %}
             - name: awx-devel
               mountPath: "/awx_devel"
@@ -459,6 +479,11 @@ spec:
               - key: bundle-ca.crt
                 path: 'bundle-ca.crt'
 {% endif %}
+{% if postgres_client_ssl_secret %}
+        - name: "postgres-client-cert"
+          secret:
+            secretName: "{{ postgres_client_ssl_secret }}"
+{% endif %}
 {% if ingress_type | lower == 'route' and route_tls_termination_mechanism | lower == 'passthrough' %}
         - name: "{{ ansible_operator_meta.name }}-nginx-certs"
           secret:
@@ -537,6 +562,10 @@ spec:
           emptyDir: {}
         - name: {{ ansible_operator_meta.name }}-receptor-config
           emptyDir: {}
+{% if postgres_client_ssl_secret %}
+        - name: "{{ ansible_operator_meta.name }}-postgresql-client-tls"
+          emptyDir: {}
+{% endif %}
         - name: {{ ansible_operator_meta.name }}-default-receptor-config
           configMap:
             name: '{{ ansible_operator_meta.name }}-{{ deployment_type }}-configmap'

--- a/roles/installer/templates/deployments/web.yaml.j2
+++ b/roles/installer/templates/deployments/web.yaml.j2
@@ -93,6 +93,11 @@ spec:
               mkdir -p /etc/pki/ca-trust/extracted/{java,pem,openssl,edk2}
               update-ca-trust
 {% endif %}
+{% if postgres_client_ssl_secret %}
+              cp /etc/postgresql/tls/secret/tls.crt /etc/postgresql/tls/client/client.crt
+              cp /etc/postgresql/tls/secret/tls.key /etc/postgresql/tls/client/client.key
+              chmod 0600 /etc/postgresql/tls/client/client.key
+{% endif %}
 {% if init_container_extra_commands %}
               {{ init_container_extra_commands | indent(width=14) }}
 {% endif %}
@@ -128,6 +133,13 @@ spec:
           volumeMounts:
             - name: "{{ ansible_operator_meta.name }}-projects"
               mountPath: "/var/lib/awx/projects"
+{% endif %}
+{% if postgres_client_ssl_secret %}
+            - name: "postgres-client-cert"
+              mountPath: "/etc/postgresql/tls/secret"
+              readOnly: true
+            - name: "{{ ansible_operator_meta.name }}-postgresql-client-tls"
+              mountPath: "/etc/postgresql/tls/client/"
 {% endif %}
       containers:
         - image: '{{ _redis_image }}'
@@ -171,6 +183,10 @@ spec:
               mountPath: /etc/pki/ca-trust/source/anchors/bundle-ca.crt
               subPath: bundle-ca.crt
               readOnly: true
+{% endif %}
+{% if postgres_client_ssl_secret %}
+            - name: "{{ ansible_operator_meta.name }}-postgresql-client-tls"
+              mountPath: "/etc/postgresql/tls/client/"
 {% endif %}
             - name: {{ ansible_operator_meta.name }}-uwsgi-config
               mountPath: "/etc/tower/uwsgi.ini"
@@ -295,6 +311,10 @@ spec:
               subPath: bundle-ca.crt
               readOnly: true
 {% endif %}
+{% if postgres_client_ssl_secret %}
+            - name: "{{ ansible_operator_meta.name }}-postgresql-client-tls"
+              mountPath: "/etc/postgresql/tls/client/"
+{% endif %}
 {% if development_mode | bool %}
             - name: awx-devel
               mountPath: "/awx_devel"
@@ -357,6 +377,11 @@ spec:
             items:
               - key: bundle-ca.crt
                 path: 'bundle-ca.crt'
+{% endif %}
+{% if postgres_client_ssl_secret %}
+        - name: "postgres-client-cert"
+          secret:
+            secretName: "{{ postgres_client_ssl_secret }}"
 {% endif %}
 {% if ingress_type | lower == 'route' and route_tls_termination_mechanism | lower == 'passthrough' %}
         - name: "{{ ansible_operator_meta.name }}-nginx-certs"
@@ -430,6 +455,10 @@ spec:
             items:
               - key: receptor_conf
                 path: receptor.conf
+{% if postgres_client_ssl_secret %}
+        - name: "{{ ansible_operator_meta.name }}-postgresql-client-tls"
+          emptyDir: {}
+{% endif %}
 {% if projects_persistence|bool %}
         - name: "{{ ansible_operator_meta.name }}-projects"
           persistentVolumeClaim:

--- a/roles/installer/templates/settings/credentials.py.j2
+++ b/roles/installer/templates/settings/credentials.py.j2
@@ -11,6 +11,10 @@ DATABASES = {
 {% if awx_postgres_sslmode in ['verify-ca', 'verify-full'] %}
                      'sslrootcert': '{{ ca_trust_bundle }}',
 {% endif %}
+{% if postgres_client_ssl_secret -%}
+                     'sslcert': '{{ postgres_client_certificate }}',
+                     'sslkey': '{{ postgres_client_key }}',
+{% endif %}
 {% if postgres_keepalives %}
                      'keepalives': 1,
                      'keepalives_idle': {{ postgres_keepalives_idle }},


### PR DESCRIPTION
##### SUMMARY

This commit adds a way to provide an SSL  client certificate + private key to authenticate against an external postgresql database.

fixes #1088

##### ISSUE TYPE
 - New or Enhanced Feature


##### ADDITIONAL INFORMATION
The user will have to add the certificate + key in a tls secret and provide it in the awx configuration.

The certificate + key are mounted and copied in order to fix file authorization issues that I have encountered when mounting directly in the pod.

