### PR TITLE
Adopt LISTENER_DATABASES setting

### DIFF
--- a/roles/installer/templates/settings/credentials.py.j2
+++ b/roles/installer/templates/settings/credentials.py.j2
@@ -11,13 +11,20 @@ DATABASES = {
 {% if awx_postgres_sslmode in ['verify-ca', 'verify-full'] %}
                      'sslrootcert': '{{ ca_trust_bundle }}',
 {% endif %}
+        },
+    }
+}
+
+LISTENER_DATABASES = {
+    'default': {
+        'OPTIONS': {
 {% if postgres_keepalives %}
-                     'keepalives': 1,
-                     'keepalives_idle': {{ postgres_keepalives_idle }},
-                     'keepalives_interval': {{ postgres_keepalives_interval }},
-                     'keepalives_count': {{ postgres_keepalives_count }},
+            'keepalives': 1,
+            'keepalives_idle': {{ postgres_keepalives_idle }},
+            'keepalives_interval': {{ postgres_keepalives_interval }},
+            'keepalives_count': {{ postgres_keepalives_count }},
 {% else %}
-                     'keepalives': 0,
+            'keepalives': 0,
 {% endif %}
         },
     }


### PR DESCRIPTION
##### SUMMARY
Related to https://github.com/ansible/awx/pull/14755

move TCP keepalive to pg_listener specific db setting


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New or Enhanced Feature


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
