### PR TITLE
1587: drop/create database DB before restoring it

### DIFF
--- a/roles/restore/tasks/postgres.yml
+++ b/roles/restore/tasks/postgres.yml
@@ -82,6 +82,26 @@
       -p {{ awx_postgres_port }}
   no_log: "{{ no_log }}"
 
+- name: Set drop db command
+  set_fact:
+    pg_drop_db: >-
+      echo 'DROP DATABASE {{ awx_postgres_database }} WITH (FORCE);' | PGPASSWORD='{{ awx_postgres_pass }}' psql
+      -U {{ awx_postgres_user }}
+      -h {{ resolvable_db_host }}
+      -d postgres
+      -p {{ awx_postgres_port }}
+  no_log: "{{ no_log }}"
+
+- name: Set create db command
+  set_fact:
+    pg_create_db: >-
+      echo 'CREATE DATABASE {{ awx_postgres_database }} WITH OWNER = {{ awx_postgres_user }};' | PGPASSWORD='{{ awx_postgres_pass }}' psql
+      -U {{ awx_postgres_user }}
+      -h {{ resolvable_db_host }}
+      -d postgres
+      -p {{ awx_postgres_port }}
+  no_log: "{{ no_log }}"
+
 - name: Restore database dump to the new postgresql container
   k8s_exec:
     namespace: "{{ backup_pvc_namespace }}"
@@ -104,6 +124,8 @@
       trap 'end_keepalive \"$keepalive_file\" \"$keepalive_pid\"' EXIT SIGINT SIGTERM
       echo keepalive_pid: $keepalive_pid
       set -e -o pipefail
+      {{ pg_drop_db }}
+      {{ pg_create_db }}
       cat {{ backup_dir }}/tower.db | PGPASSWORD='{{ awx_postgres_pass }}' {{ pg_restore }}
       set +e +o pipefail
       echo 'Successful'


### PR DESCRIPTION
##### SUMMARY
Currently we require re-create PVC used by Postgres or remove all data manually before running restore. See https://github.com/ansible/awx-operator/tree/devel/roles/restore#requirements 

This might not be always possible neither it is convenient for end users. This PR introduces simpler solution:
* Force drop existing database
* Re-create empty database
* Resume as usual (pg_resore & Co)

##### ISSUE TYPE
 - New or Enhanced Feature

##### ADDITIONAL INFORMATION
See [Issue 1587](https://github.com/ansible/awx-operator/issues/1587)
