### PR TITLE
FIx permissions /var/lib/awx/projects when projects_persistence is true.

### DIFF
--- a/roles/installer/templates/deployments/task.yaml.j2
+++ b/roles/installer/templates/deployments/task.yaml.j2
@@ -129,7 +129,7 @@ spec:
             - -c
             - |
               chmod 775 /var/lib/awx/projects
-              chgrp 1000 /var/lib/awx/projects
+              chgrp 0 /var/lib/awx/projects
           env:
             - name: MY_POD_NAME
               valueFrom:

--- a/roles/installer/templates/deployments/web.yaml.j2
+++ b/roles/installer/templates/deployments/web.yaml.j2
@@ -119,7 +119,7 @@ spec:
             - -c
             - |
               chmod 775 /var/lib/awx/projects
-              chgrp 1000 /var/lib/awx/projects
+              chgrp 0 /var/lib/awx/projects
           env:
             - name: MY_POD_NAME
               valueFrom:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
When 'projects_persistence' is false, permissions /var/lib/awx/projects are 777 with root:root.
When 'projects_persistence' is true, permissions /var/lib/awx/projects are 775 with root:1000.
But the problem is : group id 1000 does not exist in ansible/awx container, so user 'awx' cannot write into /var/lib/awx/projects directory when you sync project in AWX UI.


##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
Before:
chgrp 1000 /var/lib/awx/projects
After:
chgrp 0 /var/lib/awx/projects
```
