### PR TITLE
Add keepalive to migrate data script

### DIFF
--- a/roles/installer/tasks/migrate_data.yml
+++ b/roles/installer/tasks/migrate_data.yml
@@ -59,14 +59,29 @@
     namespace: "{{ ansible_operator_meta.namespace }}"
     pod: "{{ postgres_pod_name }}"
     command: |
-      bash -c """
+      bash -c "
+      function end_keepalive {
+        rc=$?
+        rm -f \"$1\"
+        kill $(cat /proc/$2/task/$2/children 2>/dev/null) 2>/dev/null || true
+        wait $2 || true
+        exit $rc
+      }
+      keepalive_file=\"$(mktemp)\"
+      while [[ -f \"$keepalive_file\" ]]; do
+        echo 'Migrating data from old database...'
+        sleep 60
+      done &
+      keepalive_pid=$!
+      trap 'end_keepalive \"$keepalive_file\" \"$keepalive_pid\"' EXIT SIGINT SIGTERM
+      echo keepalive_pid: $keepalive_pid
       set -e -o pipefail
       PGPASSWORD='{{ awx_old_postgres_pass }}' {{ pgdump }} | PGPASSWORD='{{ awx_postgres_pass }}' {{ pg_restore }}
+      set +e +o pipefail
       echo 'Successful'
-      """
+      "
   no_log: "{{ no_log }}"
   register: data_migration
-  failed_when: "'Successful' not in data_migration.stdout"
 
 - name: Set flag signifying that this instance has been migrated
   set_fact:


### PR DESCRIPTION
##### SUMMARY
This PR supercedes:
* https://github.com/ansible/awx-operator/pull/1535
* https://github.com/ansible/awx-operator/pull/1530


 - pg_restore is silent and if the data migration takes longer than 15 minute exec/rsh to the postgres pod (through which we run the command) will idle timeout
 - This PR adds a background process that prints keepalive messages during the migration process to keep the exec/rsh alive

    Co-Authored-By: Hao Liu <haoli@redhat.com>
    Co-Authored-By: Rick Elrod <rick@elrod.me>

##### ISSUE TYPE

 - Bug, Docs Fix or other nominal change
