### PR TITLE
Add Docs for customizing the favicon for AWX

### DIFF
--- a/README.md
+++ b/README.md
@@ -1064,6 +1064,33 @@ Using the [extra_volumes feature](#custom-volume-and-volume-mount-options), it i
 
 The AWX nginx config automatically includes /etc/nginx/conf.d/*.conf if present.
 
+##### Custom Favicon
+
+You can use custom volume mounts to mount in your own favicon to be displayed in your AWX browser tab.
+
+First, Create the configmap from a local favicon.ico file.
+
+```bash
+$ oc create configmap favicon-configmap --from-file favicon.ico
+```
+
+Then specify the extra_volume and web_extra_volume_mounts on your AWX CR spec
+
+```yaml
+spec:
+  extra_volumes: |
+    - name: favicon
+      configMap:
+        defaultMode: 420
+        items:
+          - key: favicon.ico
+            path: favicon.ico
+        name: favicon-configmap
+  web_extra_volume_mounts: |
+    - name: favicon
+      mountPath: /var/lib/awx/public/static/media/favicon.ico
+      subPath: favicon.ico
+```
 
 #### Default execution environments from private registries
 


### PR DESCRIPTION
##### SUMMARY

Ever wonder if you could customize your AWX favicon in addition to your logo?  You can! This adds some docs on how to do it.

![image](https://github.com/ansible/awx-operator/assets/11698892/c921cc46-e952-4627-9c7b-276c31682d86)

Not exactly a new feature, but this just exposes more possibilities available via custom volume mounts.  

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - New or Enhanced Feature
