### PR TITLE
Enforce that Projects Persistance SC is only set to be RWX

### DIFF
--- a/config/crd/bases/awx.ansible.com_awxs.yaml
+++ b/config/crd/bases/awx.ansible.com_awxs.yaml
@@ -1776,9 +1776,11 @@ spec:
                 default: 8Gi
                 type: string
               projects_storage_access_mode:
-                description: AccessMode for the /var/lib/projects PersistentVolumeClaim
+                description: (Deprecated) AccessMode for the /var/lib/projects PersistentVolumeClaim
                 default: ReadWriteMany
                 type: string
+                enum:
+                - ReadWriteMany
               csrf_cookie_secure:
                 description: Set csrf cookie secure mode for web
                 type: string

--- a/config/manifests/bases/awx-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/awx-operator.clusterserviceversion.yaml
@@ -675,6 +675,7 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:fieldDependency:projects_use_existing_claim:_No_
         - urn:alm:descriptor:com.tectonic.ui:text
+        - urn:alm:descriptor:com.tectonic.ui:hidden
       - displayName: Task Command
         path: task_command
         x-descriptors:


### PR DESCRIPTION
##### SUMMARY

Now that web and task are now separate deployments, ReadWriteOnce is no longer a valid option for the projects persistence feature since the mounted `/projects` directory will be accessed by pods from different deployments now.  ReadWriteMany is required.  As such, we should validate that this is set as ReadWriteMany, and deprecate this parameter in the future. 

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bug, Docs Fix or other nominal change
