### PR TITLE
Docs: moved uninstall segment from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ NOTE:  we are in the process of moving this readme into official docs in the /do
 * [AWX Operator](#awx-operator)
 * [Table of Contents](#table-of-contents)
    * [Usage](#usage)
-      * [Uninstall](#uninstall)
       * [Disable IPV6](#disable-ipv6)
       * [Add Execution Nodes](#adding-execution-nodes)
           * [Custom Receptor CA](#custom-receptor-ca)
@@ -32,18 +31,6 @@ NOTE:  we are in the process of moving this readme into official docs in the /do
 
 <!--te-->
 
-### Uninstall ###
-
-To uninstall an AWX deployment instance, you basically need to remove the AWX kind related to that instance. For example, to delete an AWX instance named awx-demo, you would do:
-
-```
-$ kubectl delete awx awx-demo
-awx.awx.ansible.com "awx-demo" deleted
-```
-
-Deleting an AWX instance will remove all related deployments and statefulsets, however, persistent volumes and secrets will remain. To enforce secrets also getting removed, you can use `garbage_collect_secrets: true`.
-
-**Note**: If you ever intend to recover an AWX from an existing database you will need a copy of the secrets in order to perform a successful recovery.
 
 ### Disable IPV6
 Starting with AWX Operator release 0.24.0,[IPV6 was enabled in ngnix configuration](https://github.com/ansible/awx-operator/pull/950) which causes

--- a/docs/uninstall/uninstall.md
+++ b/docs/uninstall/uninstall.md
@@ -1,0 +1,12 @@
+### Uninstall ###
+
+To uninstall an AWX deployment instance, you basically need to remove the AWX kind related to that instance. For example, to delete an AWX instance named awx-demo, you would do:
+
+```
+$ kubectl delete awx awx-demo
+awx.awx.ansible.com "awx-demo" deleted
+```
+
+Deleting an AWX instance will remove all related deployments and statefulsets, however, persistent volumes and secrets will remain. To enforce secrets also getting removed, you can use `garbage_collect_secrets: true`.
+
+**Note**: If you ever intend to recover an AWX from an existing database you will need a copy of the secrets in order to perform a successful recovery.


### PR DESCRIPTION
##### SUMMARY
Moved _Uninstall_ from ReadME to it's folder in /docs directory.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION
This PR is in line with the docs revamp and tracked by issue [#1360](https://github.com/ansible/awx-operator/issues/1360)
