### PR TITLE
Adding in Kind specific install docs

### DIFF
--- a/docs/installation/basic-install.md
+++ b/docs/installation/basic-install.md
@@ -2,6 +2,8 @@
 
 Once you have a running Kubernetes cluster, you can deploy AWX Operator into your cluster using [Kustomize](https://kubectl.docs.kubernetes.io/guides/introduction/kustomize/). Since kubectl version 1.14 kustomize functionality is built-in (otherwise, follow the instructions here to install the latest version of Kustomize: https://kubectl.docs.kubernetes.io/installation/kustomize/ )
 
+> Some things may need to be configured slightly differently for different Kubernetes flavors for the networking aspects. When installing on Kind, see the [kind install docs](./kind-install.md) for more details.
+
 There is a make target you can run:
 ```
 make deploy

--- a/docs/installation/index.md
+++ b/docs/installation/index.md
@@ -1,2 +1,2 @@
 
-This Kubernetes Operator is meant to be deployed in your Kubernetes cluster(s) and can manage one or more AWX instances in any namespace.
+This Kubernetes Operator is meant to be deployed in your Kubernetes cluster(s) and can be used to install and manage the lifecycle of an AWX instance in the same namespace.

--- a/docs/installation/kind-install.md
+++ b/docs/installation/kind-install.md
@@ -1,0 +1,125 @@
+# AWX Operator on Kind
+
+## Kind Install
+
+Install Kind by running the following
+
+```
+# For Intel Macs
+[ $(uname -m) = x86_64 ] && curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.20.0/kind-darwin-amd64
+# For M1 / ARM Macs
+[ $(uname -m) = arm64 ] && curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.20.0/kind-darwin-arm64
+chmod +x ./kind
+mv ./kind /some-dir-in-your-PATH/kind
+```
+
+> https://kind.sigs.k8s.io/docs/user/quick-start/
+
+
+### Create the Kind cluster
+
+Create a file called `kind.config`
+
+```yaml
+apiVersion: kind.x-k8s.io/v1alpha4
+kind: Cluster
+nodes:
+- role: control-plane
+  extraPortMappings:
+  - containerPort: 32000
+    hostPort: 32000
+    listenAddress: "0.0.0.0" # Optional, defaults to "0.0.0.0"
+    protocol: tcp # Optional, defaults to tcp
+- role: worker
+```
+
+Then create a cluster using that config
+
+```
+kind create cluster --config=kind.config
+```
+
+Set cluster context for kubectl
+
+```
+kubectl cluster-info --context kind-kind
+```
+
+Install NGINX Ingress Controller
+
+```
+kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/kind/deploy.yaml
+```
+
+
+## AWX
+
+Set the namespace context
+
+```
+kubectl config set-context --current --namespace=awx
+```
+
+Checkout the tag you want to install from
+
+```
+git checkout 2.7.2
+```
+
+Create a file named `kustomization.yaml` in the root of your local awx-operator clone. Include the following:
+
+```
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  # Find the latest tag here: https://github.com/ansible/awx-operator/releases
+  - github.com/ansible/awx-operator/config/default?ref=2.7.2
+
+# Set the image tags to match the git version from above
+images:
+  - name: quay.io/ansible/awx-operator
+    newTag: 2.7.2
+
+# Specify a custom namespace in which to install AWX
+namespace: awx
+```
+
+Run the following to apply the yaml
+
+```
+kubectl apply -k .
+```
+
+
+Create a file called `awx-cr.yaml` with the following contents and any configuration changes you may wish to add.
+
+```
+---
+apiVersion: awx.ansible.com/v1beta1
+kind: AWX
+metadata:
+  name: awx-demo
+spec:
+  service_type: nodeport
+  nodeport_port: 32000
+```
+
+Create your AWX CR
+
+```
+oc create -f awx-cr.yaml
+```
+
+Your AWX instance should now be reacheable at http://localhost:32000/
+
+> If you configured a custom nodeport_port, you can find it by running `kubectl -n awx get svc awx-demo-service`
+
+
+
+## Cleanup
+
+When you are done, you can delete all of this by running
+
+```
+kind delete cluster
+```


### PR DESCRIPTION
##### SUMMARY

Adding in docs for how to run the awx-operator and AWX on a Kind cluster.  I think it would be useful to do this for the main k8s flavors, or at least cover the Networking quirks of each.  

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bug, Docs Fix or other nominal change
