### PR TITLE
Add ability to configure Postgres keepalive settings

### DIFF
--- a/config/crd/bases/awx.ansible.com_awxs.yaml
+++ b/config/crd/bases/awx.ansible.com_awxs.yaml
@@ -1596,6 +1596,25 @@ spec:
                 type: array
                 items:
                   type: string
+              postgres_keepalives:
+                description: Controls whether client-side TCP keepalives are used for Postgres connections.
+                default: true
+                type: boolean
+              postgres_keepalives_count:
+                description: Controls the number of TCP keepalives that can be lost before the client's connection to the server is considered dead.
+                type: integer
+                default: 5
+                format: int32
+              postgres_keepalives_idle:
+                description: Controls the number of seconds of inactivity after which TCP should send a keepalive message to the server.
+                type: integer
+                default: 5
+                format: int32
+              postgres_keepalives_interval:
+                description: Controls the number of seconds after which a TCP keepalive message that is not acknowledged by the server should be retransmitted.
+                type: integer
+                default: 5
+                format: int32
               ca_trust_bundle:
                 description: Path where the trusted CA bundle is available
                 type: string

--- a/config/manifests/bases/awx-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/awx-operator.clusterserviceversion.yaml
@@ -483,6 +483,26 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:hidden
+      - displayName: Enable Postgres Keepalives
+        path: postgres_keepalives
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - displayName: Postgres Keepalives Count
+        path: postgres_keepalives_count
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - displayName: Postgres Keepalives Idle
+        path: postgres_keepalives_idle
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - displayName: Postgres Keepalives Interval
+        path: postgres_keepalives_interval
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:hidden
       - displayName: Certificate Authorirty Trust Bundle
         path: ca_trust_bundle
         x-descriptors:

--- a/roles/installer/defaults/main.yml
+++ b/roles/installer/defaults/main.yml
@@ -384,6 +384,12 @@ projects_existing_claim: ''
 # Define postgres configuration arguments to use
 postgres_extra_args: ''
 
+# Configure postgres connection keepalive
+postgres_keepalives: true
+postgres_keepalives_idle: 5
+postgres_keepalives_interval: 5
+postgres_keepalives_count: 5
+
 # Define the storage_class, size and access_mode
 # when not using an existing claim
 projects_storage_size: 8Gi

--- a/roles/installer/templates/settings/credentials.py.j2
+++ b/roles/installer/templates/settings/credentials.py.j2
@@ -11,6 +11,14 @@ DATABASES = {
 {% if awx_postgres_sslmode in ['verify-ca', 'verify-full'] %}
                      'sslrootcert': '{{ ca_trust_bundle }}',
 {% endif %}
+{% if postgres_keepalives %}
+                     'keepalives': 1,
+                     'keepalives_idle': {{ postgres_keepalives_idle }},
+                     'keepalives_interval': {{ postgres_keepalives_interval }},
+                     'keepalives_count': {{ postgres_keepalives_count }},
+{% else %}
+                     'keepalives': 0,
+{% endif %}
         },
     }
 }


### PR DESCRIPTION
##### SUMMARY
During our test for DB failover we notice that dispatcher will hang and keep polling a idle (and dead) database connection after database failover happens, this PR will use TCP keepalive to kill the dead TCP connection and allow dispatcher to reconnect and able to handle DB failover 

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
