### PR TITLE
Allow {web_,task_,}replicas to be 0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,6 +10,11 @@ jobs:
   molecule:
     runs-on: ubuntu-latest
     name: molecule
+    strategy:
+      matrix:
+        ansible_args:
+          - --skip-tags=replicas
+          - -t replicas
     env:
       DOCKER_API_VERSION: "1.41"
     steps:
@@ -35,7 +40,7 @@ jobs:
         run: |
           sudo rm -f $(which kustomize)
           make kustomize
-          KUSTOMIZE_PATH=$(readlink -f bin/kustomize) molecule test -s kind
+          KUSTOMIZE_PATH=$(readlink -f bin/kustomize) molecule test -s kind -- ${{ matrix.ansible_args }}
   helm:
     runs-on: ubuntu-latest
     name: helm

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,10 +4,7 @@ name: CI
 
 on:
   pull_request:
-    branches: [devel]
-
   push:
-    branches: [devel]
 
 jobs:
   molecule:

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -12,7 +12,11 @@
         api_version: v1
         kind: Namespace
         name: '{{ namespace }}'
+      tags:
+        - always
 
     - import_tasks: kustomize.yml
       vars:
         state: present
+      tags:
+        - always

--- a/molecule/default/destroy.yml
+++ b/molecule/default/destroy.yml
@@ -10,6 +10,8 @@
     - import_tasks: kustomize.yml
       vars:
         state: absent
+      tags:
+        - always
 
     - name: Destroy Namespace
       k8s:
@@ -17,8 +19,12 @@
         kind: Namespace
         name: '{{ namespace }}'
         state: absent
+      tags:
+        - always
 
     - name: Unset pull policy
       command: '{{ kustomize }} edit remove patch --path pull_policy/{{ operator_pull_policy }}.yaml'
       args:
         chdir: '{{ config_dir }}/testing'
+      tags:
+        - always

--- a/molecule/default/kustomize.yml
+++ b/molecule/default/kustomize.yml
@@ -6,6 +6,8 @@
     chdir: '{{ config_dir }}/testing'
   register: resources
   changed_when: false
+  tags:
+    - always
 
 - name: Set resources to {{ state }}
   k8s:
@@ -13,3 +15,5 @@
     state: '{{ state }}'
     wait: yes
   loop: '{{ resources.stdout | from_yaml_all | list }}'
+  tags:
+    - always

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -11,18 +11,26 @@
           You must specify the OPERATOR_IMAGE environment variable in order to run the
           'default' scenario
       when: not operator_image
+      tags:
+        - always
 
     - name: Set testing image
       command: '{{ kustomize }} edit set image testing={{ operator_image }}'
       args:
         chdir: '{{ config_dir }}/testing'
+      tags:
+        - always
 
     - name: Set pull policy
       command: '{{ kustomize }} edit add patch --path pull_policy/{{ operator_pull_policy }}.yaml'
       args:
         chdir: '{{ config_dir }}/testing'
+      tags:
+        - always
 
     - name: Set testing namespace
       command: '{{ kustomize }} edit set namespace {{ namespace }}'
       args:
         chdir: '{{ config_dir }}/testing'
+      tags:
+        - always

--- a/molecule/default/tasks/_test_case_replicas.yml
+++ b/molecule/default/tasks/_test_case_replicas.yml
@@ -1,0 +1,35 @@
+---
+- name: Get web pod details
+  k8s_info:
+    namespace: '{{ namespace }}'
+    kind: Pod
+    label_selectors:
+      - app.kubernetes.io/name = example-awx-web
+  register: awx_web_pod
+  # This can take a while to actually make it to the cluster
+  retries: 30
+  delay: 5
+  until: awx_web_pod.resources | length == expected_web_replicas
+  ignore_errors: true
+
+- name: Get task pod details
+  k8s_info:
+    namespace: '{{ namespace }}'
+    kind: Pod
+    label_selectors:
+      - app.kubernetes.io/name = example-awx-task
+  register: awx_task_pod
+  # This can take a while to actually make it to the cluster
+  retries: 30
+  delay: 5
+  until: awx_task_pod.resources | length == expected_task_replicas
+  ignore_errors: true
+
+- name: Ensure that the correct number of web and task pods exist
+  assert:
+    that:
+      - awx_web_pod.resources | length == expected_web_replicas
+      - awx_task_pod.resources | length == expected_task_replicas
+    fail_msg: >-
+      Web pods: Expected {{ expected_web_replicas }}, got {{ awx_web_pod.resources | length }}.
+      Task pods: Expected {{ expected_task_replicas }}, got {{ awx_task_pod.resources | length }}.

