### PR TITLE
web: Use sha1 filter instead of md5

### DIFF
--- a/roles/installer/templates/deployments/web.yaml.j2
+++ b/roles/installer/templates/deployments/web.yaml.j2
@@ -32,7 +32,7 @@ spec:
     "secrets/app_credentials",
     "storage/persistent",
   ] %}
-        checksum-{{ template | replace('/', '-') }}: "{{ lookup('template', template + '.yaml.j2') | md5 }}"
+        checksum-{{ template | replace('/', '-') }}: "{{ lookup('template', template + '.yaml.j2') | sha1 }}"
 {% endfor %}
 {% for secret in [
     "bundle_cacert",
@@ -42,7 +42,7 @@ spec:
     "receptor_ca",
     "receptor_work_signing",
   ] %}
-        checksum-secret-{{ secret }}: "{{ lookup('ansible.builtin.vars', secret, default='')["resources"][0]["data"] | default('') | md5 }}"
+        checksum-secret-{{ secret }}: "{{ lookup('ansible.builtin.vars', secret, default='')["resources"][0]["data"] | default('') | sha1 }}"
 {% endfor %}
 {% if web_annotations %}
         {{ web_annotations | indent(width=8) }}


### PR DESCRIPTION
##### SUMMARY
This was fixed in 6cae8df but the task/web split rebase didn't apply this to the web deployment.
This prevents to deploy the operator when FIPS is enabled.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION
```console
TASK [Apply deployment resources] ********************************
fatal: [localhost]: FAILED! =>

{"msg": "An unhandled exception occurred while running the lookup plugin 'template'. Error was a <class 'ValueError'>, original message: [digital envelope routines: EVP_DigestInit_ex] disabled for FIPS"}
```
