### PR TITLE
Revert "Stage and promote operator catalog and bundle (#1598)"

### DIFF
--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -22,28 +22,11 @@ jobs:
 
       - name: Re-tag and promote awx-operator image
         run: |
-          # Promote operator image
           docker pull ghcr.io/${{ github.repository }}:${{ github.event.release.tag_name }}
-          docker tag \
-            ghcr.io/${{ github.repository }}:${{ github.event.release.tag_name }} \
-            quay.io/${{ github.repository }}:${{ github.event.release.tag_name }}
-          docker tag \
-            ghcr.io/${{ github.repository }}:${{ github.event.release.tag_name }} \
-            quay.io/${{ github.repository }}:latest
+          docker tag ghcr.io/${{ github.repository }}:${{ github.event.release.tag_name }} quay.io/${{ github.repository }}:${{ github.event.release.tag_name }}
+          docker tag ghcr.io/${{ github.repository }}:${{ github.event.release.tag_name }} quay.io/${{ github.repository }}:latest
           docker push quay.io/${{ github.repository }}:${{ github.event.release.tag_name }}
           docker push quay.io/${{ github.repository }}:latest
-          # Promote bundle image
-          docker pull ghcr.io/${{ github.repository }}-bundle:v${{ github.event.release.tag_name }}
-          docker tag \
-            ghcr.io/${{ github.repository }}-bundle:v${{ github.event.release.tag_name }} \
-            quay.io/${{ github.repository }}-bundle:v${{ github.event.release.tag_name }}
-          docker push quay.io/${{ github.repository }}-bundle:v${{ github.event.release.tag_name }}
-          # Promote catalog image
-          docker pull ghcr.io/${{ github.repository }}-catalog:v${{ github.event.release.tag_name }}
-          docker tag \
-            ghcr.io/${{ github.repository }}-catalog:v${{ github.event.release.tag_name }} \
-            quay.io/${{ github.repository }}-catalog:v${{ github.event.release.tag_name }}
-          docker push quay.io/${{ github.repository }}-catalog:v${{ github.event.release.tag_name }}
 
       - name: Release Helm chart
         run: |

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -63,8 +63,7 @@ jobs:
           BUILD_ARGS="--build-arg DEFAULT_AWX_VERSION=${{ github.event.inputs.default_awx_version }} \
                       --build-arg OPERATOR_VERSION=${{ github.event.inputs.version }}" \
           IMAGE_TAG_BASE=ghcr.io/${{ github.repository_owner }}/awx-operator \
-          VERSION=${{ github.event.inputs.version }} \
-          make bundle docker-build docker-push bundle-build bundle-push catalog-build catalog-push
+          VERSION=${{ github.event.inputs.version }} make docker-build docker-push
 
       - name: Run test deployment
         working-directory: awx-operator


### PR DESCRIPTION
##### SUMMARY
This reverts commit d4c1fda066a290db84035a34b25250e8b0bda295.

apparently we do not run the stage workflow in THIS repo to stage the images during release process its run in the awx repo... >.<

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
