### PR TITLE
modify container security context

### DIFF
--- a/README.md
+++ b/README.md
@@ -672,7 +672,7 @@ spec:
 ```
 
 #### Redis container capabilities
-> :warning: The `redis_capabilities` option is depracated. Please use `security_context_settings` to set any securityContext related settings such as container capabilites.
+> :warning: The `redis_capabilities` option is deprecated. Please use `security_context_settings` to set any securityContext related settings such as container capabilites.
 
 Depending on your kubernetes cluster and settings you might need to grant some capabilities to the redis container so it can start. Set the `redis_capabilities` option so the capabilities are added in the deployment.
 

--- a/README.md
+++ b/README.md
@@ -672,6 +672,7 @@ spec:
 ```
 
 #### Redis container capabilities
+> :warning: The `redis_capabilities` option is depracated. Please use `security_context_settings` to set any securityContext related settings such as container capabilites.
 
 Depending on your kubernetes cluster and settings you might need to grant some capabilities to the redis container so it can start. Set the `redis_capabilities` option so the capabilities are added in the deployment.
 

--- a/README.md
+++ b/README.md
@@ -655,7 +655,7 @@ spec:
 **Note**: The `image` and `image_version` are intended for local mirroring scenarios. Please note that using a version of AWX other than the one bundled with the `awx-operator` is **not** supported. For the default values, check the [main.yml](https://github.com/ansible/awx-operator/blob/devel/roles/installer/defaults/main.yml) file.
 
 #### Container security context
-To change/add the security context for a specified container, add your items as key-value pairs under the nbame of the container in question. Possible container names are `redis`, `init`, `ee`, `task`, `web`, `rsyslog`. 
+To change/add the security context for a specified container, add your items as key-value pairs under the name of the container in question. Possible container names are `redis`, `init`, `ee`, `task`, `web`, `rsyslog`. 
 
 ```yaml
 ---

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ An [Ansible AWX](https://github.com/ansible/awx) operator for Kubernetes built w
          * [Managed PostgreSQL Service](#managed-postgresql-service)
       * [Advanced Configuration](#advanced-configuration)
          * [Deploying a specific version of AWX](#deploying-a-specific-version-of-awx)
+         * [Container security context](#container-security-context)
          * [Redis container capabilities](#redis-container-capabilities)
          * [Privileged Tasks](#privileged-tasks)
          * [Containers Resource Requirements](#containers-resource-requirements)
@@ -652,6 +653,20 @@ spec:
 ```
 
 **Note**: The `image` and `image_version` are intended for local mirroring scenarios. Please note that using a version of AWX other than the one bundled with the `awx-operator` is **not** supported. For the default values, check the [main.yml](https://github.com/ansible/awx-operator/blob/devel/roles/installer/defaults/main.yml) file.
+
+#### Container security context
+To change/add the security context for a specified container, add your items as key-value pairs under the nbame of the container in question. Possible container names are `redis`, `init`, `ee`, `task`, `web`, `rsyslog`. 
+
+```yaml
+---
+spec:
+  security_context_settings:
+    task:
+      runAsUser: 1000
+      runAsGroup: 1000
+    rsyslog:
+      runAsUser: 1000
+```
 
 #### Redis container capabilities
 

--- a/README.md
+++ b/README.md
@@ -661,11 +661,14 @@ To change/add the security context for a specified container, add your items as 
 ---
 spec:
   security_context_settings:
-    task:
+    redis:
+      capabilities:
+        add:
+          - CHOWN
+          - SETUID
+          - SETGID
       runAsUser: 1000
       runAsGroup: 1000
-    rsyslog:
-      runAsUser: 1000
 ```
 
 #### Redis container capabilities

--- a/config/manifests/bases/awx-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/awx-operator.clusterserviceversion.yaml
@@ -833,6 +833,10 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:hidden
+      - displayName: Custom Security Context
+        path: security_context_settings
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
       - displayName: API Extra Settings
         path: extra_settings
         x-descriptors:

--- a/roles/installer/templates/deployments/task.yaml.j2
+++ b/roles/installer/templates/deployments/task.yaml.j2
@@ -77,6 +77,12 @@ spec:
           image: '{{ _init_container_image }}'
           imagePullPolicy: '{{ image_pull_policy }}'
           resources: {{ init_container_resource_requirements }}
+{% if security_context_settings.init is defined %}
+          securityContext:
+{% for key, value in security_context_settings.init.items() %}
+            {{ key }}: {{ value }}
+{% endfor %}
+{% endif %}
           command:
             - /bin/sh
             - -c
@@ -123,6 +129,12 @@ spec:
           image: '{{ _init_projects_container_image }}'
           imagePullPolicy: '{{ image_pull_policy }}'
           resources: {{ init_container_resource_requirements }}
+{% if security_context_settings.init is defined %}
+          securityContext:
+{% for key, value in security_context_settings.init.items() %}
+            {{ key }}: {{ value }}
+{% endfor %}
+{% endif %}
           command:
             - /bin/sh
             - -c
@@ -142,8 +154,15 @@ spec:
         - image: '{{ _redis_image }}'
           imagePullPolicy: '{{ image_pull_policy }}'
           name: redis
-{% if redis_capabilities is defined and redis_capabilities %}
+{% if security_context_settings.redis is defined or redis_capabilities is defined %}
           securityContext:
+{% endif %}
+{% if security_context_settings.redis is defined %}
+{% for key, value in security_context_settings.redis.items() %}
+            {{ key }}: {{ value }}
+{% endfor %}
+{% endif %}
+{% if redis_capabilities is defined and redis_capabilities %}
             capabilities:
               add: {{ redis_capabilities }}
 {% endif %}
@@ -178,8 +197,15 @@ spec:
         - image: '{{ _image }}'
           name: '{{ ansible_operator_meta.name }}-task'
           imagePullPolicy: '{{ image_pull_policy }}'
-{% if task_privileged == true %}
+{% if security_context_settings.task is defined or task_privileged == true %}
           securityContext:
+{% endif %}
+{% if security_context_settings.task is defined %}
+{% for key, value in security_context_settings.web.items() %}
+            {{ key }}: {{ value }}
+{% endfor %}
+{% endif %}
+{% if task_privileged == true %}
             privileged: true
 {% endif %}
 {% if task_command %}
@@ -280,6 +306,12 @@ spec:
         - image: '{{ _control_plane_ee_image }}'
           name: '{{ ansible_operator_meta.name }}-ee'
           imagePullPolicy: '{{ image_pull_policy }}'
+{% if security_context_settings.ee is defined %}
+          securityContext:
+{% for key, value in security_context_settings.ee.items() %}
+            {{ key }}: {{ value }}
+{% endfor %}
+{% endif %}
           resources: {{ ee_resource_requirements }}
           args:
             - /bin/sh
@@ -353,6 +385,12 @@ spec:
 {% endif %}
           imagePullPolicy: '{{ image_pull_policy }}'
           resources: {{ rsyslog_resource_requirements }}
+{% if security_context_settings.rsyslog is defined %}
+          securityContext:
+{% for key, value in security_context_settings.rsyslog.items() %}
+            {{ key }}: {{ value }}
+{% endfor %}
+{% endif %}
           volumeMounts:
             - name: "{{ ansible_operator_meta.name }}-application-credentials"
               mountPath: "/etc/tower/conf.d/credentials.py"

--- a/roles/installer/templates/deployments/web.yaml.j2
+++ b/roles/installer/templates/deployments/web.yaml.j2
@@ -316,7 +316,7 @@ spec:
             - name: {{ ansible_operator_meta.name }}-redis-socket
               mountPath: "/var/run/redis"
             - name: rsyslog-socket
-              mountPath: "/var/run/awx-rsyslog"   
+              mountPath: "/var/run/awx-rsyslog"
 {% if bundle_ca_crt  %}
             - name: "ca-trust-extracted"
               mountPath: "/etc/pki/ca-trust/extracted"

--- a/roles/installer/templates/deployments/web.yaml.j2
+++ b/roles/installer/templates/deployments/web.yaml.j2
@@ -316,8 +316,7 @@ spec:
             - name: {{ ansible_operator_meta.name }}-redis-socket
               mountPath: "/var/run/redis"
             - name: rsyslog-socket
-              mountPath: "/var/run/awx-rsyslog"
-          resources: {{ rsyslog_resource_requirements }}   
+              mountPath: "/var/run/awx-rsyslog"   
 {% if bundle_ca_crt  %}
             - name: "ca-trust-extracted"
               mountPath: "/etc/pki/ca-trust/extracted"

--- a/roles/installer/templates/deployments/web.yaml.j2
+++ b/roles/installer/templates/deployments/web.yaml.j2
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: '{{ ansible_operator_meta.name }}-web'
     {{ lookup("template", "../common/templates/labels/common.yaml.j2")  | indent(width=4) | trim }}
-    {{ lookup("template", "../common/templates/labels//version.yaml.j2") | indent(width=4) | trim }}
+    {{ lookup("template", "../common/templates/labels/version.yaml.j2") | indent(width=4) | trim }}
 spec:
 {% if web_replicas != '' %}
   replicas: {{ web_replicas }}
@@ -24,7 +24,7 @@ spec:
       labels:
         app.kubernetes.io/name: '{{ ansible_operator_meta.name }}-web'
         {{ lookup("template", "../common/templates/labels/common.yaml.j2")  | indent(width=8) | trim }}
-        {{ lookup("template", "../common/templates/labels//version.yaml.j2") | indent(width=8) | trim }}
+        {{ lookup("template", "../common/templates/labels/version.yaml.j2") | indent(width=8) | trim }}
       annotations:
 {% for template in [
     "configmaps/config",

--- a/roles/installer/templates/deployments/web.yaml.j2
+++ b/roles/installer/templates/deployments/web.yaml.j2
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: '{{ ansible_operator_meta.name }}-web'
     {{ lookup("template", "../common/templates/labels/common.yaml.j2")  | indent(width=4) | trim }}
-    {{ lookup("template", "../common/templates/labels/version.yaml.j2") | indent(width=4) | trim }}
+    {{ lookup("template", "../common/templates/labels//version.yaml.j2") | indent(width=4) | trim }}
 spec:
 {% if web_replicas != '' %}
   replicas: {{ web_replicas }}
@@ -24,7 +24,7 @@ spec:
       labels:
         app.kubernetes.io/name: '{{ ansible_operator_meta.name }}-web'
         {{ lookup("template", "../common/templates/labels/common.yaml.j2")  | indent(width=8) | trim }}
-        {{ lookup("template", "../common/templates/labels/version.yaml.j2") | indent(width=8) | trim }}
+        {{ lookup("template", "../common/templates/labels//version.yaml.j2") | indent(width=8) | trim }}
       annotations:
 {% for template in [
     "configmaps/config",
@@ -84,6 +84,12 @@ spec:
           image: '{{ _init_container_image }}'
           imagePullPolicy: '{{ image_pull_policy }}'
           resources: {{ init_container_resource_requirements }}
+{% if security_context_settings.init is defined %}
+          securityContext:
+{% for key, value in security_context_settings.init.items() %}
+            {{ key }}: {{ value }}
+{% endfor %}
+{% endif %}
           command:
             - /bin/sh
             - -c
@@ -113,6 +119,12 @@ spec:
           image: '{{ _init_projects_container_image }}'
           imagePullPolicy: '{{ image_pull_policy }}'
           resources: {{ init_container_resource_requirements }}
+{% if security_context_settings.init is defined %}
+          securityContext:
+{% for key, value in security_context_settings.init.items() %}
+            {{ key }}: {{ value }}
+{% endfor %}
+{% endif %}
           command:
             - /bin/sh
             - -c
@@ -132,8 +144,15 @@ spec:
         - image: '{{ _redis_image }}'
           imagePullPolicy: '{{ image_pull_policy }}'
           name: redis
-{% if redis_capabilities is defined and redis_capabilities %}
+{% if security_context_settings.redis is defined or redis_capabilities is defined %}
           securityContext:
+{% endif %}
+{% if security_context_settings.redis is defined %}
+{% for key, value in security_context_settings.redis.items() %}
+            {{ key }}: {{ value }}
+{% endfor %}
+{% endif %}
+{% if redis_capabilities is defined and redis_capabilities %}
             capabilities:
               add: {{ redis_capabilities }}
 {% endif %}
@@ -151,6 +170,12 @@ spec:
         - image: '{{ _image }}'
           name: '{{ ansible_operator_meta.name }}-web'
           imagePullPolicy: '{{ image_pull_policy }}'
+{% if security_context_settings.web is defined %}
+          securityContext:
+{% for key, value in security_context_settings.web.items() %}
+            {{ key }}: {{ value }}
+{% endfor %}
+{% endif %}
 {% if web_command %}
           command: {{ web_command }}
 {% endif %}
@@ -269,6 +294,12 @@ spec:
           args: {{ rsyslog_args }}
 {% endif %}
           imagePullPolicy: '{{ image_pull_policy }}'
+{% if security_context_settings.rsyslog is defined %}
+          securityContext:
+{% for key, value in security_context_settings.rsyslog.items() %}
+            {{ key }}: {{ value }}
+{% endfor %}
+{% endif %}
           volumeMounts:
             - name: "{{ ansible_operator_meta.name }}-application-credentials"
               mountPath: "/etc/tower/conf.d/credentials.py"
@@ -286,6 +317,7 @@ spec:
               mountPath: "/var/run/redis"
             - name: rsyslog-socket
               mountPath: "/var/run/awx-rsyslog"
+          resources: {{ rsyslog_resource_requirements }}   
 {% if bundle_ca_crt  %}
             - name: "ca-trust-extracted"
               mountPath: "/etc/pki/ca-trust/extracted"


### PR DESCRIPTION
##### SUMMARY
Changes for adding/modifying securityContext of a container. It re-uses already present variable `security_context_settings`. All security context items can be added as key-value pair under a name of each container. 


##### ISSUE TYPE
 - New or Enhanced Feature
 #1413

##### ADDITIONAL INFORMATION

