### PR TITLE
Hardcode the link for the operatorhub publish script

### DIFF
--- a/docs/contributors-guide/release-process.md
+++ b/docs/contributors-guide/release-process.md
@@ -9,7 +9,7 @@ After the draft release is created, publish it and the [Promote AWX Operator ima
 - Publish image to Quay
 - Release Helm chart
 
-After the GHA is complete, the final step is to run the [publish-to-operator-hub.sh](./hack/publish-to-operator-hub.sh) script, which will create a PR in the following repos to add the new awx-operator bundle version to OperatorHub:
+After the GHA is complete, the final step is to run the [publish-to-operator-hub.sh](https://github.com/ansible/awx-operator/blob/devel/hack/publish-to-operator-hub.sh) script, which will create a PR in the following repos to add the new awx-operator bundle version to OperatorHub:
 * https://github.com/k8s-operatorhub/community-operators (community operator index)
 * https://github.com/redhat-openshift-ecosystem/community-operators-prod (operator index shipped with Openshift)
 


### PR DESCRIPTION
The docsite will not pick up the relative link because it is outside of the docs/ directory.  This fixes that.

##### SUMMARY

When building the docsite, the following warning is shown.

```
WARNING -  Doc file 'contributors-guide/release-process.md' contains a relative link '../../hack/publish-to-operator-hub.sh', but the
           target '../hack/publish-to-operator-hub.sh' is not found among documentation files.

```

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bug, Docs Fix or other nominal change

