### PR TITLE
Do not cause web deployment restart on pre-stop scripts changes

### DIFF
--- a/roles/installer/templates/deployments/web.yaml.j2
+++ b/roles/installer/templates/deployments/web.yaml.j2
@@ -28,7 +28,6 @@ spec:
       annotations:
 {% for template in [
     "configmaps/config",
-    "configmaps/pre_stop_scripts",
     "secrets/app_credentials",
     "storage/persistent",
   ] %}


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This is a small change to remove unrelated checksum annotation from `web` deployment, as this deployment is not utilizing the corresponding referenced ConfigMap and thus should not be [rolled out (restarted)](https://github.com/ansible/awx-operator/commit/94d68bf382ec8dc4ce28d7d8d154663afd00b7fe) whenever that changes.


<!---
If you are fixing an existing issue, please include "fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
-->
The similar  annotation changes will have to be provided in future, should it be ever decided that e.g. receptor certs/configs or projects PVC are no longer needed (both for `web` and `task` deployments). Likewise, when new mounts are added the annotations should be extended.
