### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1220,6 +1220,8 @@ With`extra_settings`, you can pass multiple custom settings via the `awx-operato
 | -------------- | -------------- | ------- |
 | extra_settings | Extra settings | ''      |
 
+**Note:** Parameters configured in `extra_settings` cannot change after deployed awx.
+
 Example configuration of `extra_settings` parameter
 
 ```yaml

--- a/README.md
+++ b/README.md
@@ -1220,7 +1220,7 @@ With`extra_settings`, you can pass multiple custom settings via the `awx-operato
 | -------------- | -------------- | ------- |
 | extra_settings | Extra settings | ''      |
 
-**Note:** Parameters configured in `extra_settings` cannot change after deployed awx.
+**Note:** Parameters configured in `extra_settings` are set as read-only settings in AWX.  As a result, they cannot be changed in the UI after deployment. If you need to change the setting after the initial deployment, you need to change it on the AWX CR spec.  
 
 Example configuration of `extra_settings` parameter
 


### PR DESCRIPTION
##### SUMMARY
Added a note of extra_settings parameters to warn users that those parameters cannot change after deploying awx. 
This is critical information because if users need to change those parameters after deploying awx, there is only one way that 
they need to rebuild instances.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change
