### PR TITLE
add 'customSecrets' and 'customVolumes' values to Helm Chart to simplifies the creation of ressources for PoC

### DIFF
--- a/.helm/starter/README.md
+++ b/.helm/starter/README.md
@@ -90,6 +90,101 @@ extraDeploy:
             key: awx/postgres-configuration-secret
 ```
 
+### Custom secrets
+The `customSecrets` section simplifies the creation of our custom secrets used during AWX deployment. Supplying the passwords this way is not recommended for production use, but may be helpful for initial PoC.
+
+If enabled, the configs provided will automatically used to create the respective secrets and linked at the CR spec level. For proper secret management, the sensitive values can be passed in at the command line rather than specified in code. Use the `--set` argument with `helm install`.
+
+Example:
+
+```yaml
+AWX:
+  # enable use of awx-deploy template
+  ...
+
+  # configurations for external postgres instance
+  postgres:
+    enabled: false
+    ...
+
+  customSecrets:
+    enabled: true
+    admin:
+      enabled: true
+      password: mysuperlongpassword
+      secretName: my-admin-password
+    secretKey:
+      enabled: true
+      key: supersecuresecretkey
+      secretName: my-awx-secret-key
+    ingressTls:
+      enabled: true
+      selfSignedCert: true
+      key: unset
+      certificate: unset
+    routeTls:
+      enabled: false
+      key: <contentoftheprivatekey>
+      certificate: <contentofthepublickey>
+    ldapCacert:
+      enabled: false
+      crt: <contentofmybundlecacrt>
+    ldap:
+      enabled: true
+      password: yourldapdnpassword
+    bundleCacert:
+      enabled: false
+      crt: <contentofmybundlecacrt>
+    eePullCredentials:
+      enabled: false
+      url: unset
+      username: unset
+      password: unset
+      sslVerify: true
+      secretName: my-ee-pull-credentials
+    cpPullCredentials:
+      enabled: false
+      dockerconfig:
+        - registry: https://index.docker.io/v1/
+          username: unset
+          password: unset
+      secretName: my-cp-pull-credentials
+```
+
+### Custom volumes
+The `customVolumes` section simplifies the creation of Persistent Volumes used when you want to store your databases and projects files on the cluster's Node. Since their backends are `hostPath`, the size specified are just like a label and there is no actual capacity limitation.
+
+You have to prepare directories for these volumes. For example:
+
+```bash
+sudo mkdir -p /data/postgres-13
+sudo mkdir -p /data/projects
+sudo chmod 755 /data/postgres-13
+sudo chown 1000:0 /data/projects
+```
+
+Example:
+
+```yaml
+AWX:
+  # enable use of awx-deploy template
+  ...
+
+  # configurations for external postgres instance
+  postgres:
+    enabled: false
+    ...
+
+  customVolumes:
+    postgres:
+      enabled: true
+      hostPath: /data/postgres-13
+    projects:
+      enabled: true
+      hostPath: /data/projects
+      size: 1Gi
+```
+
 ## Values Summary
 
 ### AWX
@@ -104,6 +199,116 @@ extraDeploy:
 | Value | Description | Default |
 |---|---|---|
 | `extraDeploy` | array of additional resources to be deployed (supports YAML or literal "\|") | - |
+
+### customSecrets
+| Value | Description | Default |
+|---|---|---|
+| `customSecrets.enabled` | Enable the secret resources configuration | `false` |
+| `customSecrets.admin` | Configurations for the secret that contains the admin user password | - |
+| `customSecrets.secretKey` | Configurations for the secret that contains the symmetric key for encryption | - |
+| `customSecrets.ingressTls` | Configurations for the secret that contains the TLS information when `ingress_type=ingress` | - |
+| `customSecrets.routeTls` |  Configurations for the secret that contains the TLS information when `ingress_type=route` (`route_tls_secret`) | - |
+| `customSecrets.ldapCacert` | Configurations for the secret that contains the LDAP Certificate Authority | - |
+| `customSecrets.ldap` | Configurations for the secret that contains the LDAP BIND DN password | - |
+| `customSecrets.bundleCacert` | Configurations for the secret that contains the Certificate Authority | - |
+| `customSecrets.eePullCredentials` | Configurations for the secret that contains the pull credentials for registered ees can be found | - |
+| `customSecrets.cpPullCredentials` | Configurations for the secret that contains the image pull credentials for app and database containers | - |
+
+
+Below the addition variables to customize the secret configuration.
+
+#### Admin user password secret configuration
+| Value | Description | Default |
+|---|---|---|
+| `customSecrets.admin.enabled` | If `true`, secret will be created | `false` |
+| `customSecrets.admin.password` | Admin user password | - |
+| `customSecrets.admin.secretName` | Name of secret for `admin_password_secret` | `<resourcename>-admin-password>` |
+
+#### Secret Key secret configuration
+| Value | Description | Default |
+|---|---|---|
+| `customSecrets.secretKey.enabled` | If `true`, secret will be created | `false` |
+| `customSecrets.secretKey.key` | Key is used to encrypt sensitive data in the database | - |
+| `customSecrets.secretKey.secretName` | Name of secret for `secret_key_secret` | `<resourcename>-secret-key` |
+
+#### Ingress TLS secret configuration
+| Value | Description | Default |
+|---|---|---|
+| `customSecrets.ingressTls.enabled` | If `true`, secret will be created | `false` |
+| `customSecrets.ingressTls.selfSignedCert` | If `true`, an self-signed TLS certificate for `AWX.spec.hostname` will be create by helm | `false` |
+| `customSecrets.ingressTls.key` | Private key to use for TLS/SSL | - |
+| `customSecrets.ingressTls.certificate` | Certificate to use for TLS/SSL | - |
+| `customSecrets.ingressTls.secretName` | Name of secret for `ingress_tls_secret` | `<resourcename>-ingress-tls` |
+| `customSecrets.ingressTls.labels` | Array of labels for the secret | - |
+
+#### Route TLS secret configuration
+| Value | Description | Default |
+|---|---|---|
+| `customSecrets.routeTls.enabled` | If `true`, secret will be created | `false` |
+| `customSecrets.routeTls.key` | Private key to use for TLS/SSL | - |
+| `customSecrets.routeTls.certificate` | Certificate to use for TLS/SSL | - |
+| `customSecrets.routeTls.secretName` | Name of secret for `route_tls_secret` | `<resourcename>-route-tls` |
+
+#### LDAP Certificate Authority secret configuration
+| Value | Description | Default |
+|---|---|---|
+| `customSecrets.ldapCacert.enabled` | If `true`, secret will be created | `false` |
+| `customSecrets.ldapCacert.crt` | Bundle of CA Root Certificates | - |
+| `customSecrets.ldapCacert.secretName` | Name of secret for `ldap_cacert_secret` | `<resourcename>-custom-certs` |
+
+#### LDAP BIND DN Password secret configuration
+| Value | Description | Default |
+|---|---|---|
+| `customSecrets.ldap.enabled` | If `true`, secret will be created | `false` |
+| `customSecrets.ldap.password` | LDAP BIND DN password | - |
+| `customSecrets.ldap.secretName` | Name of secret for `ldap_password_secret` | `<resourcename>-ldap-password` |
+
+#### Certificate Authority secret configuration
+| Value | Description | Default |
+|---|---|---|
+| `customSecrets.bundleCacert.enabled` | If `true`, secret will be created | `false` |
+| `customSecrets.bundleCacert.crt` | Bundle of CA Root Certificates | - |
+| `customSecrets.bundleCacert.secretName` | Name of secret for `bundle_cacert_secret` | `<resourcename>-custom-certs` |
+
+#### Default EE pull secrets configuration
+| Value | Description | Default |
+|---|---|---|
+| `customSecrets.eePullCredentials.enabled` | If `true`, secret will be created | `false` |
+| `customSecrets.eePullCredentials.url` | Registry url | - |
+| `customSecrets.eePullCredentials.username` | Username to connect as | - |
+| `customSecrets.eePullCredentials.password` | Password to connect with | - |
+| `customSecrets.eePullCredentials.sslVerify` | Whether verify ssl connection or not. | `true` |
+| `customSecrets.eePullCredentials.secretName` | Name of secret for `ee_pull_credentials_secret` | `<resourcename>-ee-pull-credentials` |
+
+#### Control Plane pull secrets configuration
+| Value | Description | Default |
+|---|---|---|
+| `customSecrets.cpPullCredentials.enabled` | If `true`, secret will be created | `false` |
+| `customSecrets.cpPullCredentials.dockerconfig` | Array of configurations for the Docker credentials that are used for accessing a registry | - |
+| `customSecrets.cpPullCredentials.dockerconfig[].registry` | Server location for Docker registry | `https://index.docker.io/v1/` |
+| `customSecrets.cpPullCredentials.dockerconfig[].username` | Username to connect as | - |
+| `customSecrets.cpPullCredentials.dockerconfig[].password` | Password to connect with | - |
+| `customSecrets.cpPullCredentials.secretName` |  Name of secret for `image_pull_secrets`| `<resoucename>-cp-pull-credentials` |
+
+### customVolumes
+
+#### Persistent Volume for databases postgres
+| Value | Description | Default |
+|---|---|---|
+| `customVolumes.postgres.enabled` | Enable the PV resource configuration for the postgres databases | `false` |
+| `customVolumes.postgres.hostPath` | Directory location on host | - |
+| `customVolumes.postgres.size` | Size of the volume | `8Gi` |
+| `customVolumes.postgres.accessModes` | Volume access mode | `ReadWriteOnce` |
+| `customVolumes.postgres.storageClassName` | PersistentVolume storage class name for `postgres_storage_class` | `<resourcename>-postgres-volume` |
+
+#### Persistent Volume for projects files
+| Value | Description | Default |
+|---|---|---|
+| `customVolumes.projects.enabled` | Enable the PVC and PVC resources configuration for the projects files | `false` |
+| `customVolumes.projects.hostPath` | Directory location on host | - |
+| `customVolumes.projects.size` |  Size of the volume | `8Gi` |
+| `customVolumes.projects.accessModes` | Volume access mode | `ReadWriteOnce` |
+| `customVolumes.postgres.storageClassName` | PersistentVolume storage class name | `<resourcename>-projects-volume` |
 
 # Contributing
 

