### PR TITLE
Bump kube-rbac-proxy image to v0.15.0

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -15,7 +15,7 @@ spec:
           capabilities:
             drop:
             - "ALL"
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.14.1
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.15.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"


### PR DESCRIPTION
##### SUMMARY

The kube-rbac-proxy v0.15.0 image is available.


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bug, Docs Fix or other nominal change
