### PR TITLE
update deprecated collections path variable

### DIFF
--- a/roles/installer/templates/configmaps/config.yaml.j2
+++ b/roles/installer/templates/configmaps/config.yaml.j2
@@ -54,9 +54,6 @@ data:
 
     INTERNAL_API_URL = 'http://127.0.0.1:8052'
 
-    # Sets Ansible Collection path
-    AWX_ANSIBLE_COLLECTIONS_PATHS = '/var/lib/awx/vendor/awx_ansible_collections'
-
     # Container environments don't like chroots
     AWX_PROOT_ENABLED = False
 


### PR DESCRIPTION
##### SUMMARY

This PR replaces the `ANSIBLE_COLLECTIONS_PATHS` environment variable in AWX Web that has been deprecated and replaced by `ANSIBLE_COLLECTIONS_PATH` (available since Ansible 2.10).

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION

**Warning message when executing jobs**
```
[DEPRECATION WARNING]: ANSIBLE_COLLECTIONS_PATHS option, does not fit var 
naming standard, use the singular form ANSIBLE_COLLECTIONS_PATH instead. This 
feature will be removed from ansible-core in version 2.19. Deprecation warnings
can be disabled by setting deprecation_warnings=False in ansible.cfg.
```

https://docs.ansible.com/ansible/latest/reference_appendices/config.html#envvar-ANSIBLE_COLLECTIONS_PATHS