--- a/molecule/default/tasks/apply_awx_spec.yml
+++ b/molecule/default/tasks/apply_awx_spec.yml
@@ -1,0 +1,12 @@
+---
+- name: Create or update the awx.ansible.com/v1alpha1.AWX
+  k8s:
+    state: present
+    namespace: '{{ namespace }}'
+    definition: "{{ lookup('template', 'awx_cr_molecule.yml.j2') | from_yaml }}"
+    wait: yes
+    wait_timeout: 900
+    wait_condition:
+      type: Running
+      reason: Successful
+      status: "True"

--- a/molecule/default/tasks/apply_awx_spec.yml
+++ b/molecule/default/tasks/apply_awx_spec.yml
@@ -4,6 +4,7 @@
     state: present
     namespace: '{{ namespace }}'
     definition: "{{ lookup('template', 'awx_cr_molecule.yml.j2') | from_yaml }}"
+    apply: true
     wait: yes
     wait_timeout: 900
     wait_condition:

--- a/molecule/default/tasks/awx_replicas_test.yml
+++ b/molecule/default/tasks/awx_replicas_test.yml
@@ -1,85 +1,61 @@
+---
+- debug:
+    msg: test - web_replicas and task_replicas should override replicas
+
+- include_tasks: apply_awx_spec.yml
+  vars:
+    additional_fields:
+      replicas: 2
+      web_replicas: 0
+      task_replicas: 0
+
+- include_tasks: _test_case_replicas.yml
+  vars:
+    expected_web_replicas: 0
+    expected_task_replicas: 0
+
+####
+
+- debug:
+    msg: test - replicas should act as a default
+
+- include_tasks: apply_awx_spec.yml
+  vars:
+    additional_fields:
+      replicas: 2
+      web_replicas: 1
+
+- include_tasks: _test_case_replicas.yml
+  vars:
+    expected_web_replicas: 1
+    expected_task_replicas: 2
+
+####
+
+- debug:
+    msg: test - replicas=0 should kill all pods
+
 - include_tasks: apply_awx_spec.yml
   vars:
     additional_fields:
       replicas: 0
-      web_replicas: 0
-      task_replicas: 0
 
-- name: Get web pod details
-  k8s_info:
-    namespace: '{{ namespace }}'
-    kind: Pod
-    label_selectors:
-      - app.kubernetes.io/name = example-awx-web
-  register: awx_web_pod
+- include_tasks: _test_case_replicas.yml
+  vars:
+    expected_web_replicas: 0
+    expected_task_replicas: 0
 
-- name: Get task pod details
-  k8s_info:
-    namespace: '{{ namespace }}'
-    kind: Pod
-    label_selectors:
-      - app.kubernetes.io/name = example-awx-task
-  register: awx_task_pod
+####
 
-- name: Ensure that the pods do not exist (0 replicas)
-  assert:
-    that:
-      - awx_web_pod.resources | length == 0
-      - awx_task_pod.resources | length == 0
+- debug:
+    msg: test - replicas=3 should give 3 of each
 
 - include_tasks: apply_awx_spec.yml
   vars:
     additional_fields:
-      replicas: 2
-      web_replicas: 0
-      task_replicas: 0
+      replicas: 3
 
-- name: Get web pod details
-  k8s_info:
-    namespace: '{{ namespace }}'
-    kind: Pod
-    label_selectors:
-      - app.kubernetes.io/name = example-awx-web
-  register: awx_web_pod
-
-- name: Get task pod details
-  k8s_info:
-    namespace: '{{ namespace }}'
-    kind: Pod
-    label_selectors:
-      - app.kubernetes.io/name = example-awx-task
-  register: awx_task_pod
-
-- name: Ensure that the pods do not exist (0 replicas)
-  assert:
-    that:
-      - awx_web_pod.resources | length == 2
-      - awx_task_pod.resources | length == 2
-
-- include_tasks: apply_awx_spec.yml
+- include_tasks: _test_case_replicas.yml
   vars:
