### PR TITLE
Changed replica from string to int for default

### DIFF
--- a/roles/installer/defaults/main.yml
+++ b/roles/installer/defaults/main.yml
@@ -273,7 +273,7 @@ _init_projects_container_image: quay.io/centos/centos:stream9
 
 create_preload_data: true
 
-replicas: "1"
+replicas: 1
 web_replicas: ''
 task_replicas: ''
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Change var for replicas from string to int
<!---
If you are fixing an existing issue, please include "fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
-->
If spec is absent for `replicas` for the awx CR, upgrades will fail like so:
<!--- Paste verbatim command output below, e.g. before and after your change -->
```
fatal: [localhost]: FAILED! => {"msg": "The conditional check 'task_replicas | int > 0 or (task_replicas == '' and replicas > 0)' failed. The error was: Unexpected templating type error occurred on ({% if task_replicas | int > 0 or (task_replicas == '' and replicas > 0) %} True {% else %} False {% endif %}): '>' not supported between instances of 'AnsibleUnicode' and 'int'\n\nThe error appears to be in '/opt/ansible/roles/installer/tasks/resources_configuration.yml': line 286, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: Verify the resource pod name is populated.\n  ^ here\n"}
```
