### PR TITLE
Make PostgreSQL PVC storage requirements immutable

### DIFF
--- a/config/crd/bases/awx.ansible.com_awxs.yaml
+++ b/config/crd/bases/awx.ansible.com_awxs.yaml
@@ -1680,12 +1680,19 @@ spec:
                     properties:
                       storage:
                         type: string
+                        default: 8Gi
                     type: object
+                    x-kubernetes-validations:
+                    - rule: "self == oldSelf"
+                      message: "The postgres_storage_requirements.requests field is immutable and cannot be changed once set."
                   limits:
                     properties:
                       storage:
                         type: string
                     type: object
+                    x-kubernetes-validations:
+                    - rule: "self == oldSelf"
+                      message: "The postgres_storage_requirements.limits field is immutable and cannot be changed once set."
                 type: object
               postgres_resource_requirements:
                 description: Resource requirements for the PostgreSQL container

--- a/config/manifests/bases/awx-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/awx-operator.clusterserviceversion.yaml
@@ -583,8 +583,8 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:hidden
-      - displayName: Postgres Extra Volumes
-        description: Specify extra volumes to add to the postgres pod
+      - description: Specify extra volumes to add to the postgres pod
+        displayName: Postgres Extra Volumes
         path: postgres_extra_volumes
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced


### PR DESCRIPTION
##### SUMMARY

k8s does not allow a user to modify a PVC's size after it has been created, so we should prevent users from trying to change this on the AWX CR after the initial deployment.  Currently, if a user _does_ change the requests or limits on the db PVC, the operator will crashloop with the following error:

```
Forbidden: updates to statefulset spec for fields other than \\'replicas\\', \\'template\\', \\'updateStrategy\\', \\'persistentVolumeClaimRetentionPolicy\\' and \\'minReadySeconds\\' are forbidden\",\"field\":\"spec\"}]},\"code\":422}\\n'", "reason": "Unprocessable Entity"}      
```

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bug, Docs Fix or other nominal change

