### PR TITLE
Add postgres_storage_class to UI form & fix PG Storage requirements

### DIFF
--- a/config/manifests/bases/awx-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/awx-operator.clusterserviceversion.yaml
@@ -88,10 +88,10 @@ spec:
       kind: AWXRestore
       name: awxrestores.awx.ansible.com
       specDescriptors:
-      - displayName: Backup Source to restore from
-        description: Select what type of backup to specify. Backup CR, allows you to specify
-          the name of an AWXBackup object (recommended approach).  The PVC option allows you to
-          specify a custom PVC and directory to backup from.
+      - description: Select what type of backup to specify. Backup CR, allows you
+          to specify the name of an AWXBackup object (recommended approach).  The
+          PVC option allows you to specify a custom PVC and directory to backup from.
+        displayName: Backup Source to restore from
         path: backup_source
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:select:Backup CR
@@ -115,8 +115,9 @@ spec:
         path: backup_pvc_namespace
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:hidden
-      - displayName: Backup Directory
-        description: This is the directory inside the PVC that your backup is stored in.
+      - description: This is the directory inside the PVC that your backup is stored
+          in.
+        displayName: Backup Directory
         path: backup_dir
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
@@ -151,7 +152,8 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
       version: v1beta1
-    - description: Deploy a new instance of AWX. A standardized way to define, operate and scale automation with Ansible.
+    - description: Deploy a new instance of AWX. A standardized way to define, operate
+        and scale automation with Ansible.
       displayName: AWX
       kind: AWX
       name: awxs.awx.ansible.com
@@ -186,8 +188,9 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:io.kubernetes:Secret
-      - displayName: Secret Key
-        description: Name of the k8s secret the symmetric encryption key is stored in.
+      - description: Name of the k8s secret the symmetric encryption key is stored
+          in.
+        displayName: Secret Key
         path: secret_key_secret
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
@@ -226,7 +229,7 @@ spec:
         path: ingress_api_version
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
-        - urn:alm:descriptor:com.tectonic.ui:text 
+        - urn:alm:descriptor:com.tectonic.ui:text
       - displayName: Ingress Path
         path: ingress_path
         x-descriptors:
@@ -335,9 +338,9 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
-      - displayName: PostgreSQL Init Container Resource Requirements
-        description: The PostgreSQL init container is not used when an external DB
+      - description: The PostgreSQL init container is not used when an external DB
           is configured
+        displayName: PostgreSQL Init Container Resource Requirements
         path: postgres_init_container_resource_requirements
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
@@ -347,20 +350,17 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
-      - displayName: PostgreSQL Container Resource Requirements
-        description: The PostgreSQL container is not used when an external DB
-          is configured
+      - description: The PostgreSQL container is not used when an external DB is configured
+        displayName: PostgreSQL Container Resource Requirements
         path: postgres_resource_requirements
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
-      - displayName: PostgreSQL Container Storage Requirements
-        description: The PostgreSQL container is not used when an external DB
-          is configured
+      - description: The PostgreSQL container is not used when an external DB is configured
+        displayName: PostgreSQL Container Storage Requirements
         path: postgres_storage_requirements
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
-        - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
       - displayName: Replicas
         path: replicas
         x-descriptors:
@@ -472,7 +472,6 @@ spec:
         path: postgres_storage_class
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
-        - urn:alm:descriptor:com.tectonic.ui:hidden
       - displayName: Postgres Datapath
         path: postgres_data_path
         x-descriptors:
@@ -790,8 +789,8 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
-      - displayName: Additional labels defined on the resource, which should be
-          propagated to child resources
+      - displayName: Additional labels defined on the resource, which should be propagated
+          to child resources
         path: additional_labels
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
@@ -876,7 +875,7 @@ spec:
   - email: awx-project@googlegroups.com
     name: AWX Team
   maturity: alpha
-  MinKubeVersion: 1.22.15
+  minKubeVersion: 1.22.15
   provider:
     name: Ansible
     url: github.com/ansible/awx-operator


### PR DESCRIPTION


##### SUMMARY

This solves 3 issues:
* `postgres_storage_class` was hidden from the UI Form, but customers need it for certain deployment scenarios, so we should make this visible.
* `postgres_storage_requirements` was displayed in the UI form in a misleading way, which resulted in invalid an invalid value.  This is fixed by not using the `resourceRequirements` x-descriptor.
* clean up formatting that was being automatically done anyways when `make bundle` was run.  Now we won't see the noisy `git diff` locally after running `make bundle`

**Before these changes**

![image](https://user-images.githubusercontent.com/11698892/236329439-a4ba5844-61d3-4a59-8883-7199a99c55b2.png)

Which results in:

```
 postgres_storage_requirements:
    limits:
      cpu: 500m
      ephemeral-storage: 50Gi
    requests:
      ephemeral-storage: 10Gi

  postgres_resource_requirements:
    limits:
      cpu: 500m
      memory: 100Mi
    requests:
      memory: 50Mi
      cpu: 100m
```

The  postgres_resource_requirements is fine, even if the user specifies postgres_resource_requirements.storage, it will be ignored (not ideal, but no deployment issues)

But the `postgres_storage_requirements` yaml is incorrect and will result in a deployment issue because the variable is defined, but is invalid syntax.  









**After these changes**

![image](https://user-images.githubusercontent.com/11698892/236329030-b99aca5e-09ea-4b57-b473-8a3841a18dbf.png)

![image](https://user-images.githubusercontent.com/11698892/236330738-63207c50-cd70-4bea-ad43-af9d3644781e.png)


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION

Here is an example of valid yaml for reference:

```
spec:
  postgres_storage_requirements:
    requests:
      storage: 10Gi
    limits:
      storage: 50Gi
  postgres_resource_requirements:
    requests:
      cpu: 10m
      memory: 64Mi
    limits:
      cpu: 250m
      memory: 1Gi
  postgres_init_container_resource_requirements:
    requests:
      cpu: 10m
      memory: 64Mi
    limits:
      cpu: 250m
      memory: 1Gi
```
