### PR TITLE
Fix rsyslog container resources in task deployment template

### DIFF
--- a/roles/installer/templates/deployments/task.yaml.j2
+++ b/roles/installer/templates/deployments/task.yaml.j2
@@ -343,7 +343,6 @@ spec:
 {% if ee_extra_env -%}
             {{ ee_extra_env | indent(width=12, first=True) }}
 {% endif %}
-          resources: {{ rsyslog_resource_requirements }}
         - image: '{{ _image }}'
           name: '{{ ansible_operator_meta.name }}-rsyslog'
 {% if rsyslog_command %}
@@ -353,6 +352,7 @@ spec:
           args: {{ rsyslog_args }}
 {% endif %}
           imagePullPolicy: '{{ image_pull_policy }}'
+          resources: {{ rsyslog_resource_requirements }}
           volumeMounts:
             - name: "{{ ansible_operator_meta.name }}-application-credentials"
               mountPath: "/etc/tower/conf.d/credentials.py"


### PR DESCRIPTION
##### SUMMARY

In https://github.com/ansible/awx-operator/pull/1410, a field named rsyslog_resource_requirements was added to the AWX CRD.  This field allows users to set requests and limits on the rsyslog container in both the web and task deployments.

In the task deployment template, the rsyslog resources were applied in the wrong location.  They were placed within the configuration block for the execution environment container, overriding the ee container resources, and failing to set the rsyslog resources as was intended.

This mistake called out in this comment: https://github.com/ansible/awx-operator/pull/1410#issuecomment-1554299712

This PR moves the rsyslog resources config to a better location in the task deployment template.

##### ISSUE TYPE

 - Bug, Docs Fix or other nominal change
