### PR TITLE
Add support for horizontal pod autoscaling

### DIFF
--- a/config/crd/bases/awx.ansible.com_awxs.yaml
+++ b/config/crd/bases/awx.ansible.com_awxs.yaml
@@ -1574,10 +1574,18 @@ spec:
                 description: Number of web instance replicas
                 type: integer
                 format: int32
+              web_manage_replicas:
+                description: Enables operator control of replicas count for the web deployment when set to 'true'
+                type: boolean
+                default: true
               task_replicas:
                 description: Number of task instance replicas
                 type: integer
                 format: int32
+              task_manage_replicas:
+                description: Enables operator control of replicas count for the task deployment when set to 'true'
+                type: boolean
+                default: true
               web_liveness_initial_delay:
                 description: Initial delay before starting liveness checks on web pod
                 type: integer

--- a/docs/user-guide/advanced-configuration/horizontal-pod-autoscaler.md
+++ b/docs/user-guide/advanced-configuration/horizontal-pod-autoscaler.md
@@ -1,0 +1,27 @@
+### Horizontal Pod Autoscaler (HPA)
+
+Horizontal Pod Autoscaler allows Kubernetes to scale the number of replicas of
+deployments in response to configured metrics.
+
+This feature conflicts with the operators ability to manage the number of static
+replicas to create for each deployment.
+
+The use of the settings below will tell the operator to not manage the replicas
+field on the identified deployments even if a replicas count has been set for those
+properties in the operator resource.
+
+| Name                   | Description                               | Default |
+| -----------------------| ----------------------------------------- | ------- |
+| web_manage_replicas    | Indicates operator should control the     | true    |
+|                        | replicas count for the web deployment.    |         |
+|                        |                                           |         |
+| task_manage_replicas   | Indicates operator should control the     | true    |
+|                        | replicas count for the task deployment.   |         |
+
+#### Recommended Settings for HPA
+
+Please see the Kubernetes documentation on how to configure the horizontal pod
+autoscaler.
+
+The values for optimal HPA are cluster and need specific so general guidelines
+are not available at this time.

--- a/docs/user-guide/advanced-configuration/scaling-the-web-and-task-pods-independently.md
+++ b/docs/user-guide/advanced-configuration/scaling-the-web-and-task-pods-independently.md
@@ -1,8 +1,13 @@
-#### Scaling the Web and Task Pods independently 
+#### Scaling the Web and Task Pods independently
 
 You can scale replicas up or down for each deployment by using the `web_replicas` or `task_replicas` respectively. You can scale all pods across both deployments by using `replicas` as well. The logic behind these CRD keys acts as such:
 
-- If you specify the `replicas` field, the key passed will scale both the `web` and `task` replicas to the same number. 
+- If you specify the `replicas` field, the key passed will scale both the `web` and `task` replicas to the same number.
 - If `web_replicas` or `task_replicas` is ever passed, it will override the existing `replicas` field on the specific deployment with the new key value.
 
-These new replicas can be constrained in a similar manner to previous single deployments by appending the particular deployment name in front of the constraint used. More about those new constraints can be found in the [Assigning AWX pods to specific nodes](./assigning-awx-pods-to-specific-nodes.md) page. 
+These new replicas can be constrained in a similar manner to previous single deployments by appending the particular deployment name in front of the constraint used. More about those new constraints can be found in the [Assigning AWX pods to specific nodes](./assigning-awx-pods-to-specific-nodes.md) page.
+
+##### Horizontal Pod Autoscaling
+
+The operator is capable of working with Kubernete's HPA capabilities.  See [Horizontal Pod Autoscaler](./horizontal-pod-autoscaler.md)
+documentation for more information.

--- a/roles/installer/templates/deployments/task.yaml.j2
+++ b/roles/installer/templates/deployments/task.yaml.j2
@@ -8,9 +8,9 @@ metadata:
     {{ lookup("template", "../common/templates/labels/common.yaml.j2")  | indent(width=4) | trim }}
     {{ lookup("template", "../common/templates/labels/version.yaml.j2") | indent(width=4) | trim }}
 spec:
-{% if task_replicas != '' %}
+{% if task_replicas != '' and task_manage_replicas is true %}
   replicas: {{ task_replicas }}
-{% elif replicas != '' %}
+{% elif replicas != '' and task_manage_replicas is true %}
   replicas: {{ replicas }}
 {% endif %}
   selector:

--- a/roles/installer/templates/deployments/web.yaml.j2
+++ b/roles/installer/templates/deployments/web.yaml.j2
@@ -9,9 +9,9 @@ metadata:
     {{ lookup("template", "../common/templates/labels/common.yaml.j2")  | indent(width=4) | trim }}
     {{ lookup("template", "../common/templates/labels/version.yaml.j2") | indent(width=4) | trim }}
 spec:
-{% if web_replicas != '' %}
+{% if web_replicas != '' and web_manage_replicas is true %}
   replicas: {{ web_replicas }}
-{% elif replicas != '' %}
+{% elif replicas != '' and web_manage_replicas is true %}
   replicas: {{ replicas }}
 {% endif %}
   selector:


### PR DESCRIPTION
##### SUMMARY

Allows the operator to create horizontal pod autoscaling resources for the web and task deployments.

It does _**not**_ provide guidance on how to configure the HPA as those details are very cluster and use case specific.

##### ISSUE TYPE

 - New or Enhanced Feature

##### ADDITIONAL INFORMATION

This code does not change the default behavior of the operator.  A horizontal pod autoscaler will not be created unless it is specifically configured.

The minimum configuration required is to set the option `task_max_replicas` or `web_max_replicas` to be an integer greater than `task_replicas` or `web_replicas` respecitively.   This should create a HPA using the default values for a HPA which on OpenShift monitors CPU consumption.

A good configuration for HPA will require requests, limits, and health probes for the the web and task pods to be implemented.
