### PR TITLE
Enable configuration of rsyslog env vars, volume mounts and entrypoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -998,6 +998,7 @@ In a scenario where custom volumes and volume mounts are required to either over
 | extra_volumes                      | Specify extra volumes to add to the application pod      | ''      |
 | web_extra_volume_mounts            | Specify volume mounts to be added to Web container       | ''      |
 | task_extra_volume_mounts           | Specify volume mounts to be added to Task container      | ''      |
+| rsyslog_extra_volume_mounts        | Specify volume mounts to be added to Rsyslog container   | ''      |
 | ee_extra_volume_mounts             | Specify volume mounts to be added to Execution container | ''      |
 | init_container_extra_volume_mounts | Specify volume mounts to be added to Init container      | ''      |
 | init_container_extra_commands      | Specify additional commands for Init container           | ''      |
@@ -1159,11 +1160,12 @@ type: kubernetes.io/dockerconfigjson
 
 If you need to export custom environment variables to your containers.
 
-| Name           | Description                                         | Default |
-| -------------- | --------------------------------------------------- | ------- |
-| task_extra_env | Environment variables to be added to Task container | ''      |
-| web_extra_env  | Environment variables to be added to Web container  | ''      |
-| ee_extra_env   | Environment variables to be added to EE container   | ''      |
+| Name              | Description                                            | Default |
+| ----------------- | ------------------------------------------------------ | ------- |
+| task_extra_env    | Environment variables to be added to Task container    | ''      |
+| web_extra_env     | Environment variables to be added to Web container     | ''      |
+| rsyslog_extra_env | Environment variables to be added to Rsyslog container | ''      |
+| ee_extra_env      | Environment variables to be added to EE container      | ''      |
 
 > :warning: The `ee_extra_env` will only take effect to the globally available Execution Environments. For custom `ee`, please [customize the Pod spec](https://docs.ansible.com/ansible-tower/latest/html/administration/external_execution_envs.html#customize-the-pod-spec).
 
@@ -1175,6 +1177,9 @@ Example configuration of environment variables
       - name: MYCUSTOMVAR
         value: foo
     web_extra_env: |
+      - name: MYCUSTOMVAR
+        value: foo
+    rsyslog_extra_env: |
       - name: MYCUSTOMVAR
         value: foo
     ee_extra_env: |

--- a/config/crd/bases/awx.ansible.com_awxs.yaml
+++ b/config/crd/bases/awx.ansible.com_awxs.yaml
@@ -1529,9 +1529,19 @@ spec:
                 type: array
                 items:
                   type: string
+              rsyslog_args:
+                type: array
+                items:
+                  type: string
+              rsyslog_command:
+                type: array
+                items:
+                  type: string
               task_extra_env:
                 type: string
               web_extra_env:
+                type: string
+              rsyslog_extra_env:
                 type: string
               ee_extra_env:
                 type: string
@@ -1543,6 +1553,9 @@ spec:
                 type: string
               web_extra_volume_mounts:
                 description: Specify volume mounts to be added to the Web container
+                type: string
+              rsyslog_extra_volume_mounts:
+                description: Specify volume mounts to be added to the Rsyslog container
                 type: string
               redis_image:
                 description: Registry path to the redis container to use

--- a/config/manifests/bases/awx-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/awx-operator.clusterserviceversion.yaml
@@ -643,6 +643,28 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:hidden
+      - displayName: Rsyslog Args
+        path: rsyslog_args
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - displayName: Rsyslog Command
+        path: rsyslog_command
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Environment variables to be added to Rsyslog container
+        displayName: Rsyslog Extra Env
+        path: rsyslog_extra_env
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Specify volume mounts to be added to Rsyslog container
+        displayName: Rsyslog Extra Volume Mounts
+        path: rsyslog_extra_volume_mounts
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:hidden
       - description: Specify extra volumes to add to the application pod
         displayName: Extra Volumes
         path: extra_volumes

--- a/roles/installer/defaults/main.yml
+++ b/roles/installer/defaults/main.yml
@@ -330,6 +330,7 @@ rsyslog_resource_requirements:
 #     value: bing
 task_extra_env: ''
 web_extra_env: ''
+rsyslog_extra_env: ''
 ee_extra_env: ''
 
 # Mount extra volumes on the AWX task/web containers. Specify as literal block.
@@ -339,6 +340,7 @@ ee_extra_env: ''
 #     mountPath: /some/path
 task_extra_volume_mounts: ''
 web_extra_volume_mounts: ''
+rsyslog_extra_volume_mounts: ''
 ee_extra_volume_mounts: ''
 
 # Add a nodeSelector for the Postgres pods.

--- a/roles/installer/templates/deployments/task.yaml.j2
+++ b/roles/installer/templates/deployments/task.yaml.j2
@@ -382,12 +382,18 @@ spec:
             - name: awx-devel
               mountPath: "/awx_devel"
 {% endif %}
+{% if rsyslog_extra_volume_mounts -%}
+            {{ rsyslog_extra_volume_mounts | indent(width=12, first=True) }}
+{% endif %}
           env:
             - name: SUPERVISOR_CONFIG_PATH
               value: "/etc/supervisord_rsyslog.conf"
 {% if development_mode | bool %}
             - name: AWX_KUBE_DEVEL
               value: "1"
+{% endif %}
+{% if rsyslog_extra_env -%}
+            {{ rsyslog_extra_env | indent(width=12, first=True) }}
 {% endif %}
 {% if task_node_selector %}
       nodeSelector:


### PR DESCRIPTION
##### SUMMARY

During the task-web split, we split out rsyslog into it's own container.  All of the same configuration that was possible for rsyslog when it was part of the main deployment template should be possible now as well.  

This PR makes it possible to configure the following settings for the rsyslog container:
* rsyslog_args
* rsyslog_command
* rsyslog_extra_env
* rsyslog_extra_volume_mounts

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New or Enhanced Feature

##### ADDITIONAL INFORMATION
This provides a fix for https://github.com/ansible/awx-operator/issues/1409
