### PR TITLE
Allow ability to set security context for postgres deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ All of our usage and configuration docs are nested in the `docs/` directory. Bel
     - [Redis Container Capabilities](./docs/user-guide/advanced-configuration/redis-container-capabilities.md)
     - [Trusting a Custom Certificate Authority](./docs/user-guide/advanced-configuration/trusting-a-custom-certificate-authority.md)
     - [Service Account](./docs/user-guide/advanced-configuration/service-account.md)
+    - [Security Context](./docs/user-guide/advanced-configuration/security-context.md)
     - [Persisting the Projects Directory](./docs/user-guide/advanced-configuration/persisting-projects-directory.md)
 - Troubleshooting
   - [General Debugging](./docs/troubleshooting/debugging.md)

--- a/config/crd/bases/awx.ansible.com_awxs.yaml
+++ b/config/crd/bases/awx.ansible.com_awxs.yaml
@@ -1779,6 +1779,10 @@ spec:
               session_cookie_secure:
                 description: Set session cookie secure mode for web
                 type: string
+              postgres_security_context_settings:
+                description: Key/values that will be set under the pod-level securityContext field
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
               receptor_log_level:
                 description: Set log level of receptor service
                 type: string

--- a/config/manifests/bases/awx-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/awx-operator.clusterserviceversion.yaml
@@ -62,7 +62,7 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:hidden
       - displayName: PostgreSQL Security Context Settings
-        path: postgres.security_context_settings
+        path: postgres_security_context_settings
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:hidden      

--- a/config/manifests/bases/awx-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/awx-operator.clusterserviceversion.yaml
@@ -61,6 +61,11 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:hidden
+      - displayName: PostgreSQL Security Context Settings
+        path: postgres.security_context_settings
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:hidden      
       - displayName: PostgreSQL Image
         path: postgres_image
         x-descriptors:

--- a/docs/user-guide/advanced-configuration/security-context.md
+++ b/docs/user-guide/advanced-configuration/security-context.md
@@ -1,0 +1,27 @@
+#### Service Account
+
+It is possible to modify some `SecurityContext` proprieties of the various deployments and stateful sets if needed.
+
+| Name                               | Description                                  | Default |
+| ---------------------------------- | -------------------------------------------- | ------- |
+| security_context_settings          | SecurityContext for Task and Web deployments | {}      |
+| postgres_security_context_settings | SecurityContext for Task and Web deployments | {}      |
+
+
+Example configuration securityContext for the Task and Web deployments:
+
+```yaml
+spec:
+  security_context_settings:
+    allowPrivilegeEscalation: false
+    capabilities:
+        drop:
+        - ALL
+```
+
+
+```yaml
+spec:
+  postgres_security_context_settings:
+    runAsNonRoot: true
+```

--- a/roles/installer/defaults/main.yml
+++ b/roles/installer/defaults/main.yml
@@ -424,6 +424,8 @@ garbage_collect_secrets: false
 development_mode: false
 
 security_context_settings: {}
+postgres_security_context_settings: {}
+
 
 # Set no_log settings on certain tasks
 no_log: true

--- a/roles/installer/defaults/main.yml
+++ b/roles/installer/defaults/main.yml
@@ -426,7 +426,6 @@ development_mode: false
 security_context_settings: {}
 postgres_security_context_settings: {}
 
-
 # Set no_log settings on certain tasks
 no_log: true
 

--- a/roles/installer/templates/deployments/task.yaml.j2
+++ b/roles/installer/templates/deployments/task.yaml.j2
@@ -442,7 +442,7 @@ spec:
         fsGroup: 1000
 {% endif %}
 {% if security_context_settings|length %}
-        {{ security_context_settings | to_nice_yaml | indent(8) }}
+        {{ security_context_settings | to_nice_yaml | indent(10) }}
 {% endif %}
 {% endif %}
 {% if termination_grace_period_seconds is defined %}

--- a/roles/installer/templates/deployments/web.yaml.j2
+++ b/roles/installer/templates/deployments/web.yaml.j2
@@ -341,6 +341,10 @@ spec:
       affinity:
         {{ affinity | to_nice_yaml | indent(width=8) }}
 {% endif %}
+{% if security_context_settings|length %}
+      securityContext:
+        {{ security_context_settings | to_nice_yaml | indent(8) }}
+{% endif %}
       volumes:
         - name: "{{ ansible_operator_meta.name }}-receptor-ca"
           secret:

--- a/roles/installer/templates/statefulsets/postgres.yaml.j2
+++ b/roles/installer/templates/statefulsets/postgres.yaml.j2
@@ -53,7 +53,7 @@ spec:
           name: postgres
 {% if postgres_security_context_settings|length %}
           securityContext:
-            {{ postgres_security_context_settings | to_nice_yaml | indent(8) }}
+            {{ postgres_security_context_settings | to_nice_yaml | indent(12) }}
 {% endif %}
 {% if postgres_extra_args %}
           args: {{ postgres_extra_args }}

--- a/roles/installer/templates/statefulsets/postgres.yaml.j2
+++ b/roles/installer/templates/statefulsets/postgres.yaml.j2
@@ -51,11 +51,9 @@ spec:
         - image: '{{ _postgres_image }}'
           imagePullPolicy: '{{ image_pull_policy }}'
           name: postgres
-{% if postgres.security_context_settings is defined %}
+{% if postgres_security_context_settings|length %}
           securityContext:
-{% if postgres.security_context_settings|length %}
-      {{ postgres_security_context_settings | to_nice_yaml | indent(8) }}
-{% endif %}
+            {{ postgres_security_context_settings | to_nice_yaml | indent(8) }}
 {% endif %}
 {% if postgres_extra_args %}
           args: {{ postgres_extra_args }}

--- a/roles/installer/templates/statefulsets/postgres.yaml.j2
+++ b/roles/installer/templates/statefulsets/postgres.yaml.j2
@@ -51,6 +51,12 @@ spec:
         - image: '{{ _postgres_image }}'
           imagePullPolicy: '{{ image_pull_policy }}'
           name: postgres
+{% if postgres.security_context_settings is defined %}
+          securityContext:
+{% if postgres.security_context_settings|length %}
+      {{ postgres.security_context_settings | to_nice_yaml | indent(8) }}
+{% endif %}
+{% endif %}
 {% if postgres_extra_args %}
           args: {{ postgres_extra_args }}
 {% endif %}

--- a/roles/installer/templates/statefulsets/postgres.yaml.j2
+++ b/roles/installer/templates/statefulsets/postgres.yaml.j2
@@ -54,7 +54,7 @@ spec:
 {% if postgres.security_context_settings is defined %}
           securityContext:
 {% if postgres.security_context_settings|length %}
-      {{ postgres.security_context_settings | to_nice_yaml | indent(8) }}
+      {{ postgres_security_context_settings | to_nice_yaml | indent(8) }}
 {% endif %}
 {% endif %}
 {% if postgres_extra_args %}


### PR DESCRIPTION
##### SUMMARY
Allow ability to set security context for postgres containers during deployment.
Example it will allow users to deploy postgres as Non Root.

##### ISSUE TYPE
 - New or Enhanced Feature

##### ADDITIONAL INFORMATION
Issue #1451  will be addressed hopefully
