### PR TITLE
Deployment name should be referenced, not the restore object name

### DIFF
--- a/roles/restore/tasks/postgres.yml
+++ b/roles/restore/tasks/postgres.yml
@@ -50,7 +50,7 @@
   k8s_info:
     api_version: apps/v1
     kind: Deployment
-    name: "{{ ansible_operator_meta.namespace }}-task"
+    name: "{{ deployment_name }}-task"
     namespace: "{{ ansible_operator_meta.namespace }}"
   register: this_deployment
 
@@ -63,8 +63,8 @@
     replicas: 0
     wait: yes
   loop:
-    - "{{ ansible_operator_meta.name }}-task"
-    - "{{ ansible_operator_meta.name }}-web"
+    - "{{ deployment_name }}-task"
+    - "{{ deployment_name }}-web"
   when: this_deployment['resources'] | length
 
 - name: Set full resolvable host name for postgres pod


### PR DESCRIPTION
##### SUMMARY


The awx-operator is currently broken:
* [https://github.com/ansible/awx-operator/commit/7218e427717b0a75e087d8fe95e69dca04127ac2#diff-c17f7d066e967f544578ad5[…]b33f117e83a57805119725L61-R67](https://github.com/ansible/awx-operator/commit/7218e427717b0a75e087d8fe95e69dca04127ac2#diff-c17f7d066e967f544578ad54f2bfaf27078cb1316bb33f117e83a57805119725L61-R67)
* 
That should be deployment_name (name of new deployment), not ansible_operator_meta.name (name or restore)

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bug, Docs Fix or other nominal change
