### PR TITLE
1586: awx-operator restore from PVC is not working

### DIFF
--- a/roles/restore/tasks/init.yml
+++ b/roles/restore/tasks/init.yml
@@ -34,7 +34,7 @@
         backup_pvc: "{{ this_backup['resources'][0]['status']['backupClaim'] }}"
         backup_dir: "{{ this_backup['resources'][0]['status']['backupDirectory'] }}"
   when:
-    - backup_name != '' or backup_name is defined
+    - backup_name is defined and backup_name != ''
 
 # Check to make sure provided pvc exists, error loudly if not.  Otherwise, the management pod will just stay in pending state forever.
 - name: Check provided PVC exists


### PR DESCRIPTION
##### SUMMARY
An upgrade to Operator SDK 1.31.x that uses Ansible 2.15 caused 
awx-operator/roles/restore/tasks/init.yml conditions on "Set variables from awxbackup object statuses if provided" block to fail.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION
See [Issue 1586](https://github.com/ansible/awx-operator/issues/1586)
