### PR TITLE
Omit storage resource limit if empty

### DIFF
--- a/roles/installer/templates/statefulsets/postgres.yaml.j2
+++ b/roles/installer/templates/statefulsets/postgres.yaml.j2
@@ -33,7 +33,7 @@ spec:
         app.kubernetes.io/instance: 'postgres-{{ supported_pg_version }}-{{ ansible_operator_meta.name }}'
         app.kubernetes.io/component: 'database'
         app.kubernetes.io/part-of: '{{ ansible_operator_meta.name }}'
-        app.kubernetes.io/managed-by: '{{ deployment_type }}-operator' 
+        app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
     spec:
 {% if image_pull_secret is defined %}
       imagePullSecrets:
@@ -137,7 +137,15 @@ spec:
 {% if postgres_storage_class is defined %}
         storageClassName: '{{ postgres_storage_class }}'
 {% endif %}
-        resources: {{ postgres_storage_requirements }}
+        resources:
+{% if postgres_storage_requirements.limits.storage | default("", true) %}
+          limits:
+            storage: {{ postgres_storage_requirements.limits.storage }}
+{% endif %}
+{% if postgres_storage_requirements.requests.storage | default("", true) %}
+          requests:
+            storage: {{ postgres_storage_requirements.requests.storage }}
+{% endif %}
 
 # Postgres Service.
 ---


### PR DESCRIPTION
##### SUMMARY
We discovered some weird behavior observed on later Kubernetes version (OCP 4.12+)

For some reason why we apply the templates postgres resource with

```
postgres_storage_requirements:
  limit: {}
  requests:
    storage: <x>Gi
```

the `Create Database if no database is specified` task that does the k8s apply will always think the resource is "changed" and proceed to cycle the task and web pod

This resulted in AWX pods being continuously restarted


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
