### PR TITLE
[ci] pin ansible-compat for molecule

### DIFF
--- a/molecule/requirements.txt
+++ b/molecule/requirements.txt
@@ -5,3 +5,4 @@ ansible-lint
 openshift!=0.13.0
 jmespath
 ansible-core
+ansible-compat<4  # https://github.com/ansible-community/molecule/issues/3903


### PR DESCRIPTION
##### SUMMARY

This is a backport of #1387 to pin ansible-compat in the checkpoint_v1 branch.

Tower CI uses this branch and some tests are currently failing as a result.

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
