### PR TITLE
Add ability to mount custom volumes in the postgres pod

### DIFF
--- a/config/crd/bases/awx.ansible.com_awxs.yaml
+++ b/config/crd/bases/awx.ansible.com_awxs.yaml
@@ -1608,6 +1608,9 @@ spec:
               web_extra_volume_mounts:
                 description: Specify volume mounts to be added to the Web container
                 type: string
+              postgres_extra_volume_mounts:
+                description: Specify volume mounts to be added to Postgres container
+                type: string
               uwsgi_processes:
                 description: Set the number of uwsgi processes to run in a web container
                 type: integer
@@ -1715,6 +1718,9 @@ spec:
                 type: array
                 items:
                   type: string
+              postgres_extra_volumes:
+                description: Specify extra volumes to add to the application pod
+                type: string
               postgres_keepalives:
                 description: Controls whether client-side TCP keepalives are used for Postgres connections.
                 default: true

--- a/config/manifests/bases/awx-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/awx-operator.clusterserviceversion.yaml
@@ -583,6 +583,18 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:hidden
+      - displayName: Postgres Extra Volumes
+        description: Specify extra volumes to add to the postgres pod
+        path: postgres_extra_volumes
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Specify volume mounts to be added to Postgres container
+        displayName: Postgres Extra Volume Mounts
+        path: postgres_extra_volume_mounts
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:hidden
       - displayName: Enable Postgres Keepalives
         path: postgres_keepalives
         x-descriptors:

--- a/roles/installer/defaults/main.yml
+++ b/roles/installer/defaults/main.yml
@@ -233,6 +233,12 @@ ee_pull_credentials_secret: ''
 #     emptyDir: {}
 extra_volumes: ''
 
+# Add extra volumes to the Postgres pod. Specify as literal block. E.g.:
+# postgres_extra_volumes: |
+#   - name: my-volume
+#     emptyDir: {}
+postgres_extra_volumes: ''
+
 # Use these image versions for Ansible AWX.
 
 _image: quay.io/ansible/awx
@@ -340,13 +346,14 @@ ee_extra_env: ''
 
 # Mount extra volumes on the AWX task/web containers. Specify as literal block.
 # E.g.:
-# task_extra_volume_mounts: ''
+# task_extra_volume_mounts: |
 #   - name: my-volume
 #     mountPath: /some/path
 task_extra_volume_mounts: ''
 web_extra_volume_mounts: ''
 rsyslog_extra_volume_mounts: ''
 ee_extra_volume_mounts: ''
+postgres_extra_volume_mounts: ''
 
 # Add a nodeSelector for the Postgres pods.
 # It must match a node's labels for the pod to be scheduled on that node.

--- a/roles/installer/templates/statefulsets/postgres.yaml.j2
+++ b/roles/installer/templates/statefulsets/postgres.yaml.j2
@@ -124,11 +124,10 @@ spec:
       tolerations:
         {{ postgres_tolerations | indent(width=8) }}
 {% endif %}
-{% if postgres_extra_volumes -%}
+{% if postgres_extra_volumes %}
       volumes:
-        {{ postgres_extra_volumes | indent(width=8, first=True) }}
+        {{ postgres_extra_volumes | indent(width=8, first=False) }}
 {% endif %}
-
   volumeClaimTemplates:
     - metadata:
         name: postgres-{{ supported_pg_version }}

--- a/roles/installer/templates/statefulsets/postgres.yaml.j2
+++ b/roles/installer/templates/statefulsets/postgres.yaml.j2
@@ -112,6 +112,9 @@ spec:
             - name: postgres-{{ supported_pg_version }}
               mountPath: '{{ postgres_data_path | dirname }}'
               subPath: '{{ postgres_data_path | dirname | basename }}'
+{% if postgres_extra_volume_mounts -%}
+            {{ postgres_extra_volume_mounts | indent(width=12, first=True) }}
+{% endif %}
           resources: {{ postgres_resource_requirements }}
 {% if postgres_selector %}
       nodeSelector:
@@ -121,6 +124,11 @@ spec:
       tolerations:
         {{ postgres_tolerations | indent(width=8) }}
 {% endif %}
+{% if postgres_extra_volumes -%}
+      volumes:
+        {{ postgres_extra_volumes | indent(width=8, first=True) }}
+{% endif %}
+
   volumeClaimTemplates:
     - metadata:
         name: postgres-{{ supported_pg_version }}


### PR DESCRIPTION
##### SUMMARY

For Posix shared memory, some users need to be able to do a custom volume mount inside the postgres container.  This makes that possible from the AWX CR spec.  

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New or Enhanced Feature

##### ADDITIONAL INFORMATION

Docs on shared memory for posix:
* https://docs.openshift.com/online/pro/dev_guide/shared_memory.html
