### PR TITLE
Modify how pg password is set in postgres pod

### DIFF
--- a/roles/installer/tasks/migrate_data.yml
+++ b/roles/installer/tasks/migrate_data.yml
@@ -13,6 +13,26 @@
     awx_old_postgres_host: "{{ old_pg_config['resources'][0]['data']['host'] | b64decode }}"
   no_log: "{{ no_log }}"
 
+- name: Patch Postgres StatefulSet to add password env variable
+  k8s:
+    state: present
+    definition:
+      apiVersion: apps/v1
+      kind: StatefulSet
+      metadata:
+        name: '{{ ansible_operator_meta.name }}-postgres-{{ supported_pg_version }}'
+        namespace: '{{ ansible_operator_meta.namespace }}'
+      spec:
+        template:
+          spec:
+            containers:
+              - name: postgres
+                env:
+                  - name: PGPASSWORD_OLD
+                    value: '{{ awx_old_postgres_pass }}'
+  merge_type:
+    - strategic-merge
+
 - name: Set Default label selector for custom resource generated postgres
   set_fact:
     postgres_label_selector: "app.kubernetes.io/instance=postgres-{{ supported_pg_version }}-{{ ansible_operator_meta.name }}"
@@ -76,7 +96,7 @@
       trap 'end_keepalive \"$keepalive_file\" \"$keepalive_pid\"' EXIT SIGINT SIGTERM
       echo keepalive_pid: $keepalive_pid
       set -e -o pipefail
-      PGPASSWORD='{{ awx_old_postgres_pass }}' {{ pgdump }} | PGPASSWORD='{{ awx_postgres_pass }}' {{ pg_restore }}
+      PGPASSWORD=\"$PGPASSWORD_OLD\" {{ pgdump }} |  PGPASSWORD=\"$POSTGRES_PASSWORD\" {{ pg_restore }}
       set +e +o pipefail
       echo 'Successful'
       "

--- a/roles/installer/tasks/migrate_data.yml
+++ b/roles/installer/tasks/migrate_data.yml
@@ -59,14 +59,29 @@
     namespace: "{{ ansible_operator_meta.namespace }}"
     pod: "{{ postgres_pod_name }}"
     command: |
-      bash -c """
+      bash -c "
+      function end_keepalive {
+        rc=$?
+        rm -f \"$1\"
+        kill $(cat /proc/$2/task/$2/children 2>/dev/null) 2>/dev/null || true
+        wait $2 || true
+        exit $rc
+      }
+      keepalive_file=\"$(mktemp)\"
+      while [[ -f \"$keepalive_file\" ]]; do
+        echo 'Migrating data from old database...'
+        sleep 1
+      done &
+      keepalive_pid=$!
+      trap 'end_keepalive \"$keepalive_file\" \"$keepalive_pid\"' EXIT SIGINT SIGTERM
+      echo keepalive_pid: $keepalive_pid
       set -e -o pipefail
       PGPASSWORD='{{ awx_old_postgres_pass }}' {{ pgdump }} | PGPASSWORD='{{ awx_postgres_pass }}' {{ pg_restore }}
+      set +e +o pipefail
       echo 'Successful'
-      """
+      "
   no_log: "{{ no_log }}"
   register: data_migration
-  failed_when: "'Successful' not in data_migration.stdout"
 
 - name: Set flag signifying that this instance has been migrated
   set_fact:


### PR DESCRIPTION
##### SUMMARY

    Modify how PG password env vars are set to prevent issues with special characters
     - Certain characters like quotations would not be interpreted correctly
       if passed through bash. This avoids that issue.


##### ISSUE TYPE

 - Bug, Docs Fix or other nominal change
