### PR TITLE
Add option to force drop database before restore

### DIFF
--- a/config/crd/bases/awx.ansible.com_awxrestores.yaml
+++ b/config/crd/bases/awx.ansible.com_awxrestores.yaml
@@ -121,6 +121,10 @@ spec:
                 description: Maintain some of the recommended `app.kubernetes.io/*` labels on the resource (self)
                 type: boolean
                 default: true
+              force_drop_db:
+                description: Force drop the database before restoring. USE WITH CAUTION!
+                type: boolean
+                default: false
           status:
             type: object
             x-kubernetes-preserve-unknown-fields: true

--- a/config/manifests/bases/awx-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/awx-operator.clusterserviceversion.yaml
@@ -194,6 +194,10 @@ spec:
         path: db_management_pod_node_selector
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
+      - displayName: Force drop database before restore
+        path: force_drop_db
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
       statusDescriptors:
       - description: The state of the restore
         displayName: Restore Status

--- a/config/manifests/bases/awx-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/awx-operator.clusterserviceversion.yaml
@@ -198,6 +198,7 @@ spec:
         path: force_drop_db
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       statusDescriptors:
       - description: The state of the restore
         displayName: Restore Status

--- a/roles/restore/tasks/postgres.yml
+++ b/roles/restore/tasks/postgres.yml
@@ -82,6 +82,26 @@
       -p {{ awx_postgres_port }}
   no_log: "{{ no_log }}"
 
+- name: Set drop db command
+  set_fact:
+    pg_drop_db: >-
+      echo 'DROP DATABASE {{ awx_postgres_database }} WITH (FORCE);' | PGPASSWORD='{{ awx_postgres_pass }}' psql
+      -U {{ awx_postgres_user }}
+      -h {{ resolvable_db_host }}
+      -d postgres
+      -p {{ awx_postgres_port }}
+  no_log: "{{ no_log }}"
+
+- name: Set create db command
+  set_fact:
+    pg_create_db: >-
+      echo 'CREATE DATABASE {{ awx_postgres_database }} WITH OWNER = {{ awx_postgres_user }};' | PGPASSWORD='{{ awx_postgres_pass }}' psql
+      -U {{ awx_postgres_user }}
+      -h {{ resolvable_db_host }}
+      -d postgres
+      -p {{ awx_postgres_port }}
+  no_log: "{{ no_log }}"
+
 - name: Restore database dump to the new postgresql container
   k8s_exec:
     namespace: "{{ backup_pvc_namespace }}"
@@ -104,6 +124,8 @@
       trap 'end_keepalive \"$keepalive_file\" \"$keepalive_pid\"' EXIT SIGINT SIGTERM
       echo keepalive_pid: $keepalive_pid
       set -e -o pipefail
+      {{ pg_drop_db }}
+      {{ pg_create_db }}
       cat {{ backup_dir }}/tower.db | PGPASSWORD='{{ awx_postgres_pass }}' {{ pg_restore }}
       set +e +o pipefail
       echo 'Successful'

--- a/roles/restore/tasks/postgres.yml
+++ b/roles/restore/tasks/postgres.yml
@@ -124,8 +124,10 @@
       trap 'end_keepalive \"$keepalive_file\" \"$keepalive_pid\"' EXIT SIGINT SIGTERM
       echo keepalive_pid: $keepalive_pid
       set -e -o pipefail
-      {{ pg_drop_db }}
-      {{ pg_create_db }}
+      if {{ force_drop_db }}; then
+        {{ pg_drop_db }}
+        {{ pg_create_db }}
+      fi
       cat {{ backup_dir }}/tower.db | PGPASSWORD='{{ awx_postgres_pass }}' {{ pg_restore }}
       set +e +o pipefail
       echo 'Successful'


### PR DESCRIPTION
##### SUMMARY
Based on https://github.com/ansible/awx-operator/pull/1604

Help with recovery from a bad restore or any other database "accident" where the database is left in a state that can't perform "clean" during restore process properly

Added `force_drop_db` option in AWXRestore 

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New or Enhanced Feature

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
-->
Fixes https://github.com/ansible/awx-operator/issues/1587

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
