### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -228,7 +228,7 @@ ifeq (,$(shell which kubectl-slice 2>/dev/null))
 	@{ \
 	set -e ;\
 	mkdir -p $(dir $(KUBECTL_SLICE)) ;\
-	curl -sSLo - https://github.com/patrickdappollonio/kubectl-slice/releases/download/v1.1.0/kubectl-slice_1.1.0_$(OS)_$(ARCHX).tar.gz | \
+	curl -sSLo - https://github.com/patrickdappollonio/kubectl-slice/releases/download/v1.2.6/kubectl-slice_$(OS)_$(ARCHX).tar.gz | \
 	tar xzf - -C bin/ kubectl-slice ;\
 	}
 else


### PR DESCRIPTION
##### SUMMARY

Hey all! I'm the maintainer of `kubectl-slice` and I have received requests from some AWX users that the version of `kubectl-slice` shipped here is too old, so I'm sending this PR with a more up-to-date version with support for far more features.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION
Bumps `kubectl-slice` from 1.1.0 to 1.2.6.

```
$ make kubectl-slice
$ bin/kubectl-slice --version
kubectl-slice version 1.2.6
```