### PR TITLE
Bump ansible-operator to v1.28.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/operator-framework/ansible-operator:v1.26.0
+FROM quay.io/operator-framework/ansible-operator:v1.28.1
 
 USER 0
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

This is just a version bump to fix [CVE-2022-41723](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-41723) in `/usr/local/bin/ansible-operator`

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
-->
I don't see this CVE reported in the quay.io repository, but it showed up in our Microsoft Defender for Cloud scan in Azure.

<!--- Paste verbatim command output below, e.g. before and after your change -->

