### PR TITLE
Change storage class display type to dropdown

### DIFF
--- a/config/manifests/bases/awx-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/awx-operator.clusterserviceversion.yaml
@@ -471,6 +471,7 @@ spec:
       - displayName: Postgres Storage Class
         path: postgres_storage_class
         x-descriptors:
+        - urn:alm:descriptor:io.kubernetes:StorageClass
         - urn:alm:descriptor:com.tectonic.ui:advanced
       - displayName: Postgres Datapath
         path: postgres_data_path


### PR DESCRIPTION
##### SUMMARY
One more improvement to the storage class display in the Openshift UI.  Instead of a text field, this will make it a dropdown where you can click on any k8s secret in the selected namespace.  

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION
Current this looks like this:

![image](https://user-images.githubusercontent.com/11698892/236518156-b638b0cc-d2ef-4c6d-b1ec-52040f56f3bb.png)


This will look like this:

![image](https://user-images.githubusercontent.com/11698892/236519816-d3d6e45f-1f5d-4788-8044-d86e41481f07.png)
