### PR TITLE
Pin Cython for tests, currently PyYAML cannot build

### DIFF
--- a/molecule/requirements.txt
+++ b/molecule/requirements.txt
@@ -6,3 +6,4 @@ openshift!=0.13.0
 jmespath
 ansible-core
 ansible-compat<4  # https://github.com/ansible-community/molecule/issues/3903
+Cython<3  # https://github.com/yaml/pyyaml/issues/601


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

Try to work around https://github.com/yaml/pyyaml/issues/601 for now with a pin.

<!---
If you are fixing an existing issue, please include "fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
- Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION

https://pypi.org/project/Cython/ - 3.0.0 just landed an hour ago and caused this breakage.