### PR TITLE
Add keepalive to migrate data script

### DIFF
--- a/roles/installer/tasks/migrate_data.yml
+++ b/roles/installer/tasks/migrate_data.yml
@@ -59,11 +59,18 @@
     namespace: "{{ ansible_operator_meta.namespace }}"
     pod: "{{ postgres_pod_name }}"
     command: |
-      bash -c """
+      bash -c "
+      keepalive_file=\"$(mktemp)\"
+      while [[ -f \"$keepalive_file\" ]]; do echo 'Migrating data from old database...'; sleep 1; done & keepalive_pid=$!
+      echo keepalive_pid: $keepalive_pid
+      trap \"rm -f $keepalive_file; pkill -P $keepalive_pid; wait $keepalive_pid\" EXIT INT TERM
       set -e -o pipefail
       PGPASSWORD='{{ awx_old_postgres_pass }}' {{ pgdump }} | PGPASSWORD='{{ awx_postgres_pass }}' {{ pg_restore }}
-      echo 'Successful'
-      """
+      rm -f \"$keepalive_file\"
+      pkill -P $keepalive_pid || true
+      wait $keepalive_pid
+      echo done
+      "
   no_log: "{{ no_log }}"
   register: data_migration
   failed_when: "'Successful' not in data_migration.stdout"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
pg_restore is silent and if the data migration takes longer than 15 minute exec/rsh to the postgres pod (through which we run the data migration command) will idle timeout

this PR adds a background process that prints keepalive messages during the migration process to keep the exec/rsh alive
<!---
If you are fixing an existing issue, please include "fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
