### PR TITLE
fix: correct label selector to find task pod

### DIFF
--- a/roles/backup/tasks/postgres.yml
+++ b/roles/backup/tasks/postgres.yml
@@ -88,7 +88,7 @@
     kind: Pod
     namespace: '{{ ansible_operator_meta.namespace }}'
     label_selectors:
-      - "app.kubernetes.io/name={{ ansible_operator_meta.name }}-task"
+      - "app.kubernetes.io/name={{ deployment_name }}-task"
       - "app.kubernetes.io/managed-by={{ deployment_type }}-operator"
       - "app.kubernetes.io/component={{ deployment_type }}"
     field_selectors:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

Closes #1572

Correct label selector to find task pod to use AWX CR name instead of AWXBackup CR name.

<!---
If you are fixing an existing issue, please include "fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
-->

Tested by deploying AWX Operator that includes this PR and creating `AWXBackup` with following spec:

```yaml
---
apiVersion: awx.ansible.com/v1beta1
kind: AWXBackup
metadata:
  name: awxbackup-2023-09-29
  namespace: awx
spec:
  deployment_name: awx
```

I can confirm that the task "Precreate database partitions" is finished and the backup is completed with success.

```bash
$ kubectl -n awx logs -f deployments/awx-operator-controller-manager
...
{"level":"info","ts":"2023-09-29T15:04:31Z","logger":"logging_event_handler","msg":"[playbook task start]","name":"awxbackup-2023-09-29","namespace":"awx","gvk":"awx.ansible.com/v1beta1, Kind=AWXBackup","event_type":"playbook_on_task_start","job":"3182540303028798906","EventData.Name":"backup : Get the current resource task pod information."}

--------------------------- Ansible Task StdOut -------------------------------

TASK [backup : Get the current resource task pod information.] *****************
task path: /opt/ansible/roles/backup/tasks/postgres.yml:85

-------------------------------------------------------------------------------
{"level":"info","ts":"2023-09-29T15:04:32Z","logger":"proxy","msg":"cache miss: /v1, Kind=PodList err-Index with name field:status.phase does not exist"}
{"level":"info","ts":"2023-09-29T15:04:32Z","logger":"logging_event_handler","msg":"[playbook task start]","name":"awxbackup-2023-09-29","namespace":"awx","gvk":"awx.ansible.com/v1beta1, Kind=AWXBackup","event_type":"playbook_on_task_start","job":"3182540303028798906","EventData.Name":"backup : Precreate database partitions"}

--------------------------- Ansible Task StdOut -------------------------------

TASK [backup : Precreate database partitions] **********************************
task path: /opt/ansible/roles/backup/tasks/postgres.yml:110

-------------------------------------------------------------------------------
{"level":"info","ts":"2023-09-29T15:04:35Z","logger":"logging_event_handler","msg":"[playbook task start]","name":"awxbackup-2023-09-29","namespace":"awx","gvk":"awx.ansible.com/v1beta1, Kind=AWXBackup","event_type":"playbook_on_task_start","job":"3182540303028798906","EventData.Name":"backup : Write pg_dump to backup on PVC"}
...

--------------------------- Ansible Task StdOut -------------------------------

TASK [backup : Run finalizer tasks] ********************************************
task path: /opt/ansible/roles/backup/tasks/main.yml:6

-------------------------------------------------------------------------------
{"level":"info","ts":"2023-09-29T15:04:50Z","logger":"runner","msg":"Ansible-runner exited successfully","job":"7542177016972752309","name":"awxbackup-2023-09-29","namespace":"awx"}

----- Ansible Task Status Event StdOut (awx.ansible.com/v1beta1, Kind=AWXBackup, awxbackup-2023-09-29/awx) -----


PLAY RECAP *********************************************************************
localhost                  : ok=7    changed=0    unreachable=0    failed=0    skipped=9    rescued=0    ignored=0   
```