### PR TITLE
Add keepalive to migrate data script with restart of postgres pod [DNM]

### DIFF
--- a/roles/installer/tasks/migrate_data.yml
+++ b/roles/installer/tasks/migrate_data.yml
@@ -59,14 +59,49 @@
     namespace: "{{ ansible_operator_meta.namespace }}"
     pod: "{{ postgres_pod_name }}"
     command: |
-      bash -c """
+      bash -c "
+      (while true; do echo 'Migrating data from old database...'; sleep 60; done) & keep_alive_pid=$!
       set -e -o pipefail
       PGPASSWORD='{{ awx_old_postgres_pass }}' {{ pgdump }} | PGPASSWORD='{{ awx_postgres_pass }}' {{ pg_restore }}
+      echo 'Killing keep alive process...'
+      kill $keep_alive_pid || true
+      wait
       echo 'Successful'
-      """
+      "
   no_log: "{{ no_log }}"
   register: data_migration
-  failed_when: "'Successful' not in data_migration.stdout"
+
+# Previous step result in defunct processes in the Postgres pod that need to be cleaned up
+# Restarting the Postgres pod will clean up the defunct processes
+- name: Delete postgres pod to restart postgres
+  k8s:
+    state: absent
+    definition:
+      apiVersion: v1
+      kind: Pod
+      metadata:
+        name: "{{ postgres_pod_name }}"
+        namespace: "{{ ansible_operator_meta.namespace }}"
+
+- name: Get new postgres pod information
+  k8s_info:
+    kind: Pod
+    namespace: "{{ ansible_operator_meta.namespace }}"
+    name: "{{ postgres_pod_name }}"
+    field_selectors:
+      - status.phase=Running
+  register: postgres_pod
+  until:
+    - "postgres_pod['resources'] | length"
+    - "postgres_pod['resources'][0]['status']['phase'] == 'Running'"
+    - "postgres_pod['resources'][0]['status']['containerStatuses'][0]['ready'] == true"
+  delay: 5
+  retries: 60
+
+- name: Fail when data migration is not successful
+  fail:
+    msg: "Failed to migrate data from old database to new database"
+  when: data_migration.stdout.find('Successful') == -1
 
 - name: Set flag signifying that this instance has been migrated
   set_fact:


### PR DESCRIPTION
##### SUMMARY
pg_restore is silent and if the data migration takes longer than 15 minute exec/rsh to the postgres pod (through which we run the command) will idle timeout

this PR adds a background process that prints keepalive messages during the migration process to keep the exec/rsh alive

This PR also added a restart to the postgres pod after the restore finish (successful or failed) because the new code result in defunct processes and restarting the pod take care of that

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
