### PR TITLE
Add background keepalive to awx-manage migrate

### DIFF
--- a/roles/installer/tasks/install.yml
+++ b/roles/installer/tasks/install.yml
@@ -96,8 +96,26 @@
     namespace: "{{ ansible_operator_meta.namespace }}"
     pod: "{{ awx_task_pod_name }}"
     container: "{{ ansible_operator_meta.name }}-task"
-    command: >-
-      bash -c "awx-manage migrate --noinput"
+    command: |
+      bash -c "
+      function end_keepalive {
+        rc=$?
+        rm -f \"$1\"
+        kill $(cat /proc/$2/task/$2/children 2>/dev/null) 2>/dev/null || true
+        wait $2 || true
+        exit $rc
+      }
+      keepalive_file=\"$(mktemp)\"
+      while [[ -f \"$keepalive_file\" ]]; do
+        echo 'Database schema migration in progress...'
+        sleep 60
+      done &
+      keepalive_pid=$!
+      trap 'end_keepalive \"$keepalive_file\" \"$keepalive_pid\"' EXIT SIGINT SIGTERM
+      echo keepalive_pid: $keepalive_pid
+      awx-manage migrate --noinput
+      echo 'Successful'
+      "
   register: migrate_result
   when:
   - awx_task_pod_name != ''


### PR DESCRIPTION
##### SUMMARY
related to https://github.com/ansible/awx/issues/14314 and https://github.com/ansible/awx/pull/14566

each step of the migration can run for undetermined amount of time

there's no output between migration steps so the exec connection might be killed due to idle

adding background keepalive to prevent exec to be killed due to idle connection


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
