### PR TITLE
Remove unnessary chmod and chown for db dump

### DIFF
--- a/roles/backup/tasks/postgres.yml
+++ b/roles/backup/tasks/postgres.yml
@@ -70,13 +70,6 @@
     command: >-
       touch {{ backup_dir }}/tower.db
 
-- name: Set permissions on file for database dump
-  k8s_exec:
-    namespace: "{{ backup_pvc_namespace }}"
-    pod: "{{ ansible_operator_meta.name }}-db-management"
-    command: >-
-      bash -c "chmod 660 {{ backup_dir }}/tower.db && chown :root {{ backup_dir }}/tower.db"
-
 - name: Set full resolvable host name for postgres pod
   set_fact:
     resolvable_db_host: '{{ (awx_postgres_type == "managed") | ternary(awx_postgres_host + "." + ansible_operator_meta.namespace + ".svc", awx_postgres_host) }}'  # yamllint disable-line rule:line-length


### PR DESCRIPTION
##### SUMMARY
Based on https://github.com/ansible/awx-operator/pull/1602

Fixes https://github.com/ansible/awx-operator/issues/1590

Tested with @chrismeyersfsu ... apparently we don't need it.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
