### PR TITLE
[PoC] using kustomize to provide flexible override to awx deployments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,10 @@ USER root
 RUN dnf update --security --bugfix -y && \
     dnf install -y openssl
 
+# Install kustomize
+RUN curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"  | bash
+RUN mv kustomize /usr/local/bin/
+
 USER 1001
 
 ARG DEFAULT_AWX_VERSION

--- a/config/crd/bases/awx.ansible.com_awxs.yaml
+++ b/config/crd/bases/awx.ansible.com_awxs.yaml
@@ -1839,6 +1839,12 @@ spec:
                 description: Disable web container's nginx ipv6 listener
                 type: boolean
                 default: false
+              task_pod_spec_kustomization:
+                description: Kustomize
+                type: string
+              web_pod_spec_kustomization:
+                description: Kustomize
+                type: string
             type: object
           status:
             properties:

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,13 +5,13 @@ generatorOptions:
   disableNameSuffixHash: true
 
 configMapGenerator:
-- files:
+- name: awx-manager-config
+  files:
   - controller_manager_config.yaml
-  name: awx-manager-config
 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: quay.io/haoliu/awx-operator
-  newTag: 2.10.0-3-g5be4c130
+  newName: quay.io/ansible/awx-operator
+  newTag: latest

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,13 +5,13 @@ generatorOptions:
   disableNameSuffixHash: true
 
 configMapGenerator:
-- name: awx-manager-config
-  files:
+- files:
   - controller_manager_config.yaml
+  name: awx-manager-config
 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: quay.io/ansible/awx-operator
-  newTag: latest
+  newName: quay.io/haoliu/awx-operator
+  newTag: 2.10.0-3-g5be4c130

--- a/roles/installer/defaults/main.yml
+++ b/roles/installer/defaults/main.yml
@@ -481,3 +481,6 @@ nginx_worker_processes: 1
 nginx_worker_connections: "{{ uwsgi_listen_queue_size }}"
 nginx_worker_cpu_affinity: 'auto'
 nginx_listen_queue_size: "{{ uwsgi_listen_queue_size }}"
+
+task_pod_spec_kustomization: ""
+web_pod_spec_kustomization: ""

--- a/roles/installer/tasks/resources_configuration.yml
+++ b/roles/installer/tasks/resources_configuration.yml
@@ -245,16 +245,58 @@
   set_fact:
     _redis_image: "{{ _custom_redis_image | default(lookup('env', 'RELATED_IMAGE_AWX_REDIS')) | default(_default_redis_image, true) }}"
 
-- name: Apply deployment resources
+- name: Create directory for kustomize
+  ansible.builtin.file:
+    path: "deployments"
+    state: directory
+  register: _deployment_kustomize_dir
+
+- name: Create tmp dir for {{ item }} deployment
+  tempfile:
+    state: directory
+  register: _deployment_kustomize_dir
+
+- name: Copy over kustomization.yaml to tmp dir
+  copy:
+    src: ../templates/deployments/kustomization.yaml
+    dest: "{{ _deployment_kustomize_dir.path }}"
+
+- name: Template deployments and overrides
+  template:
+    src: deployments/{{ item }}.yaml.j2
+    dest: "{{ _deployment_kustomize_dir.path }}/{{ item }}.yaml"
+  loop:
+    - "task"
+    - "task_override"
+    - "web"
+    - "web_override"
+
+- name: Run kustomize build on task deployment and store in deployments.yaml
+  command: kustomize build {{ _deployment_kustomize_dir.path }} -o {{ _deployment_kustomize_dir.path }}/deployments.yaml
+  register: _deployments
+
+# - name: Fail always
+#   fail:
+#     msg: "DEBUG: {{ _deployments.stdout }}"
+
+- name: Apply task deployment resources
   k8s:
     apply: yes
-    definition: "{{ lookup('template', 'deployments/{{ item }}.yaml.j2') }}"
+    definition: "{{ lookup('file', '{{ _deployment_kustomize_dir.path }}/deployments.yaml') }}"
     wait: yes
     wait_timeout: "{{ (120 * replicas) or 120 }}"
-  loop:
-    - task
-    - web
   register: this_deployment_result
+
+# - name: Apply deployment resources
+#   k8s:
+#     apply: yes
+#     definition: "{{ lookup('template', 'deployments/{{ item }}.yaml.j2') }}"
+#     wait: yes
+#     wait_timeout: "{{ (120 * replicas) or 120 }}"
+#   loop:
+#     - task
+#     - web
+#   register: this_deployment_result
 
 - block:
     - name: Get the new resource pod information after updating resource.

--- a/roles/installer/templates/deployments/kustomization.yaml
+++ b/roles/installer/templates/deployments/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - task.yaml
+  - web.yaml
+patches:
+  - path: task_override.yaml
+  - path: web_override.yaml

--- a/roles/installer/templates/deployments/task_override.yaml.j2
+++ b/roles/installer/templates/deployments/task_override.yaml.j2
@@ -1,0 +1,12 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: '{{ ansible_operator_meta.name }}-task'
+  namespace: '{{ ansible_operator_meta.namespace }}'
+{% if task_pod_spec_kustomization is defined and task_pod_spec_kustomization %}
+spec:
+  template:
+    spec:
+{{ task_pod_spec_kustomization | indent(width=6, first=True) }}
+{% endif %}

--- a/roles/installer/templates/deployments/web_override.yaml.j2
+++ b/roles/installer/templates/deployments/web_override.yaml.j2
@@ -1,0 +1,12 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: '{{ ansible_operator_meta.name }}-web'
+  namespace: '{{ ansible_operator_meta.namespace }}'
+{% if web_pod_spec_kustomization is defined and web_pod_spec_kustomization %}
+spec:
+  template:
+    spec:
+{{ web_pod_spec_kustomization | indent(width=6, first=True) }}
+{% endif %}


### PR DESCRIPTION
##### SUMMARY
example
```
task_pod_spec_kustomization: |
  containers:
  - name: extra-container
    image: quay.io/ansible/awx-ee:latest
    args:
    - /bin/sh
    - -c
    - |
      echo "Hello from extra-container"
      sleep 3600
```


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Breaking Change 
 - New or Enhanced Feature
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
