### PR TITLE
[CI] Fix failing AWX checks by pinning molecule dependency ansible-compat

### DIFF
--- a/molecule/requirements.txt
+++ b/molecule/requirements.txt
@@ -5,3 +5,4 @@ ansible-lint
 openshift!=0.13.0
 jmespath
 ansible-core
+ansible-compat<4  # https://github.com/ansible-community/molecule/issues/3903


### PR DESCRIPTION

##### SUMMARY

https://github.com/ansible-community/molecule/issues/3903

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bug, Docs Fix or other nominal change
