### PR TITLE
Add feature liveness probe for task and web deployment and containers

### DIFF
--- a/config/crd/bases/awx.ansible.com_awxs.yaml
+++ b/config/crd/bases/awx.ansible.com_awxs.yaml
@@ -211,6 +211,50 @@ spec:
               web_tolerations:
                 description: node tolerations for the web pods
                 type: string
+              task_liveness_probe:
+                description: Specify liveness Probe for awx-task container in awx-task deployment
+                type: object
+                properties:
+                  failureThreshold:
+                    type: integer
+                  initialDelaySeconds:
+                    type: integer
+                  periodSeconds:
+                    type: integer
+                  successThreshold:
+                    type: integer
+                  timeoutSeconds:
+                    type: integer
+                  exec:
+                    properties:
+                      command:
+                        items:
+                          type: string
+                        type: array
+                    type: object
+              web_liveness_probe:
+                description: Specify liveness Probe for awx-web container in awx-web deployment
+                type: object
+                properties:
+                  failureThreshold:
+                    type: integer
+                  initialDelaySeconds:
+                    type: integer
+                  periodSeconds:
+                    type: integer
+                  successThreshold:
+                    type: integer
+                  timeoutSeconds:
+                    type: integer
+                  httpGet:
+                    properties:
+                      path:
+                        type: string
+                      port:
+                        type: integer
+                      scheme:
+                        type: string
+                    type: object
               affinity:
                 description: If specified, the pod's scheduling constraints
                 properties:

--- a/roles/installer/defaults/main.yml
+++ b/roles/installer/defaults/main.yml
@@ -471,3 +471,7 @@ nginx_worker_processes: 1
 nginx_worker_connections: "{{ uwsgi_listen_queue_size }}"
 nginx_worker_cpu_affinity: 'auto'
 nginx_listen_queue_size: "{{ uwsgi_listen_queue_size }}"
+
+# Liveness probes
+web_liveness_probe: {}
+task_liveness_probe: {}

--- a/roles/installer/templates/deployments/task.yaml.j2
+++ b/roles/installer/templates/deployments/task.yaml.j2
@@ -179,6 +179,9 @@ spec:
         - image: '{{ _image }}'
           name: '{{ ansible_operator_meta.name }}-task'
           imagePullPolicy: '{{ image_pull_policy }}'
+{% if task_liveness_probe %}
+          livenessProbe: {{ task_liveness_probe }}
+{% endif %}
 {% if task_privileged == true %}
           securityContext:
             privileged: true

--- a/roles/installer/templates/deployments/web.yaml.j2
+++ b/roles/installer/templates/deployments/web.yaml.j2
@@ -152,6 +152,9 @@ spec:
         - image: '{{ _image }}'
           name: '{{ ansible_operator_meta.name }}-web'
           imagePullPolicy: '{{ image_pull_policy }}'
+{% if web_liveness_probe %}
+          livenessProbe: {{ web_liveness_probe }}
+{% endif %}
 {% if web_command %}
           command: {{ web_command }}
 {% endif %}


### PR DESCRIPTION
##### SUMMARY
add feature liveness probe for task and web deployment.
Add two new options in spec:
- task_liveness_probe for cotnainer awx-task in awx-task pod
- web_liveness_probe for cotnainer awx-webin awx-web pod

Suboptions possibles are listed in config/crd/bases/awx.ansible.com_awxs.yaml file.

Each person will can configure it as they want.

Disabled by default so no breaking changes.
##### ISSUE TYPE
 - New or Enhanced Feature

##### ADDITIONAL INFORMATION



-----
testing done:
- use awx-operator with a kind awx file with web_liveness_probe and task_liveness_probe configured
Result: liveness probe are correctly configured on deployement awx-task and awx-web
- use awx-operator with this two parameters not set
Result: ok no liveness probes in deployments task and web


Options and suboptions used for testing:
task_liveness_probe:
    exec:
      command:
      - sh
      - -c
      - exec /usr/bin/pg_isready -h X.X.X.X -p 5432
    failureThreshold: 1
    initialDelaySeconds: 60
    periodSeconds: 10
    successThreshold: 1
    timeoutSeconds: 5
  web_liveness_probe:
    failureThreshold: 6
    httpGet:
      path: /
      port: 8052
      scheme: HTTP
    initialDelaySeconds: 60
    periodSeconds: 10
    successThreshold: 1
    timeoutSeconds: 1