### PR TITLE
Molecule: Different fix for new Cython

### DIFF
--- a/molecule/kind/converge.yml
+++ b/molecule/kind/converge.yml
@@ -15,6 +15,7 @@
           - urllib3==1.26.15
           - docker
           - docker-compose
+          - pyyaml==5.3.1
         state: present
 
     - name: Build operator image

--- a/molecule/requirements.txt
+++ b/molecule/requirements.txt
@@ -6,4 +6,3 @@ openshift!=0.13.0
 jmespath
 ansible-core
 ansible-compat<4  # https://github.com/ansible-community/molecule/issues/3903
-Cython<3  # https://github.com/yaml/pyyaml/issues/601


### PR DESCRIPTION

##### SUMMARY

The first attempt (#1492) was unfortunately wrong in two ways. We need to pin the dependency in inside the container, not as a molecule dependency. Also it seems like the Cython pin needs to happen *earlier* but an easy solution is to just pin pyyaml to an old version instead for now until https://github.com/yaml/pyyaml/issues/601 is resolved.

Here's an AWX CI run showing this fix works, this time: https://github.com/ansible/awx/pull/14251

I will revert #1493 as well, it is useless.

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change
