### PR TITLE
fix: change type for precreate_partition_hours from string to integer

### DIFF
--- a/config/crd/bases/awx.ansible.com_awxbackups.yaml
+++ b/config/crd/bases/awx.ansible.com_awxbackups.yaml
@@ -92,7 +92,8 @@ spec:
                 type: string
               precreate_partition_hours:
                 description: Number of hours worth of events table partitions to precreate before backup to avoid pg_dump locks.
-                type: string
+                type: integer
+                format: int32
               image_pull_policy:
                 description: The image pull policy
                 type: string

--- a/config/manifests/bases/awx-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/awx-operator.clusterserviceversion.yaml
@@ -53,7 +53,7 @@ spec:
       - displayName: Precreate Partition Hours
         path: precreate_partition_hours
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:text
+        - urn:alm:descriptor:com.tectonic.ui:number
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:hidden
       - displayName: Database Backup Label Selector


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Closes #1570 

Change the type for `precreate_partition_hours` from `string` (`text`) to `integer` (`number`).

<!---
If you are fixing an existing issue, please include "fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
-->

Tested by deploying AWX Operator that includes this PR and creating `AWXBackup` with following spec:

```yaml
---
apiVersion: awx.ansible.com/v1beta1
kind: AWXBackup
metadata:
  name: awxbackup-2023-09-29
  namespace: awx
spec:
  deployment_name: awx
  precreate_partition_hours: 0
```

I can confirm that the task "Precreate database partitions" is skipped as expected and the backup is completed.

```bash
$ kubectl -n awx logs -f deployments/awx-operator-controller-manager
...
{"level":"info","ts":"2023-09-29T13:13:00Z","logger":"logging_event_handler","msg":"[playbook task start]","name":"awxbackup-2023-09-29","namespace":"awx","gvk":"awx.ansible.com/v1beta1, Kind=AWXBackup","event_type":"playbook_on_task_start","job":"2816938822038431376","EventData.Name":"backup : Precreate database partitions"}

--------------------------- Ansible Task StdOut -------------------------------

TASK [backup : Precreate database partitions] **********************************
task path: /opt/ansible/roles/backup/tasks/postgres.yml:110

-------------------------------------------------------------------------------
{"level":"info","ts":"2023-09-29T13:13:00Z","logger":"logging_event_handler","msg":"[playbook task start]","name":"awxbackup-2023-09-29","namespace":"awx","gvk":"awx.ansible.com/v1beta1, Kind=AWXBackup","event_type":"playbook_on_task_start","job":"2816938822038431376","EventData.Name":"backup : Write pg_dump to backup on PVC"}
...

TASK [backup : Run finalizer tasks] ********************************************
task path: /opt/ansible/roles/backup/tasks/main.yml:6

-------------------------------------------------------------------------------
{"level":"info","ts":"2023-09-29T13:13:48Z","logger":"runner","msg":"Ansible-runner exited successfully","job":"8832152870054323618","name":"awxbackup-2023-09-29","namespace":"awx"}

----- Ansible Task Status Event StdOut (awx.ansible.com/v1beta1, Kind=AWXBackup, awxbackup-2023-09-29/awx) -----


PLAY RECAP *********************************************************************
localhost                  : ok=7    changed=0    unreachable=0    failed=0    skipped=9    rescued=0    ignored=0   

----------
```