### PR TITLE
Revert "Switch to using the sclorg redis image for consistency (#1531)"

### DIFF
--- a/docs/user-guide/advanced-configuration/deploying-a-specific-version-of-awx.md
+++ b/docs/user-guide/advanced-configuration/deploying-a-specific-version-of-awx.md
@@ -9,7 +9,7 @@ There are a few variables that are customizable for awx the image management.
 | image_pull_policy   | The pull policy to adopt  | IfNotPresent                            |
 | image_pull_secrets  | The pull secrets to use   | None                                    |
 | ee_images           | A list of EEs to register | quay.io/ansible/awx-ee:latest           |
-| redis_image         | Path of the image to pull | quay.io/sclorg/redis-6-c9s              |
+| redis_image         | Path of the image to pull | docker.io/redis                         |
 | redis_image_version | Image version to pull     | latest                                  |
 
 Example of customization could be:

--- a/roles/installer/defaults/main.yml
+++ b/roles/installer/defaults/main.yml
@@ -237,8 +237,8 @@ extra_volumes: ''
 
 _image: quay.io/ansible/awx
 _image_version: "{{ lookup('env', 'DEFAULT_AWX_VERSION') or 'latest' }}"
-_redis_image: quay.io/sclorg/redis-6-c9s
-_redis_image_version: latest
+_redis_image: docker.io/redis
+_redis_image_version: 7
 _postgres_image: postgres
 _postgres_image_version: 13
 image_pull_policy: IfNotPresent

--- a/roles/installer/templates/deployments/task.yaml.j2
+++ b/roles/installer/templates/deployments/task.yaml.j2
@@ -157,7 +157,7 @@ spec:
             - name: {{ ansible_operator_meta.name }}-redis-socket
               mountPath: "/var/run/redis"
             - name: "{{ ansible_operator_meta.name }}-redis-data"
-              mountPath: "/var/lib/redis/data"
+              mountPath: "/data"
 {% if termination_grace_period_seconds is defined %}
             - name: pre-stop-data
               mountPath: /var/lib/pre-stop

--- a/roles/installer/templates/deployments/web.yaml.j2
+++ b/roles/installer/templates/deployments/web.yaml.j2
@@ -147,7 +147,7 @@ spec:
             - name: {{ ansible_operator_meta.name }}-redis-socket
               mountPath: "/var/run/redis"
             - name: "{{ ansible_operator_meta.name }}-redis-data"
-              mountPath: "/var/lib/redis/data"
+              mountPath: "/data"
           resources: {{ redis_resource_requirements }}
         - image: '{{ _image }}'
           name: '{{ ansible_operator_meta.name }}-web'


### PR DESCRIPTION
This reverts commit 48dcb08c785b70609c4dc29f1f6a8f10164e6920.

##### SUMMARY
error from web/task container
```
Traceback (most recent call last):
  File "/usr/bin/awx-manage", line 8, in <module>
    sys.exit(manage())
  File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/awx/__init__.py", line 200, in manage
    execute_from_command_line(sys.argv)
  File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/django/core/management/__init__.py", line 442, in execute_from_command_line
    utility.execute()
  File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/django/core/management/__init__.py", line 436, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/django/core/management/base.py", line 412, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/django/core/management/base.py", line 458, in execute
    output = self.handle(*args, **options)
  File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/awx/main/management/commands/run_callback_receiver.py", line 31, in handle
    CallbackBrokerWorker(),
  File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/awx/main/dispatch/worker/callback.py", line 80, in __init__
    self.redis.delete(key)
  File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/redis/commands/core.py", line 1588, in delete
    return self.execute_command("DEL", *names)
  File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/redis/client.py", line 1238, in execute_command
    return conn.retry.call_with_retry(
  File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/redis/retry.py", line 46, in call_with_retry
    return do()
  File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/redis/client.py", line 1239, in <lambda>
    lambda: self._send_command_parse_response(
  File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/redis/client.py", line 1215, in _send_command_parse_response
    return self.parse_response(conn, command_name, **options)
  File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/redis/client.py", line 1254, in parse_response
    response = connection.read_response()
  File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/redis/connection.py", line 839, in read_response
    raise response
redis.exceptions.ResponseError: MISCONF Redis is configured to save RDB snapshots, but it is currently not able to persist on disk. Commands that may modify the data set are disabled, because this instance is configured to report errors during writes if RDB snapshotting fails (stop-writes-on-bgsave-error option). Please check the Redis logs for details about the RDB error.
```
error from redis
```
find: '/var/log/redis': Permission denied
```

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