-    additional_fields:
-      replicas: 2
-      web_replicas: 4
-
-- name: Get web pod details
-  k8s_info:
-    namespace: '{{ namespace }}'
-    kind: Pod
-    label_selectors:
-      - app.kubernetes.io/name = example-awx-web
-  register: awx_web_pod
-
-- name: Get task pod details
-  k8s_info:
-    namespace: '{{ namespace }}'
-    kind: Pod
-    label_selectors:
-      - app.kubernetes.io/name = example-awx-task
-  register: awx_task_pod
-
-- name: Ensure that the pods do not exist (0 replicas)
-  assert:
-    that:
-      - awx_web_pod.resources | length == 4
-      - awx_task_pod.resources | length == 2
+    expected_web_replicas: 3
+    expected_task_replicas: 3

--- a/molecule/default/tasks/awx_replicas_test.yml
+++ b/molecule/default/tasks/awx_replicas_test.yml
@@ -1,0 +1,85 @@
+- include_tasks: apply_awx_spec.yml
+  vars:
+    additional_fields:
+      replicas: 0
+      web_replicas: 0
+      task_replicas: 0
+
+- name: Get web pod details
+  k8s_info:
+    namespace: '{{ namespace }}'
+    kind: Pod
+    label_selectors:
+      - app.kubernetes.io/name = example-awx-web
+  register: awx_web_pod
+
+- name: Get task pod details
+  k8s_info:
+    namespace: '{{ namespace }}'
+    kind: Pod
+    label_selectors:
+      - app.kubernetes.io/name = example-awx-task
+  register: awx_task_pod
+
+- name: Ensure that the pods do not exist (0 replicas)
+  assert:
+    that:
+      - awx_web_pod.resources | length == 0
+      - awx_task_pod.resources | length == 0
+
+- include_tasks: apply_awx_spec.yml
+  vars:
+    additional_fields:
+      replicas: 2
+      web_replicas: 0
+      task_replicas: 0
+
+- name: Get web pod details
+  k8s_info:
+    namespace: '{{ namespace }}'
+    kind: Pod
+    label_selectors:
+      - app.kubernetes.io/name = example-awx-web
+  register: awx_web_pod
+
+- name: Get task pod details
+  k8s_info:
+    namespace: '{{ namespace }}'
+    kind: Pod
+    label_selectors:
+      - app.kubernetes.io/name = example-awx-task
+  register: awx_task_pod
+
+- name: Ensure that the pods do not exist (0 replicas)
+  assert:
+    that:
+      - awx_web_pod.resources | length == 2
+      - awx_task_pod.resources | length == 2
+
+- include_tasks: apply_awx_spec.yml
+  vars:
+    additional_fields:
+      replicas: 2
+      web_replicas: 4
+
+- name: Get web pod details
+  k8s_info:
+    namespace: '{{ namespace }}'
+    kind: Pod
+    label_selectors:
+      - app.kubernetes.io/name = example-awx-web
+  register: awx_web_pod
+
+- name: Get task pod details
+  k8s_info:
+    namespace: '{{ namespace }}'
+    kind: Pod
+    label_selectors:
+      - app.kubernetes.io/name = example-awx-task
+  register: awx_task_pod
+
+- name: Ensure that the pods do not exist (0 replicas)
+  assert:
+    that:
+      - awx_web_pod.resources | length == 4
+      - awx_task_pod.resources | length == 2

--- a/molecule/default/tasks/awx_replicas_test.yml
+++ b/molecule/default/tasks/awx_replicas_test.yml
@@ -1,61 +1,64 @@
 ---
-- debug:
-    msg: test - web_replicas and task_replicas should override replicas
+- block:
+  - debug:
+      msg: test - web_replicas and task_replicas should override replicas
 
