### PR TITLE
Add sample AWX CR with resource limits for environments with Resource…

### DIFF
--- a/config/samples/awx_v1beta1_awx_resource_limits.yaml
+++ b/config/samples/awx_v1beta1_awx_resource_limits.yaml
@@ -1,0 +1,55 @@
+---
+apiVersion: awx.ansible.com/v1beta1
+kind: AWX
+metadata:
+  name: awx-with-limits
+spec:
+  task_resource_requirements:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 2000m
+      memory: 4Gi
+  web_resource_requirements:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 1000m
+      memory: 4Gi
+  ee_resource_requirements:
+    requests:
+      cpu: 100m
+      memory: 64Mi
+    limits:
+      cpu: 1000m
+      memory: 4Gi
+  redis_resource_requirements:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+    limits:
+      cpu: 1000m
+      memory: 4Gi
+  rsyslog_resource_requirements:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 1000m
+      memory: 2Gi
+  init_container_resource_requirements:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 1000m
+      memory: 2Gi
+  postgres_init_container_resource_requirements:
+    requests:
+      cpu: 10m
+      memory: 64Mi
+    limits:
+      cpu: 1000m
+      memory: 2Gi

--- a/docs/user-guide/advanced-configuration/containers-resource-requirements.md
+++ b/docs/user-guide/advanced-configuration/containers-resource-requirements.md
@@ -26,7 +26,13 @@ The resource requirements for both, the task and the web containers are configur
 | -------------------------- | ------------------------------------------------ | ------------------------------------ |
 | web_resource_requirements  | Web container resource requirements              | requests: {cpu: 100m, memory: 128Mi} |
 | task_resource_requirements | Task container resource requirements             | requests: {cpu: 100m, memory: 128Mi} |
-| ee_resource_requirements   | EE control plane container resource requirements | requests: {cpu: 100m, memory: 128Mi} |
+| ee_resource_requirements   | EE control plane container resource requirements | requests: {cpu: 50m, memory: 64Mi} |
+| redis_resource_requirements   | Redis container resource requirements | requests: {cpu: 100m, memory: 128Mi} |
+| postgres_resource_requirements   | Postgres container resource requirements | requests: {cpu: 10m, memory: 64Mi} |
+| rsyslog_resource_requirements   | Rsyslog container resource requirements | requests: {cpu: 100m, memory: 128Mi} |
+| init_container_resource_requirements   | Init Container resource requirements | requests: {cpu: 100m, memory: 128Mi} |
+| postgres_init_container_resource_requirements   | Postgres Init Container resource requirements | requests: {cpu: 10m, memory: 64Mi} |
+
 
 Example of customization could be:
 
@@ -34,31 +40,63 @@ Example of customization could be:
 ---
 spec:
   ...
-  web_resource_requirements:
-    requests:
-      cpu: 250m
-      memory: 2Gi
-      ephemeral-storage: 100M
-    limits:
-      cpu: 1000m
-      memory: 4Gi
-      ephemeral-storage: 500M
+
   task_resource_requirements:
     requests:
-      cpu: 250m
-      memory: 1Gi
+      cpu: 100m
+      memory: 128Mi
       ephemeral-storage: 100M
     limits:
       cpu: 2000m
-      memory: 2Gi
+      memory: 4Gi
       ephemeral-storage: 500M
+  web_resource_requirements:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 1000m
+      memory: 4Gi
   ee_resource_requirements:
     requests:
-      cpu: 250m
-      memory: 100Mi
-      ephemeral-storage: 100M
+      cpu: 100m
+      memory: 64Mi
     limits:
-      cpu: 500m
+      cpu: 1000m
+      memory: 4Gi
+  redis_resource_requirements:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+    limits:
+      cpu: 1000m
+      memory: 4Gi
+  rsyslog_resource_requirements:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 1000m
       memory: 2Gi
-      ephemeral-storage: 500M
+  init_container_resource_requirements:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 1000m
+      memory: 2Gi
+  postgres_init_container_resource_requirements:
+    requests:
+      cpu: 10m
+      memory: 64Mi
+    limits:
+      cpu: 1000m
+      memory: 2Gi
 ```
+
+
+#### Limits and ResourceQuotas
+
+If the cluster you are deploying in has a ResoruceQuota, you will need to configure resource limits for all of the pods deployed in that cluster. This can be done for AWX pods on the AWX spec in the manner shown above.
+
+There is an example you can use in [`config/samples/awx_v1beta1_awx_resource_limits.yaml`](../../../config/samples/awx_v1beta1_awx_resource_limits.yaml).


### PR DESCRIPTION
##### SUMMARY
Add sample AWX CR with resource limits for environments with ResourceQuotas

This is follow-up for this PR which attempted to add the limits to the defaults.  We decided against this as it would break some existing deployments in the wild.  
* https://github.com/ansible/awx-operator/pull/1541 cc @imedaouidene 

##### ISSUE TYPE

 - Bug, Docs Fix or other nominal change


