### PR TITLE
Install operator-sdk if needed

### DIFF
--- a/.github/workflows/feature.yml
+++ b/.github/workflows/feature.yml
@@ -29,25 +29,6 @@ jobs:
         run: |
           echo "IMAGE_TAG_BASE=ghcr.io/${OWNER_LC}/awx-operator" >>${GITHUB_ENV}
 
-      - name: Set ARCH environment variable
-        run: |
-          echo "ARCH=$(case $(uname -m) in x86_64) echo -n amd64 ;; aarch64) echo -n arm64 ;; *) echo -n $(uname -m) ;; esac)" >>${GITHUB_ENV}
-
-      - name: Set OS environment variable
-        run: |
-          echo "OS=$(uname | awk '{print tolower($0)}')" >>${GITHUB_ENV}
-
-      - name: Install operator-sdk
-        run: |
-          echo "Installing operator-sdk ${OPERATOR_SDK_DL_URL}" && \
-          curl -LO ${OPERATOR_SDK_DL_URL}/operator-sdk_${OS}_${ARCH} && \
-          chmod +x operator-sdk_${OS}_${ARCH} && \
-          sudo mkdir -p /usr/local/bin/ && \
-          sudo mv operator-sdk_${OS}_${ARCH} /usr/local/bin/operator-sdk && \
-          operator-sdk version
-        env:
-          OPERATOR_SDK_DL_URL: https://github.com/operator-framework/operator-sdk/releases/download/v1.26.0
-
       - name: Log in to registry
         run: |
           echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin


### PR DESCRIPTION
taken inspiration from other tools used in this repo like "YQ" and "JQ" where we try to install it in bin/ if it does not exist

this should let you run any of the make command that pre-req operator-sdk without having operator-sdk installed already

also update operator-sdk version to match current opeartor sdk version

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
