### PR TITLE
1590 flag to control execution of the chmod/chown on backup data file

### DIFF
--- a/config/crd/bases/awx.ansible.com_awxbackups.yaml
+++ b/config/crd/bases/awx.ansible.com_awxbackups.yaml
@@ -78,6 +78,10 @@ spec:
               clean_backup_on_delete:
                 description: Flag to indicate if backup should be deleted on PVC if AWXBackup object is deleted
                 type: boolean
+              set_permissions_on_backup_dump:
+                description: Flag to indicate if backup dump file mode should be set with '600' with ownership to ':root'
+                type: boolean
+                default: true
               pg_dump_suffix:
                 description: Additional parameters for the pg_dump command
                 type: string

--- a/roles/backup/defaults/main.yml
+++ b/roles/backup/defaults/main.yml
@@ -17,6 +17,9 @@ no_log: true
 # Variable to set when you want backups to be cleaned up when the CRD object is deleted
 clean_backup_on_delete: false
 
+# Change produced backup dump file mode to '600' and permissions to ':root'
+# set to false to rely of defaults configured on db-management backup pod's securityContext
+set_permissions_on_backup_dump: true
 
 # Add a nodeSelector for the Postgres pods to backup.
 # Specify as literal block. E.g.:

--- a/roles/backup/tasks/postgres.yml
+++ b/roles/backup/tasks/postgres.yml
@@ -76,6 +76,7 @@
     pod: "{{ ansible_operator_meta.name }}-db-management"
     command: >-
       bash -c "chmod 660 {{ backup_dir }}/tower.db && chown :root {{ backup_dir }}/tower.db"
+  when: set_permissions_on_backup_dump | bool
 
 - name: Set full resolvable host name for postgres pod
   set_fact:


### PR DESCRIPTION
##### SUMMARY
Depends on a storage driver configured for Backup PVC it might not be possible to change file mode or ownership on the backup file produced. This change introduces new flag that can turn off "chmod/chown".
If we run db-management pod as root, it does not matter that PVC volume mount would allow root group ownership.
Without pod's securityContext/fsGroup specified it would normally be nobody:nobody, instead of root:root. This "chown :root" might fail with some k8s storage drivers.

##### ISSUE TYPE
 - Bug

##### ADDITIONAL INFORMATION
See [Issue 1590](https://github.com/ansible/awx-operator/issues/1590)
