### PR TITLE
Revert "[checkpoint_v1] Pin Cython for tests, so that PyYAML can build (#1493)"

### DIFF
--- a/molecule/requirements.txt
+++ b/molecule/requirements.txt
@@ -6,4 +6,3 @@ openshift!=0.13.0
 jmespath
 ansible-core
 ansible-compat<4  # https://github.com/ansible-community/molecule/issues/3903
-Cython<3  # https://github.com/yaml/pyyaml/issues/601


### PR DESCRIPTION

##### SUMMARY

This reverts commit ef3c95b6b38ca022f02f86d89ea60132752ae209.

This fix was done in the wrong place - and also does not affect the checkpoint_v1 branch, so it was really completely pointless. Oops.


<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE

 - Bug, Docs Fix or other nominal change
