### PR TITLE
Allow configuration of resource requirements for init containers

### DIFF
--- a/roles/installer/templates/deployments/task.yaml.j2
+++ b/roles/installer/templates/deployments/task.yaml.j2
@@ -112,6 +112,7 @@ spec:
         - name: init-projects
           image: '{{ _init_projects_container_image }}'
           imagePullPolicy: '{{ image_pull_policy }}'
+          resources: {{ task_resource_requirements }}
           command:
             - /bin/sh
             - -c

--- a/roles/installer/templates/deployments/web.yaml.j2
+++ b/roles/installer/templates/deployments/web.yaml.j2
@@ -68,6 +68,7 @@ spec:
         - name: init
           image: '{{ _init_container_image }}'
           imagePullPolicy: '{{ image_pull_policy }}'
+          resources: {{ web_resource_requirements }}
           command:
             - /bin/sh
             - -c
@@ -96,6 +97,7 @@ spec:
         - name: init-projects
           image: '{{ _init_projects_container_image }}'
           imagePullPolicy: '{{ image_pull_policy }}'
+          resources: {{ web_resource_requirements }}
           command:
             - /bin/sh
             - -c


### PR DESCRIPTION

##### SUMMARY

In some use cases, limits must be set for every container in a cluster. To address this, we will use the task and web resource requirements for the initContainers where applicable.  


Limits being set on all pods in a cluster are required which certain ResourceQuota's are in place on a given cluster.
> If the quota has a value specified for requests.cpu or requests.memory, then it requires that every incoming container make an explicit request for those resources. If the quota has a value specified for limits.cpu or limits.memory, then it requires that every incoming container specify an explicit limit for those resources.

[Ref: [RH Quotas and Limit Ranges docs](https://docs.openshift.com/online/pro/dev_guide/compute_resources.html)]

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bug, Docs Fix or other nominal change
