### PR TITLE
Updated the "index" file to include "Adding execution nodes" section.

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -63,6 +63,7 @@ nav:
       - user-guide/advanced-configuration/privileged-tasks.md
       - user-guide/advanced-configuration/containers-resource-requirements.md
       - user-guide/advanced-configuration/priority-classes.md
+      - user-guide/advanced-configuration/adding-execution-nodes.md
       - user-guide/advanced-configuration/scaling-the-web-and-task-pods-independently.md
       - user-guide/advanced-configuration/assigning-awx-pods-to-specific-nodes.md
       - user-guide/advanced-configuration/trusting-a-custom-certificate-authority.md


### PR DESCRIPTION
##### SUMMARY
Due to PR #1678, the section, [Adding execution nodes](https://ansible.readthedocs.io/projects/awx-operator/en/latest/user-guide/advanced-configuration/adding-execution-nodes.html) didn't actually get included in the TOC for the RTD output. This PR adds that section to the left nav so readers can navigate to the section.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION
none