### PR TITLE
Set a default container for web & task deployments

### DIFF
--- a/roles/installer/templates/deployments/task.yaml.j2
+++ b/roles/installer/templates/deployments/task.yaml.j2
@@ -25,6 +25,7 @@ spec:
         {{ lookup("template", "../common/templates/labels/common.yaml.j2")  | indent(width=8) | trim }}
         {{ lookup("template", "../common/templates/labels/version.yaml.j2") | indent(width=8) | trim }}
       annotations:
+        kubectl.kubernetes.io/default-container: '{{ ansible_operator_meta.name }}-task'
 {% for template in [
     "configmaps/config",
     "configmaps/pre_stop_scripts",

--- a/roles/installer/templates/deployments/web.yaml.j2
+++ b/roles/installer/templates/deployments/web.yaml.j2
@@ -26,6 +26,7 @@ spec:
         {{ lookup("template", "../common/templates/labels/common.yaml.j2")  | indent(width=8) | trim }}
         {{ lookup("template", "../common/templates/labels/version.yaml.j2") | indent(width=8) | trim }}
       annotations:
+        kubectl.kubernetes.io/default-container: '{{ ansible_operator_meta.name }}-web'
 {% for template in [
     "configmaps/config",
     "secrets/app_credentials",


### PR DESCRIPTION
 - This will make it so that when you query the pod for logs, it assumes the default container.

##### SUMMARY
Now when you query a pod for logs, it will assume the default container, saving you from having to pass `-c awx-task`, or something similar.  

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New or Enhanced Feature

