### PR TITLE
Adding keepalive while doing pg_dump

### DIFF
--- a/roles/backup/tasks/postgres.yml
+++ b/roles/backup/tasks/postgres.yml
@@ -134,11 +134,27 @@
     namespace: "{{ backup_pvc_namespace }}"
     pod: "{{ ansible_operator_meta.name }}-db-management"
     command: |
-      bash -c """
+      bash -c "
+      function end_keepalive {
+        rc=$?
+        rm -f \"$1\"
+        kill $(cat /proc/$2/task/$2/children 2>/dev/null) 2>/dev/null || true
+        wait $2 || true
+        exit $rc
+      }
+      keepalive_file=\"$(mktemp)\"
+      while [[ -f \"$keepalive_file\" ]]; do
+        echo 'Dumping data from database...'
+        sleep 60
+      done &
+      keepalive_pid=$!
+      trap 'end_keepalive \"$keepalive_file\" \"$keepalive_pid\"' EXIT SIGINT SIGTERM
+      echo keepalive_pid: $keepalive_pid
       set -e -o pipefail
       PGPASSWORD='{{ awx_postgres_pass }}' {{ pgdump }} > {{ backup_dir }}/tower.db
+      set +e +o pipefail
       echo 'Successful'
-      """
+      "
   register: data_migration
   no_log: "{{ no_log }}"
   failed_when: "'Successful' not in data_migration.stdout"


### PR DESCRIPTION
##### SUMMARY
fixes #1435

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION
Manual test performed
- on openshift cluster
- build and deploy awx-operator with code change with 
```
make docker-build docker-push deploy IMAGE_TAG_BASE=quay.io/haoliu/awx-operator NAMESPACE=backup-test
```
- create awx instance with 
```
ansible-playbook ansible/instantiate-awx-deployment.yml \ 
    -e image=ghcr.io/ansible/awx \
    -e image_version=devel \
    -e image_pull_policy=Always \
    -e namespace=backup-test \
    -e ingress_type=route
```
- test backup by creating awxbackup
```
apiVersion: awx.ansible.com/v1beta1
kind: AWXBackup
name: example-backup
namespace: backup-test
spec:
  deployment_name: awx
```
- 🟢 verifying that the backup completed successfully
```
status:
  ...
  conditions:
  ...
  - lastTransitionTime: "2023-10-06T14:51:06Z"
    reason: Successful
    status: "True"
    type: Successful
```
- test backup can be used in restore by creating awxrestore using the test backup
```
apiVersion: awx.ansible.com/v1beta1
kind: AWXRestore
name: example-restore
namespace: backup-test
spec:
  backup_name: example-backup
  backup_source: Backup CR
  deployment_name: awx
```
- 🟢 verify that restore with the backup completed successfully by checking the status of example-restore
```
status:
  conditions:
  ...
  - lastTransitionTime: "2023-10-06T15:15:01Z"
    reason: Successful
    status: "True"
    type: Successful
  restoreComplete: true
```
- 🟢 verify awx is still functional after restore from backup 


