### PR TITLE
Fix failure in CI while creating kind cluster

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     name: molecule
     env:
-      DOCKER_API_VERSION: "1.38"
+      DOCKER_API_VERSION: "1.41"
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
##### SUMMARY
```
      "stderr": "Creating cluster \"osdk-test\" ...\n • Ensuring node image (kindest/node:v1.27.3) 🖼  ...\n ✓ Ensuring node image (kindest/node:v1.27.3) 🖼\n • Preparing nodes 📦   ...\n ✗ Preparing nodes 📦 \nERROR: failed to create cluster: command \"docker run --name osdk-test-control-plane --hostname osdk-test-control-plane --label io.x-k8s.kind.role=control-plane --privileged --security-opt seccomp=unconfined --security-opt apparmor=unconfined --tmpfs /tmp --tmpfs /run --volume /var --volume /lib/modules:/lib/modules:ro -e KIND_EXPERIMENTAL_CONTAINERD_SNAPSHOTTER --detach --tty --label io.x-k8s.kind.cluster=osdk-test --net kind --restart=on-failure:1 --init=false --cgroupns=private --publish=0.0.0.0:80:80/TCP --publish=0.0.0.0:443:443/TCP --publish=127.0.0.1:41265:6443/TCP -e KUBECONFIG=/etc/kubernetes/admin.conf kindest/node:v1.27.3@sha256:3966ac761ae0136263ffdb6cfd4db23ef8a83cba8a463690e98317add2c9ba72\" failed with error: exit status 1\n\nCommand Output: \"--cgroupns\" requires API version 1.41, but the Docker daemon API version is 1.38",
      "stderr_lines": [
          "Creating cluster \"osdk-test\" ...",
          " • Ensuring node image (kindest/node:v1.27.3) 🖼  ...",
          " ✓ Ensuring node image (kindest/node:v1.27.3) 🖼",
          " • Preparing nodes 📦   ...",
          " ✗ Preparing nodes 📦 ",
          "ERROR: failed to create cluster: command \"docker run --name osdk-test-control-plane --hostname osdk-test-control-plane --label io.x-k8s.kind.role=control-plane --privileged --security-opt seccomp=unconfined --security-opt apparmor=unconfined --tmpfs /tmp --tmpfs /run --volume /var --volume /lib/modules:/lib/modules:ro -e KIND_EXPERIMENTAL_CONTAINERD_SNAPSHOTTER --detach --tty --label io.x-k8s.kind.cluster=osdk-test --net kind --restart=on-failure:1 --init=false --cgroupns=private --publish=0.0.0.0:80:80/TCP --publish=0.0.0.0:443:443/TCP --publish=127.0.0.1:41265:6443/TCP -e KUBECONFIG=/etc/kubernetes/admin.conf kindest/node:v1.27.3@sha256:3966ac761ae0136263ffdb6cfd4db23ef8a83cba8a463690e98317add2c9ba72\" failed with error: exit status 1",
```

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
