### PR TITLE
Switch to using the sclorg redis image for consistency

### DIFF
--- a/docs/user-guide/advanced-configuration/deploying-a-specific-version-of-awx.md
+++ b/docs/user-guide/advanced-configuration/deploying-a-specific-version-of-awx.md
@@ -9,7 +9,7 @@ There are a few variables that are customizable for awx the image management.
 | image_pull_policy   | The pull policy to adopt  | IfNotPresent                            |
 | image_pull_secrets  | The pull secrets to use   | None                                    |
 | ee_images           | A list of EEs to register | quay.io/ansible/awx-ee:latest           |
-| redis_image         | Path of the image to pull | docker.io/redis                         |
+| redis_image         | Path of the image to pull | quay.io/sclorg/redis-6-c9s              |
 | redis_image_version | Image version to pull     | latest                                  |
 
 Example of customization could be:

--- a/roles/installer/defaults/main.yml
+++ b/roles/installer/defaults/main.yml
@@ -237,8 +237,8 @@ extra_volumes: ''
 
 _image: quay.io/ansible/awx
 _image_version: "{{ lookup('env', 'DEFAULT_AWX_VERSION') or 'latest' }}"
-_redis_image: docker.io/redis
-_redis_image_version: 7
+_redis_image: quay.io/sclorg/redis-6-c9s
+_redis_image_version: latest
 _postgres_image: postgres
 _postgres_image_version: 13
 image_pull_policy: IfNotPresent

--- a/roles/installer/templates/deployments/task.yaml.j2
+++ b/roles/installer/templates/deployments/task.yaml.j2
@@ -157,7 +157,7 @@ spec:
             - name: {{ ansible_operator_meta.name }}-redis-socket
               mountPath: "/var/run/redis"
             - name: "{{ ansible_operator_meta.name }}-redis-data"
-              mountPath: "/data"
+              mountPath: "/var/lib/redis/data"
 {% if termination_grace_period_seconds is defined %}
             - name: pre-stop-data
               mountPath: /var/lib/pre-stop

--- a/roles/installer/templates/deployments/web.yaml.j2
+++ b/roles/installer/templates/deployments/web.yaml.j2
@@ -147,7 +147,7 @@ spec:
             - name: {{ ansible_operator_meta.name }}-redis-socket
               mountPath: "/var/run/redis"
             - name: "{{ ansible_operator_meta.name }}-redis-data"
-              mountPath: "/data"
+              mountPath: "/var/lib/redis/data"
           resources: {{ redis_resource_requirements }}
         - image: '{{ _image }}'
           name: '{{ ansible_operator_meta.name }}-web'


### PR DESCRIPTION

##### SUMMARY

The eda-server-operator uses the sclorg redis image as well, which is closer to what we use downstream.  Consistency will improve maintainability.  

New image:
* quay.io/sclorg/redis-6-c8s:latest

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bug, Docs Fix or other nominal change
