### PR TITLE
Fix wsrelay still using port 443 even BROADCAST_WEBSOCKET_PORT=8052

### DIFF
--- a/roles/installer/templates/configmaps/config.yaml.j2
+++ b/roles/installer/templates/configmaps/config.yaml.j2
@@ -135,7 +135,7 @@ data:
             server_name _;
 
             # Redirect all HTTP links to the matching HTTPS page
-            return 301 https://$host$request_uri;
+            return 301 https://$host:8053$request_uri;
         }
         {% endif %}
 


### PR DESCRIPTION
SUMMARY
Fix wsrelay connection to awx-web when route_tls_termination_mechanism: passthrough

ISSUE TYPE
- Bug, Docs Fix or other nominal change

ADDITIONAL INFORMATION
Fixes #1474