-- include_tasks: apply_awx_spec.yml
-  vars:
-    additional_fields:
-      replicas: 2
-      web_replicas: 0
-      task_replicas: 0
+  - include_tasks: apply_awx_spec.yml
+    vars:
+      additional_fields:
+        replicas: 2
+        web_replicas: 0
+        task_replicas: 0
 
-- include_tasks: _test_case_replicas.yml
-  vars:
-    expected_web_replicas: 0
-    expected_task_replicas: 0
-
-####
-
-- debug:
-    msg: test - replicas should act as a default
-
-- include_tasks: apply_awx_spec.yml
-  vars:
-    additional_fields:
-      replicas: 2
-      web_replicas: 1
-
-- include_tasks: _test_case_replicas.yml
-  vars:
-    expected_web_replicas: 1
-    expected_task_replicas: 2
+  - include_tasks: _test_case_replicas.yml
+    vars:
+      expected_web_replicas: 0
+      expected_task_replicas: 0
 
 ####
 
-- debug:
-    msg: test - replicas=0 should kill all pods
+  - debug:
+      msg: test - replicas should act as a default
 
-- include_tasks: apply_awx_spec.yml
-  vars:
-    additional_fields:
-      replicas: 0
+  - include_tasks: apply_awx_spec.yml
+    vars:
+      additional_fields:
+        replicas: 2
+        web_replicas: 1
 
-- include_tasks: _test_case_replicas.yml
-  vars:
-    expected_web_replicas: 0
-    expected_task_replicas: 0
+  - include_tasks: _test_case_replicas.yml
+    vars:
+      expected_web_replicas: 1
+      expected_task_replicas: 2
 
 ####
 
-- debug:
-    msg: test - replicas=3 should give 3 of each
+  - debug:
+      msg: test - replicas=0 should kill all pods
 
-- include_tasks: apply_awx_spec.yml
-  vars:
-    additional_fields:
-      replicas: 3
+  - include_tasks: apply_awx_spec.yml
+    vars:
+      additional_fields:
+        replicas: 0
 
-- include_tasks: _test_case_replicas.yml
-  vars:
-    expected_web_replicas: 3
-    expected_task_replicas: 3
+  - include_tasks: _test_case_replicas.yml
+    vars:
+      expected_web_replicas: 0
+      expected_task_replicas: 0
+
+####
+
+  - debug:
+      msg: test - replicas=3 should give 3 of each
+
+  - include_tasks: apply_awx_spec.yml
+    vars:
+      additional_fields:
+        replicas: 3
+
+  - include_tasks: _test_case_replicas.yml
+    vars:
+      expected_web_replicas: 3
+      expected_task_replicas: 3
+  tags:
+    - replicas

--- a/molecule/default/tasks/awx_test.yml
+++ b/molecule/default/tasks/awx_test.yml
@@ -1,15 +1,5 @@
 ---
-- name: Create the awx.ansible.com/v1alpha1.AWX
-  k8s:
-    state: present
-    namespace: '{{ namespace }}'
-    definition: "{{ lookup('template', 'awx_cr_molecule.yml.j2') | from_yaml }}"
-    wait: yes
-    wait_timeout: 900
-    wait_condition:
-      type: Running
-      reason: Successful
-      status: "True"
+- include_tasks: apply_awx_spec.yml
 
 - name: Obtain generated admin password
   k8s_info:

--- a/molecule/default/templates/awx_cr_molecule.yml.j2
+++ b/molecule/default/templates/awx_cr_molecule.yml.j2
@@ -37,3 +37,6 @@ spec:
   additional_labels:
   - my/team
   - my/service
+{% if additional_fields is defined %}
+{{ additional_fields | to_nice_yaml(indent=2)}}
+{% endif %}

--- a/molecule/default/templates/awx_cr_molecule.yml.j2
+++ b/molecule/default/templates/awx_cr_molecule.yml.j2
@@ -20,15 +20,15 @@ spec:
     kubernetes.io/ingress.class: nginx
   web_resource_requirements:
     requests:
-      cpu: 50m
+      cpu: 20m
       memory: 32M
   task_resource_requirements:
     requests:
