### PR TITLE
Wait for termination grace period when scaling down the deployments

### DIFF
--- a/roles/installer/tasks/scale_down_deployment.yml
+++ b/roles/installer/tasks/scale_down_deployment.yml
@@ -16,6 +16,7 @@
     namespace: "{{ ansible_operator_meta.namespace }}"
     replicas: 0
     wait: yes
+    wait_timeout: "{{ termination_grace_period_seconds | default(120) }}"
   loop:
     - "{{ ansible_operator_meta.name }}-task"
     - "{{ ansible_operator_meta.name }}-web"


### PR DESCRIPTION
##### SUMMARY
Currently we don't respect the termination grace period when scaling down the deployments 

default wait timeout for k8s module is 120 second so we might end up in a case where deployment is not down and it try to do stuff with the database like migrating the data

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
