### PR TITLE
Unpin ubuntu version for feature branch CI build (#1400)

### DIFF
--- a/.github/workflows/feature.yml
+++ b/.github/workflows/feature.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     name: Push devel image
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
##### SUMMARY
Fix hanging github action for publishing feature branch images 

```
Requested labels: ubuntu-18.04
Job defined at: ansible/awx-operator/.github/workflows/feature.yml@refs/heads/feature_keepalive
Waiting for a runner to pick up this job...
Requested labels: ubuntu-18.04
Job defined at: ansible/awx-operator/.github/workflows/feature.yml@refs/heads/feature_keepalive
Waiting for a runner to pick up this job...
```

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
