### PR TITLE
Bump Ansible Operator SDK version to 1.32.0 for OS updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM quay.io/operator-framework/ansible-operator:v1.31.0
+FROM quay.io/operator-framework/ansible-operator:v1.32.0
 
-USER 0
-
-RUN dnf install -y openssl
+USER root
+RUN dnf update --security --bugfix -y && \
+    dnf install -y openssl
 
 USER 1001
 

--- a/Makefile
+++ b/Makefile
@@ -162,7 +162,7 @@ ifeq (,$(shell which operator-sdk 2>/dev/null))
 	@{ \
 	set -e ;\
 	mkdir -p $(dir $(OPERATOR_SDK)) ;\
-	curl -sSLo $(OPERATOR_SDK) https://github.com/operator-framework/operator-sdk/releases/download/v1.31.0/operator-sdk_$(OS)_$(ARCHA) ;\
+	curl -sSLo $(OPERATOR_SDK) https://github.com/operator-framework/operator-sdk/releases/download/v1.32.0/operator-sdk_$(OS)_$(ARCHA) ;\
 	chmod +x $(OPERATOR_SDK) ;\
 	}
 else
@@ -178,7 +178,7 @@ ifeq (,$(shell which ansible-operator 2>/dev/null))
 	@{ \
 	set -e ;\
 	mkdir -p $(dir $(ANSIBLE_OPERATOR)) ;\
-	curl -sSLo $(ANSIBLE_OPERATOR) https://github.com/operator-framework/operator-sdk/releases/download/v1.31.0/ansible-operator_$(OS)_$(ARCHA) ;\
+	curl -sSLo $(ANSIBLE_OPERATOR) https://github.com/operator-framework/operator-sdk/releases/download/v1.32.0/ansible-operator_$(OS)_$(ARCHA) ;\
 	chmod +x $(ANSIBLE_OPERATOR) ;\
 	}
 else


### PR DESCRIPTION
##### SUMMARY

Use the new v1.32.0 ansible-operator base image to pick up OS updates.

There are no repo updates required this time besides bumping the image and makefile references:
* https://sdk.operatorframework.io/docs/upgrading-sdk-version/v1.32.0/

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New or Enhanced Feature
