### PR TITLE
Add docs for publishing new operator versions to OperatorHub

### DIFF
--- a/docs/contributors-guide/release-process.md
+++ b/docs/contributors-guide/release-process.md
@@ -8,3 +8,18 @@ After the draft release is created, publish it and the [Promote AWX Operator ima
 
 - Publish image to Quay
 - Release Helm chart
+
+After the GHA is complete, the final step is to run the [publish-to-operator-hub.sh](./hack/publish-to-operator-hub.sh) script, which will create a PR in the following repos to add the new awx-operator bundle version to OperatorHub:
+* https://github.com/k8s-operatorhub/community-operators (community operator index)
+* https://github.com/redhat-openshift-ecosystem/community-operators-prod (operator index shipped with Openshift)
+
+The usage is documented in the script itself, but here is an example of how you would use the script to publish the 2.5.3 awx-opeator bundle to OperatorHub.
+Note that you need to specify the version being released, as well as the previous version. This is because the bundle has a pointer to the previous version that is it being upgrade from. This is used by OLM to create a dependency graph.
+
+```bash
+$ VERSION=2.5.3 PREV_VERSION=2.5.2 ./publish-operator.sh
+```
+
+> Note: There are some quirks with running this on OS X that still need to be fixed, but the script runs smoothly on linux.
+
+As soon as CI completes successfully, the PR's will be auto-merged. Please remember to monitor those PR's to make sure that CI passes, sometimes it needs a retry.


### PR DESCRIPTION
##### SUMMARY

For the last dozen releases or so, we have run the following script after the Release GHA in order to put publish the operator to OperatorHub.  Ultimately, it would be great to have this as part of the GHA, but for the time being, let's call this out in the Release docs so that it doesn't get forgotten. 

##### ISSUE TYPE

 - Bug, Docs Fix or other nominal change