--- a/.helm/starter/templates/awx-deploy.yaml
+++ b/.helm/starter/templates/awx-deploy.yaml
@@ -6,6 +6,10 @@ metadata:
   name: {{ .name }}
   namespace: {{ $.Release.Namespace }}
 spec:
+{{- /* Provide custom persistent volumes configs if enabled */}}
+{{- include "spec.storageClassNames" $ }}
+{{- /* Provide custom secrets configs if enabled */}}
+{{- include "spec.secrets" $ }}
 {{- /* Include raw map from the values file spec */}}
 {{ .spec | toYaml | indent 2 }}
 {{- /* Provide security context defaults */}}

--- a/.helm/starter/templates/secrets/_helpers.tpl
+++ b/.helm/starter/templates/secrets/_helpers.tpl
@@ -1,0 +1,170 @@
+{{/*
+Generate certificates for ingress
+*/}}
+{{- define "ingress.gen-certs" -}}
+{{- $ca := genCA "ingress-ca" 365 -}}
+{{- $cert := genSignedCert ( $.Values.AWX.spec.hostname | required "AWX.spec.hostname is required!" ) nil nil 365 $ca -}}
+tls.crt: {{ $cert.Cert | b64enc }}
+tls.key: {{ $cert.Key | b64enc }}
+{{- end -}}
+
+{{/*
+Generate the name of the secret that contains the admin user password
+*/}}
+{{- define "admin.secretName" -}}
+{{ default (printf "%s-admin-password" $.Values.AWX.name) (default $.Values.customSecrets.admin.secretName $.Values.AWX.spec.admin_password_secret) }}
+{{- end }}
+
+{{/*
+Generate the name of the secret that contains the TLS information when ingress_type=route
+*/}}
+{{- define "routeTls.secretName" -}}
+{{ default (printf "%s-route-tls" $.Values.AWX.name) (default $.Values.customSecrets.routeTls.secretName $.Values.AWX.spec.route_tls_secret) }}
+{{- end }}
+
+{{/*
+Generate the name of the secret that contains the TLS information when ingress_type=ingress
+*/}}
+{{- define "ingressTls.secretName" -}}
+{{ default (printf "%s-ingress-tls" $.Values.AWX.name) (default $.Values.customSecrets.ingressTls.secretName $.Values.AWX.spec.ingress_tls_secret) }}
+{{- end }}
+
+{{/*
+Generate the name of the secret that contains the LDAP Certificate Authority
+*/}}
+{{- define "ldapCacert.secretName" -}}
+{{ default (printf "%s-custom-certs" $.Values.AWX.name) (default ($.Values.customSecrets.ldapCacert).secretName $.Values.AWX.spec.ldap_cacert_secret) }}
+{{- end }}
+
+{{/*
+Generate the name of the secret that contains the custom Certificate Authority
+*/}}
+{{- define "bundleCacert.secretName" -}}
+{{ default (printf "%s-custom-certs" $.Values.AWX.name) (default ($.Values.customSecrets.bundleCacert).secretName $.Values.AWX.spec.bundle_cacert_secret) }}
+{{- end }}
+
+{{/*
+Generate the name of the secret that contains the LDAP BIND DN password
+*/}}
+{{- define "ldap.secretName" -}}
+{{ default (printf "%s-ldap-password" $.Values.AWX.name) (default $.Values.customSecrets.ldap.secretName $.Values.AWX.spec.ldap_password_secret) }}
+{{- end }}
+
+{{/*
+Generate the name of the secret that contains the symmetric key for encryption
+*/}}
+{{- define "secretKey.secretName" -}}
+{{ default (printf "%s-secret-key" $.Values.AWX.name) (default $.Values.customSecrets.secretKey.secretName $.Values.AWX.spec.secret_key_secret) }}
+{{- end }}
+
+{{/*
+Generate the name of the secret that contains the default execution environment pull credentials
+*/}}
+{{- define "eePullCredentials.secretName" -}}
+{{ default (printf "%s-ee-pull-credentials" $.Values.AWX.name) (default $.Values.customSecrets.eePullCredentials.secretName $.Values.AWX.spec.ee_pull_credentials_secret) }}
+{{- end }}
+
+{{/*
+Generate the name of the secret that contains the default control plane pull credentials
+*/}}
+{{- define "cpPullCredentials.secretName" -}}
+{{ default (printf "%s-cp-pull-credentials" $.Values.AWX.name) (default $.Values.customSecrets.cpPullCredentials.secretName $.Values.AWX.spec.image_pull_secrets) }}
+{{- end }}
+
+{{/*
+Generate the .dockerconfigjson file unencoded.
+*/}}
+{{- define "dockerconfigjson.b64dec" }}
+  {{- print "{\"auths\":{" }}
+  {{- range $index, $item := . }}
+    {{- if $index }}
+      {{- print "," }}
+    {{- end }}
+    {{- printf "\"%s\":{\"username\":\"%s\",\"password\":\"%s\",\"email\":\"%s\",\"auth\":\"%s\"}" (default "https://index.docker.io/v1/" $item.registry) $item.username $item.password (default "" $item.email) (printf "%s:%s" $item.username $item.password | b64enc) }}
+  {{- end }}
+  {{- print "}}" }}
+{{- end }}
+
+{{/*
+Generate the base64-encoded .dockerconfigjson.
+*/}}
+{{- define "dockerconfigjson.b64enc" }}
+  {{- $list := ternary (list .) . (kindIs "map" .) }}
+  {{- include "dockerconfigjson.required" $list }}
+  {{- include "dockerconfigjson.b64dec" $list | b64enc }}
+{{- end }}
+
+{{/*
+Required values for .dockerconfigjson
+*/}}
+{{- define "dockerconfigjson.required" -}}
+  {{- range . -}}
+    {{- $_ := required "cpPullCredentials.dockerconfigjson[].username is required!" .username -}}
+    {{- $_ := required "cpPullCredentials.dockerconfigjson[].password is required!" .password -}}
+  {{- end -}}
+  {{/* Check for registry uniqueness */}}
+  {{- $registries := list -}}
+  {{- range . -}}
+    {{- $registries = append $registries (default "https://index.docker.io/v1/" .registry) -}}
+  {{- end -}}
+  {{- $_ := required "All cpPullCredentials.dockerconfigjson[].registry's must be unique!" (or (eq (len $registries) (len ($registries | uniq))) nil) -}}
+{{- end -}}
+
+{{/*
+Generate the name of the secrets
+*/}}
+{{- define "spec.secrets" -}}
+{{- /* secret configs if enabled */}}
+{{- if hasKey $.Values "customSecrets" }}
+{{- with $.Values.customSecrets }}
+{{- if .enabled }}
+  {{- if hasKey . "admin" }}
+  {{- if and (not (hasKey $.Values.AWX.spec "admin_password_secret")) .admin.enabled }}
+  admin_password_secret: {{ include "admin.secretName" $ }}
+  {{- end }}
+  {{- end }}
+  {{- if hasKey . "secretKey" }}
+  {{- if and (not (hasKey $.Values.AWX.spec "secret_key_secret")) .secretKey.enabled }}
+  secret_key_secret: {{ include "secretKey.secretName" $ }}
+  {{- end }}
+  {{- end }}
+  {{- if hasKey . "routeTls" }}
+  {{- if and (not (hasKey $.Values.AWX.spec "route_tls_secret")) .routeTls.enabled }}
+  route_tls_secret: {{ include "routeTls.secretName" $ }}
+  {{- end }}
+  {{- end }}
+  {{- if hasKey . "ingressTls" }}
+  {{- if and (not (hasKey $.Values.AWX.spec "ingress_tls_secret")) .ingressTls.enabled }}
+  ingress_tls_secret: {{ include "ingressTls.secretName" $ }}
+  {{- end }}
+  {{- end }}
+  {{- if hasKey . "ldapCacert" }}
+  {{- if and (not (hasKey $.Values.AWX.spec "ldap_cacert_secret")) .ldapCacert.enabled }}
+  ldap_cacert_secret: {{ include "ldapCacert.secretName" $ }}
+  {{- end }}
+  {{- end }}
+  {{- if hasKey . "bundleCacert" }}
+  {{- if and (not (hasKey $.Values.AWX.spec "bundle_cacert_secret")) .bundleCacert.enabled }}
+  bundle_cacert_secret: {{ include "bundleCacert.secretName" $ }}
+  {{- end }}
+  {{- end }}
+  {{- if hasKey . "ldap" }}
+  {{- if and (not (hasKey $.Values.AWX.spec "ldap_password_secret")) .ldap.enabled }}
+  ldap_password_secret: {{ include "ldap.secretName" $ }}
+  {{- end }}
+  {{- end }}
+  {{- if hasKey . "eePullCredentials" }}
+  {{- if and (not (hasKey $.Values.AWX.spec "ee_pull_credentials_secret")) .eePullCredentials.enabled }}
+  ee_pull_credentials_secret: {{ include "eePullCredentials.secretName" $ }}
+  {{- end }}
+  {{- end }}
+  {{- if hasKey . "cpPullCredentials" }}
+  {{- if and (not (hasKey $.Values.AWX.spec "image_pull_secrets")) .cpPullCredentials.enabled }}
+  image_pull_secrets:
+    - {{ include "cpPullCredentials.secretName" $ }}
+  {{- end }}
+  {{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/.helm/starter/templates/secrets/admin-password-secret.yaml
+++ b/.helm/starter/templates/secrets/admin-password-secret.yaml
@@ -1,0 +1,16 @@
+{{- if ($.Values.customSecrets).enabled }}
+{{- if hasKey .Values.customSecrets "admin" }}
+{{- with $.Values.customSecrets.admin }}
+{{- if .enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "admin.secretName" $ }}
+  namespace: {{ $.Release.Namespace }}
+type: Opaque
+data:
+  password: {{ .password | required "customSecrets.admin.password is required!" | b64enc }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/.helm/starter/templates/secrets/cp-pull-credentials-secret.yaml
+++ b/.helm/starter/templates/secrets/cp-pull-credentials-secret.yaml
@@ -1,0 +1,16 @@
+{{- if ($.Values.customSecrets).enabled }}
+{{- if hasKey .Values.customSecrets "cpPullCredentials" }}
+{{- with $.Values.customSecrets.cpPullCredentials }}
+{{- if .enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "cpPullCredentials.secretName" $ }}
+  namespace: {{ $.Release.Namespace }}
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: {{ template "dockerconfigjson.b64enc" .dockerconfig | required "customSecrets.cpPullCredentials.dockerconfig is required!" }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/.helm/starter/templates/secrets/custom-certs-secret.yaml
+++ b/.helm/starter/templates/secrets/custom-certs-secret.yaml
@@ -1,0 +1,49 @@
+{{- if ($.Values.customSecrets).enabled }}
+{{- with .Values.customSecrets }}
+{{- $hasLdapCrt := (hasKey $.Values.customSecrets "ldapCacert") -}}
+{{- $hasBundleCrt := (hasKey . "bundleCacert") -}}
+{{- if or $hasLdapCrt $hasBundleCrt }}
+{{- $ldapCrtEnabled := ternary (.ldapCacert).enabled false $hasLdapCrt -}}
+{{- $bundleCrtEnabled := ternary (.bundleCacert).enabled false $hasBundleCrt -}}
+{{- $ldapSecretName := (include "ldapCacert.secretName" $) -}}
+{{- $bundleSecretName := (include "bundleCacert.secretName" $) -}}
+{{- if and (or $bundleCrtEnabled $ldapCrtEnabled) (eq $ldapSecretName $bundleSecretName) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $ldapSecretName }}
+  namespace: {{ $.Release.Namespace }}
+type: Opaque
+data:
+{{- if $ldapCrtEnabled }}
+  ldap-ca.crt: {{ .ldapCacert.crt | required "customSecrets.ldapCacert.crt is required!" | b64enc }}
+{{- end }}
+{{- if $bundleCrtEnabled }}
+  bundle-ca.crt: {{ .bundleCacert.crt | required "customSecrets.bundleCacert.crt is required!" | b64enc }}
+{{- end }}
+{{- else }}
+{{- if $ldapCrtEnabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $ldapSecretName }}
+  namespace: {{ $.Release.Namespace }}
+type: Opaque
+data:
+  ldap-ca.crt: {{ .ldapCacert.crt | required "customSecrets.ldapCacert.crt is required!" | b64enc }}
+{{- end }}
+{{- if $bundleCrtEnabled }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $bundleSecretName }}
+  namespace: {{ $.Release.Namespace }}
+type: Opaque
+data:
+  bundle-ca.crt: {{ .bundleCacert.crt | required "customSecrets.bundleCacert.crt is required!" | b64enc }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/.helm/starter/templates/secrets/ee-pull-credentials-secret.yaml
+++ b/.helm/starter/templates/secrets/ee-pull-credentials-secret.yaml
@@ -1,0 +1,19 @@
+{{- if ($.Values.customSecrets).enabled }}
+{{- if hasKey .Values.customSecrets "eePullCredentials" }}
+{{- with $.Values.customSecrets.eePullCredentials }}
+{{- if .enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "eePullCredentials.secretName" $ }}
+  namespace: {{ $.Release.Namespace }}
+type: Opaque
+stringData:
+  url: {{ (required "customSecrets.eePullCredentials.url is required!" .url) | quote }}
+  username: {{ (required "customSecrets.eePullCredentials.username is required!" .username) | quote }}
+  password: {{ (required "customSecrets.eePullCredentials.password is required!" .password) | quote }}
+  ssl_verify: {{ or .sslVerify (eq (.sslVerify | toString) "<nil>") | quote }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/.helm/starter/templates/secrets/ingress-tls-secret.yaml
+++ b/.helm/starter/templates/secrets/ingress-tls-secret.yaml
@@ -1,0 +1,25 @@
+{{- if ($.Values.customSecrets).enabled }}
+{{- if hasKey .Values.customSecrets "ingressTls" }}
+{{- with $.Values.customSecrets.ingressTls }}
+{{- if .enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "ingressTls.secretName" $ }}
+  namespace: {{ $.Release.Namespace }}
+{{- if .labels }}
+  labels:
+{{ toYaml .labels | indent 4 }}
+{{- end }}
+type: kubernetes.io/tls
+data:
+{{- if .selfSignedCert }}
+{{ ( include "ingress.gen-certs" $ ) | indent 2 }}
+{{ else }}
+  tls.key: {{ (.key | required "customSecrets.ingressTls.key is required!") | b64enc }}
+  tls.crt: {{ (.certificate | required "customSecrets.ingressTls.certificate is required!") | b64enc }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/.helm/starter/templates/secrets/ldap-password-secret.yaml
+++ b/.helm/starter/templates/secrets/ldap-password-secret.yaml
@@ -1,0 +1,16 @@
+{{- if ($.Values.customSecrets).enabled }}
+{{- if hasKey .Values.customSecrets "ldap" }}
+{{- with $.Values.customSecrets.ldap }}
+{{- if .enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "ldap.secretName" $ }}
+  namespace: {{ $.Release.Namespace }}
+type: Opaque
+data:
+  ldap-password: {{ .password | required "customSecrets.ldap.password is required!" | b64enc }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/.helm/starter/templates/secrets/route-tls-secret.yaml
+++ b/.helm/starter/templates/secrets/route-tls-secret.yaml
@@ -1,0 +1,17 @@
+{{- if ($.Values.customSecrets).enabled }}
+{{- if hasKey .Values.customSecrets "routeTls" }}
+{{- with $.Values.customSecrets.routeTls }}
+{{- if .enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "routeTls.secretName" $ }}
+  namespace: {{ $.Release.Namespace }}
+type: kubernetes.io/tls
+data:
+  tls.key: {{ (.key | required "customSecrets.routeTls.key is required!") | b64enc }}
+  tls.crt: {{ (.certificate | required "customSecrets.routeTls.certificate is required!") | b64enc }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/.helm/starter/templates/secrets/secret-key-secret.yaml
+++ b/.helm/starter/templates/secrets/secret-key-secret.yaml
@@ -1,0 +1,16 @@
+{{- if ($.Values.customSecrets).enabled }}
+{{- if hasKey .Values.customSecrets "secretKey" }}
+{{- with $.Values.customSecrets.secretKey }}
+{{- if .enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "secretKey.secretName" $ }}
+  namespace: {{ $.Release.Namespace }}
+type: Opaque
+stringData:
+  secret_key: {{ .key | required "customSecrets.secretKey.key is required!" | quote }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/.helm/starter/templates/storage/_helpers.tpl
+++ b/.helm/starter/templates/storage/_helpers.tpl
@@ -1,0 +1,57 @@
+{{/*
+Generate the name of the persistent volume for postgres folders
+*/}}
+{{- define "postgres.persistentVolumeName" -}}
+{{ printf "%s-postgres-volume" $.Values.AWX.name }}
+{{- end }}
+
+{{/*
+Generate the name of the persistent volume for projects folder
+*/}}
+{{- define "projects.persistentVolumeName" -}}
+{{ printf "%s-projects-volume" $.Values.AWX.name }}
+{{- end }}
+
+{{/*
+Generate the name of the persistent volume claim for the projects volume
+*/}}
+{{- define "projects.persistentVolumeClaim" -}}
+{{ printf "%s-projects-claim" $.Values.AWX.name }}
+{{- end }}
+
+{{/*
+Generate the name of the storage class to use for the postgres volume
+*/}}
+{{- define "postgres.storageClassName" -}}
+{{ default (printf "%s-postgres-volume" $.Values.AWX.name) (default $.Values.AWX.spec.postgres_storage_class (($.Values.customVolumes).postgres).storageClassName) }}
+{{- end }}
+
+{{/*
+Generate the name of the storage class to use for the projects volume
+*/}}
+{{- define "projects.storageClassName" -}}
+{{ default (printf "%s-projects-volume" $.Values.AWX.name) (default $.Values.AWX.spec.projects_storage_class (($.Values.customVolumes).projects).storageClassName) }}
+{{- end }}
+
+{{/*
+Generate the name of the storage class names, expects AWX context passed in
+*/}}
+{{- define "spec.storageClassNames" -}}
+{{- if and (not $.Values.AWX.postgres.enabled) (eq (($.Values.AWX.spec).postgres_configuration_secret | default "") "") -}}
+{{- if (($.Values.customVolumes).postgres).enabled -}}
+  {{- if not (hasKey $.Values.AWX.spec "postgres_storage_class") }}
+  postgres_storage_class: {{ include "postgres.storageClassName" $ }}    
+  {{- end }}
+  {{- if not (hasKey $.Values.AWX.spec "postgres_storage_requirements") }}
+  postgres_storage_requirements:
+    requests:
+      storage: {{ default "8Gi" $.Values.customVolumes.postgres.size | quote }}
+  {{- end }}
+{{- end }}
+{{- end }}
+{{- if and ($.Values.AWX.spec.projects_persistence) (eq (($.Values.AWX.spec).projects_existing_claim | default "") "") -}}
+{{- if (($.Values.customVolumes).projects).enabled }}
+  projects_existing_claim: {{ include "projects.persistentVolumeClaim" $ }} 
+{{- end }}
+{{- end }}
+{{- end }}

--- a/.helm/starter/templates/storage/postgres-pv.yaml
+++ b/.helm/starter/templates/storage/postgres-pv.yaml
@@ -1,0 +1,19 @@
+{{- if and (not $.Values.AWX.postgres.enabled) (eq (($.Values.AWX.spec).postgres_configuration_secret | default "") "") -}}
+{{- if (($.Values.customVolumes).postgres).enabled -}}
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: {{ include "postgres.persistentVolumeName" $ }}
+{{- with $.Values.customVolumes.postgres }}
+spec:
+  accessModes:
+    - {{ default "ReadWriteOnce" .accessModes }}
+  persistentVolumeReclaimPolicy: {{ default "Retain" .reclaimPolicy | quote }}
+  capacity:
+    storage: {{ default "8Gi" .size | quote }}
+  storageClassName: {{ include "postgres.storageClassName" $ }}
+  hostPath:
+    path: {{ required "customVolumes.postgres.hostPath or spec.postgres_data_path are required!" (default ($.Values.AWX.spec).postgres_data_path .hostPath) | quote }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/.helm/starter/templates/storage/projects-pv.yaml
+++ b/.helm/starter/templates/storage/projects-pv.yaml
@@ -1,0 +1,32 @@
+{{- if and ($.Values.AWX.spec.projects_persistence) (eq (($.Values.AWX.spec).projects_existing_claim | default "") "") -}}
+{{- if (($.Values.customVolumes).projects).enabled -}}
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: {{ include "projects.persistentVolumeName" $ }}
+{{- with $.Values.customVolumes.projects }}
+spec:
+  accessModes:
+    - {{ default "ReadWriteOnce" (default $.Values.AWX.spec.projects_storage_access_mode .accessModes) }}
+  persistentVolumeReclaimPolicy: {{ default "Retain" .reclaimPolicy | quote }}
+  capacity:
+    storage: {{ default "8Gi" (default $.Values.AWX.spec.projects_storage_size .size) | quote }}
+  storageClassName: {{ include "projects.storageClassName" $ }}
+  hostPath:
+    path: {{ required "customVolumes.projects.hostPath is required!" .hostPath | quote }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "projects.persistentVolumeClaim" $ }} 
+spec:
+  accessModes:
+    - {{ default "ReadWriteOnce" (default $.Values.AWX.spec.projects_storage_access_mode .accessModes) }}
+  volumeMode: Filesystem
+  resources:
+    requests:
+      storage: {{ default "8Gi" (default $.Values.AWX.spec.projects_storage_size .size) | quote }}
+  storageClassName: {{ include "projects.storageClassName" $ }}
+{{- end }}  
+{{- end }}
+{{- end }}


### PR DESCRIPTION
##### SUMMARY
This PR allows deploying secrets and persistentvolumes resources required by AWX in the cluster when using the Helm Chart for PoC or testing. 

Resources are defined in the `customSecrets` and `customVolumes` values. 

Compared to the `extraDeploy` value, you don't need to know any special syntax to describe resources.

##### ISSUE TYPE
- New or Enhanced Feature

Example usage in a values.yml file

````yaml
AWX:
  # enable use of awx-deploy template
  ...

  spec:
     projects_persistence: true

  # configurations for external postgres instance
  postgres:
    enabled: false
    ...

customSecrets:
  enabled: true
  admin:
    enabled: true
    password: mysuperlongpassword
  secretKey:
    enabled: true
    key: supersecuresecretkey
    secretName: my-awx-secret-key
  ingressTls:
    enabled: true
    selfSignedCert: false
    key: fakekey 
    certificate: fakecertificate
  bundleCacert:
    enabled: true
    crt: <contentofmybundlecacrt>
  cpPullCredentials:
    enabled: false
    dockerconfig:
      - registry: docker.io
        username: user
        password: pwd

customVolumes:
  postgres:
    enabled: true
    hostPath: /data/postgres-13
  projects:
   enabled: true
   hostPath: /data/projects
````

Example usage with `kubernetes.core.helm` Ansible module: 

````yaml
- name: Deploy the AWX instance
  kubernetes.core.helm:
    ...  
    values_files: 
      AWX:
        spec:
           projects_persistence: true
      customSecrets:
        enabled: true
        admin:
          enabled: true
          password: !vault |
            $ANSIBLE_VAULT;1.2;AES256
            346534353436643039616632653135656534
        secretKey:
          enabled: true
          password: !vault |
            $ANSIBLE_VAULT;1.2;AES256
            346534353436643039616632653135656534
          secretName: my-awx-secret-key
        ingressTls:
          enabled: true
          selfSignedCert: false
          key: fakekey 
          certificate: fakecertificate
        bundleCacert:
          enabled: true
          crt: "{{ lookup('ansible.builtin.file', 'ca-certs.crt') }}"
        ldapCacert:
          enabled: true
          crt: "{{ lookup('ansible.builtin.file', 'ldap-certs.crt') }}"
      customVolumes:
        postgres:
        enabled: true
          hostPath: /data/postgres-13
        projects:
          enabled: true
          hostPath: /data/projects