### PR TITLE
Docs: moved introduction from readme to docs folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ An [Ansible AWX](https://github.com/ansible/awx) operator for Kubernetes built w
 <!--ts-->
 * [AWX Operator](#awx-operator)
 * [Table of Contents](#table-of-contents)
-   * [Purpose](#purpose)
    * [Usage](#usage)
       * [Creating a minikube cluster for testing](#creating-a-minikube-cluster-for-testing)
       * [Basic Install](#basic-install)
@@ -69,10 +68,6 @@ An [Ansible AWX](https://github.com/ansible/awx) operator for Kubernetes built w
 <!-- Created by https://github.com/ekalinin/github-markdown-toc -->
 
 <!--te-->
-
-## Purpose
-
-This operator is meant to provide a more Kubernetes-native installation method for AWX via an AWX Custom Resource Definition (CRD).
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ An [Ansible AWX](https://github.com/ansible/awx) operator for Kubernetes built w
 <!-- Regenerate this table of contents using https://github.com/ekalinin/github-markdown-toc -->
 <!-- gh-md-toc --insert README.md -->
 <!--ts-->
+
+NOTE:  we are in the process of moving this readme into official docs in the /docs folder. Please go there to find additional sections during this interim move phase.
+
 * [AWX Operator](#awx-operator)
 * [Table of Contents](#table-of-contents)
    * [Usage](#usage)

--- a/docs/introduction/introduction.md
+++ b/docs/introduction/introduction.md
@@ -1,0 +1,3 @@
+## Purpose
+
+This operator is meant to provide a more Kubernetes-native installation method for AWX via an AWX Custom Resource Definition (CRD).


### PR DESCRIPTION
##### SUMMARY
Moved *Introduction* from ReadME to it's folder in /docs directory. 

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION
This PR is in line with the docs revamp and tracked by issue #1360 
