### PR TITLE
Adding default resource limits for all containers

### DIFF
--- a/roles/installer/defaults/main.yml
+++ b/roles/installer/defaults/main.yml
@@ -291,17 +291,25 @@ task_resource_requirements:
   requests:
     cpu: 100m
     memory: 128Mi
+  limits:
+    cpu: 2000m
+    memory: 4Gi
 
 web_resource_requirements:
   requests:
     cpu: 100m
     memory: 128Mi
+  limits:
+    cpu: 1000m
+    memory: 4Gi
 
 ee_resource_requirements:
   requests:
     cpu: 100m
     memory: 64Mi
-
+  limits:
+    cpu: 1000m
+    memory: 4Gi
 # TODO: validate default resource requirements
 
 # Customize CSRF options
@@ -315,17 +323,24 @@ redis_resource_requirements:
   requests:
     cpu: 50m
     memory: 64Mi
-
+  limits:
+    cpu: 1000m
+    memory: 4Gi
 rsyslog_resource_requirements:
   requests:
     cpu: 100m
     memory: 128Mi
+  limits:
+    cpu: 1000m
+    memory: 2Gi
 
 init_container_resource_requirements:
   requests:
     cpu: 100m
     memory: 128Mi
-
+  limits:
+    cpu: 1000m
+    memory: 2Gi
 # Add extra environment variables to the AWX task/web containers. Specify as
 # literal block. E.g.:
 # task_extra_env: |
@@ -375,10 +390,16 @@ postgres_resource_requirements:
   requests:
     cpu: 10m
     memory: 64Mi
+  limits:
+    cpu: 2000m
+    memory: 4Gi
 postgres_init_container_resource_requirements:
   requests:
     cpu: 10m
     memory: 64Mi
+  limits:
+    cpu: 1000m
+    memory: 2Gi
 # Assign a preexisting priority class to the postgres pod
 postgres_priority_class: ''
 postgres_data_path: '/var/lib/postgresql/data/pgdata'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Adding default resource limits to all containers. 
REASON: by default only resource requests are defined when creating an AWX instance, AWX pod won't be created created when ResourceQuota is present on the namespace when no direct logs from the operator. 


<!---
If you are fixing an existing issue, please include "fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New or Enhanced Feature

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
-->
limit values can be revisited to increase/decrease them .

