### PR TITLE
Updated task.yaml.j2 logic to terminate rsyslog container when terminationGracePeriod happens

### DIFF
--- a/roles/installer/templates/deployments/task.yaml.j2
+++ b/roles/installer/templates/deployments/task.yaml.j2
@@ -382,6 +382,18 @@ spec:
             - name: awx-devel
               mountPath: "/awx_devel"
 {% endif %}
+{% if termination_grace_period_seconds is defined %}
+            - name: pre-stop-data
+              mountPath: /var/lib/pre-stop
+            - name: pre-stop-scripts
+              mountPath: /var/lib/pre-stop/scripts
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                - bash
+                - /var/lib/pre-stop/scripts/termination-master
+{% endif %}
           env:
             - name: SUPERVISOR_CONFIG_PATH
               value: "/etc/supervisord_rsyslog.conf"


### PR DESCRIPTION
Missing pre-stop hook on rsyslog in the task pod

##### SUMMARY
Updated task.yaml.j2 logic to terminate rsyslog container when terminationGracePeriod happens

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION
Updated task.yaml.j2 logic to terminate rsyslog container when terminationGracePeriod happens.
This addresses the following issue #1383 
