### PR TITLE
Fix variable name for loadbalancerip in template.

### DIFF
--- a/roles/installer/templates/networking/service.yaml.j2
+++ b/roles/installer/templates/networking/service.yaml.j2
@@ -52,7 +52,7 @@ spec:
   type: NodePort
 {% elif service_type | lower == "loadbalancer" %}
   type: LoadBalancer
-{% if variable is defined and variable|length %}
+{% if loadbalancer_ip is defined and loadbalancer_ip|length %}
   loadbalancerip: '{{ loadbalancer_ip }}'
 {% endif %}
 {% else %}


### PR DESCRIPTION
##### SUMMARY
This fixes a bug in the template file of the service which checked a wrong variable thus never applying the loadbalancerip setting.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION
none