### PR TITLE
Always check and wait for a restore pg_restore to finish

### DIFF
--- a/roles/installer/tasks/install.yml
+++ b/roles/installer/tasks/install.yml
@@ -77,6 +77,20 @@
   - ingress_type | lower == 'route'
   - route_tls_secret != ''
 
+- name: Wait for {{ deployment_type }}restore to complete
+  kubernetes.core.k8s_info:
+    api_version: "{{ api_version }}"
+    kind: "{{ deployment_type }}restore"
+    namespace: "{{ ansible_operator_meta.namespace }}"
+  register: restore_status_check
+  until:
+    # yamllint disable-line rule:line-length
+    - (restore_status_check.resources | length == 0) or (restore_status_check.resources | selectattr('spec.deployment_name', 'equalto', ansible_operator_meta.name) | map(attribute='status') | selectattr('restoreComplete', 'defined') | map(attribute='restoreComplete') | list | length > 0)
+  delay: 10
+  retries: 8640
+  ignore_errors: yes
+  changed_when: false
+
 - name: Include resources configuration tasks
   include_tasks: resources_configuration.yml
 
@@ -91,7 +105,7 @@
   when: awx_task_pod_name != ''
   register: database_check
 
-- name: Migrate the database if the K8s resources were updated.  # noqa 305
+- name: Migrate the database if the K8s resources were updated  # noqa 305
   k8s_exec:
     namespace: "{{ ansible_operator_meta.namespace }}"
     pod: "{{ awx_task_pod_name }}"


### PR DESCRIPTION
##### SUMMARY


If the database is big enough in a backup, when restoring it, the restore role's pg_restore command can sometimes be at odds with the installer role of the new AWX instance (specifically when I tries to run migrations).  This can result in some unpleasant db errors.

This resolves that by checking for the presence of an AWXRestore object with a deployment_name that matches, and waiting for it to complete before continuing the installer role.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bug, Docs Fix or other nominal change