-      cpu: 50m
+      cpu: 20m
       memory: 32M
   ee_resource_requirements:
     requests:
-      cpu: 50m
+      cpu: 20m
       memory: 16M
   no_log: false
   postgres_resource_requirements: {}
@@ -38,5 +38,5 @@ spec:
   - my/team
   - my/service
 {% if additional_fields is defined %}
-{{ additional_fields | to_nice_yaml(indent=2)}}
+  {{ additional_fields | to_nice_yaml | indent(2) }}
 {% endif %}

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -15,6 +15,8 @@
           include_tasks: '{{ item }}'
           with_fileglob:
             - tasks/*_test.yml
+          tags:
+            - always
       rescue:
         - name: Retrieve relevant resources
           k8s_info:
@@ -31,6 +33,8 @@
             - api_version: v1
               kind: ConfigMap
           register: debug_resources
+          tags:
+            - always
 
         - name: Retrieve Pod logs
           k8s_log:
@@ -39,15 +43,21 @@
             container: awx-manager
           loop: "{{ q('k8s', api_version='v1', kind='Pod', namespace=namespace, label_selector=ctrl_label) }}"
           register: debug_logs
+          tags:
+            - always
 
         - name: Output gathered resources
           debug:
             var: debug_resources
+          tags:
+            - always
 
         - name: Output gathered logs
           debug:
             var: item.log_lines
           loop: '{{ debug_logs.results }}'
+          tags:
+            - always
 
         - name: Re-emit failure
           vars:
@@ -55,3 +65,5 @@
               result: '{{ ansible_failed_result }}'
           fail:
             msg: '{{ failed_task }}'
+          tags:
+            - always

--- a/molecule/kind/converge.yml
+++ b/molecule/kind/converge.yml
@@ -29,11 +29,16 @@
         push: no
         source: build
         force_source: yes
+      tags:
+        - always
 
     - name: Load operator image into kind cluster
       command: kind load docker-image --name osdk-test '{{ operator_image }}'
       register: result
       changed_when: '"not yet present" in result.stdout'
+      tags:
+        - always
+
 
     - name: Load awx image into kind cluster
       command: kind load docker-image --name osdk-test '{{ awx_image }}:{{ awx_version }}'
@@ -42,5 +47,7 @@
       when:
         - awx_image is defined
         - awx_image != ''
+      tags:
+        - always
 
 - import_playbook: ../default/converge.yml

--- a/molecule/kind/destroy.yml
+++ b/molecule/kind/destroy.yml
@@ -9,8 +9,12 @@
   tasks:
     - name: Destroy test kind cluster
       command: kind delete cluster --name osdk-test --kubeconfig {{ kubeconfig }}
+      tags:
+        - always
 
     - name: Unset pull policy
       command: '{{ kustomize }} edit remove patch --path pull_policy/{{ operator_pull_policy }}.yaml'
       args:
         chdir: '{{ config_dir }}/testing'
+      tags:
+        - always

--- a/molecule/kind/prepare.yml
+++ b/molecule/kind/prepare.yml
@@ -12,6 +12,8 @@
       k8s:
         definition: |
           {{ lookup('url', nginx_ingress_definition, split_lines=False) | from_yaml_all }}
+      tags:
+        - always
 
     - name: Wait for NGINX ingress to become available
       k8s_info:
@@ -25,5 +27,7 @@
           type: Ready
       register: result  # For some reason, this task always fails on the first try...
       until: result is not failed
+      tags:
+        - always
 
 - import_playbook: ../default/prepare.yml

--- a/roles/installer/tasks/install.yml
+++ b/roles/installer/tasks/install.yml
@@ -88,6 +88,7 @@
     command: >-
       bash -c "awx-manage showmigrations | grep -v '[X]' | grep '[ ]' | wc -l"
   changed_when: false
+  when: awx_task_pod_name != ''
   register: database_check
 
 - name: Migrate the database if the K8s resources were updated.  # noqa 305
@@ -99,11 +100,13 @@
       bash -c "awx-manage migrate --noinput"
   register: migrate_result
   when:
+  - awx_task_pod_name != ''
   - database_check is defined
   - (database_check.stdout|trim) != '0'
 
 - name: Initialize Django
   include_tasks: initialize_django.yml
+  when: awx_task_pod_name != ''
 
 - name: Update status variables
   include_tasks: update_status.yml

--- a/roles/installer/tasks/resources_configuration.yml
+++ b/roles/installer/tasks/resources_configuration.yml
@@ -285,5 +285,7 @@
 
 - name: Verify the resource pod name is populated.
   assert:
-    that: awx_task_pod_name != ''
+    that:
+      - awx_task_pod_name != ''
     fail_msg: "Could not find the tower pod's name."
+  when: task_replicas | int > 0 or (task_replicas == '' and replicas > 0)

--- a/roles/installer/tasks/update_status.yml
+++ b/roles/installer/tasks/update_status.yml
@@ -53,6 +53,7 @@
       bash -c "awx-manage --version"
   register: instance_version
   changed_when: false
+  when: awx_task_pod_name != ''
 
 - name: Update version status
   operator_sdk.util.k8s_status:
@@ -62,6 +63,7 @@
     namespace: "{{ ansible_operator_meta.namespace }}"
     status:
       version: "{{ instance_version.stdout | trim }}"
+  when: instance_version is not skipped
 
 - name: Update image status
   operator_sdk.util.k8s_status:

--- a/roles/installer/templates/deployments/task.yaml.j2
+++ b/roles/installer/templates/deployments/task.yaml.j2
@@ -8,9 +8,9 @@ metadata:
     {{ lookup("template", "../common/templates/labels/common.yaml.j2")  | indent(width=4) | trim }}
     {{ lookup("template", "../common/templates/labels/version.yaml.j2") | indent(width=4) | trim }}
 spec:
-{% if task_replicas %}
+{% if task_replicas != '' %}
   replicas: {{ task_replicas }}
-{% elif replicas %}
+{% elif replicas != '' %}
   replicas: {{ replicas }}
 {% endif %}
   selector:

--- a/roles/installer/templates/deployments/web.yaml.j2
+++ b/roles/installer/templates/deployments/web.yaml.j2
@@ -9,9 +9,9 @@ metadata:
     {{ lookup("template", "../common/templates/labels/common.yaml.j2")  | indent(width=4) | trim }}
     {{ lookup("template", "../common/templates/labels/version.yaml.j2") | indent(width=4) | trim }}
 spec:
-{% if web_replicas %}
+{% if web_replicas != '' %}
   replicas: {{ web_replicas }}
-{% elif replicas %}
+{% elif replicas != '' %}
   replicas: {{ replicas }}
 {% endif %}
   selector:


### PR DESCRIPTION
##### SUMMARY

There is quite a bit going on here.

On the user-facing side:

- First off allow `replicas`, `web_replicas`, and `task_replicas` to be `0`. Previously this was interpreted as a falsy value and messed up the templating logic. Now we compare it to the default (empty string) instead. Fixes #1454.
- The above uncovered another issue: If we scale replicas to 0, then the operator reconciliation loop starts failing since it tries to find some pod that doesn't exist in that case. Only run those tasks if we are able.

On the testing side:

- Add tests for the above.
- However this made the (single) test file really big, so I broke it into some separately-runnable files. For example, one file to update the `AWX` instance we are testing with. You just import that with `include_tasks`.
  - I also made it so that when you do that, you can pass in an `additional_fields` var so that you can actually customize the `AWX` definition to test how changes to fields interact.
- Lowered CPU request specs, because it was failing with testing 3 replicas on GHA.
- All these new tests made CI really slow (~13 minutes up to ~25 minutes). So to fix this, I made use of ansible tags and broke a test matrix in GHA. It's also easy to expand this (just tag the new tasks and edit/add two lines in `ci.yaml`) so that if we add chunks of other tests later, they can each run in their own separate instance, in parallel.
  - To do that, I had to tag the tasks that should always run (like the tasks to set up kind and tear it down, and to do the image build). I think this is a fair trade-off for the flexibility we get with doing matrix runs now.
- Also deleted the branch filter from `ci.yaml` so that people can run the tests in the own forks on their own feature branches.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change