### PR TITLE
Updated task.yaml.j2 rsyslog container to  have preStop hook

### DIFF
--- a/roles/installer/templates/deployments/task.yaml.j2
+++ b/roles/installer/templates/deployments/task.yaml.j2
@@ -392,7 +392,7 @@ spec:
               exec:
                 command:
                 - bash
-                - /var/lib/pre-stop/scripts/termination-master
+                - /var/lib/pre-stop/scripts/termination-waiter
 {% endif %}
           env:
             - name: SUPERVISOR_CONFIG_PATH

--- a/roles/installer/templates/deployments/task.yaml.j2
+++ b/roles/installer/templates/deployments/task.yaml.j2
@@ -382,6 +382,18 @@ spec:
             - name: awx-devel
               mountPath: "/awx_devel"
 {% endif %}
+{% if termination_grace_period_seconds is defined %}
+            - name: pre-stop-data
+              mountPath: /var/lib/pre-stop
+            - name: pre-stop-scripts
+              mountPath: /var/lib/pre-stop/scripts
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                - bash
+                - /var/lib/pre-stop/scripts/termination-master
+{% endif %}
           env:
             - name: SUPERVISOR_CONFIG_PATH
               value: "/etc/supervisord_rsyslog.conf"


### PR DESCRIPTION
##### SUMMARY
Updated task.yaml.j2 rsyslog container to  have preStop hook

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION
This addresses missing pre-stop hook on rsyslog in the task pod and rsyslog container will terminate when terminationGracePeriod happens.
This will address hopefully following issue #1383 


