### PR TITLE
Fix makefile ansible-operator URL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -177,7 +177,7 @@ ifeq (,$(shell which operator-sdk 2>/dev/null))
 	@{ \
 	set -e ;\
 	mkdir -p $(dir $(OPERATOR_SDK)) ;\
-	curl -sSLo $(OPERATOR_SDK) https://github.com/operator-framework/operator-sdk/releases/download/v1.32.0/operator-sdk_$(OS)_$(ARCHA) ;\
+	curl -sSLo $(OPERATOR_SDK) https://github.com/operator-framework/operator-sdk/releases/download/v1.33.0/operator-sdk_$(OS)_$(ARCHA) ;\
 	chmod +x $(OPERATOR_SDK) ;\
 	}
 else
@@ -193,7 +193,7 @@ ifeq (,$(shell which ansible-operator 2>/dev/null))
 	@{ \
 	set -e ;\
 	mkdir -p $(dir $(ANSIBLE_OPERATOR)) ;\
-	curl -sSLo $(ANSIBLE_OPERATOR) https://github.com/operator-framework/operator-sdk/releases/download/v1.32.0/ansible-operator_$(OS)_$(ARCHA) ;\
+	curl -sSLo $(ANSIBLE_OPERATOR) https://github.com/operator-framework/ansible-operator-plugins/releases/download/v1.34.0/ansible-operator_$(OS)_$(ARCHA) ;\
 	chmod +x $(ANSIBLE_OPERATOR) ;\
 	}
 else


### PR DESCRIPTION
The binary for ansible-operator v1.32.0 does not exist.

##### SUMMARY
The version hard coded 1.32.0 does not exist.
https://github.com/ansible/awx-operator/blob/devel/Makefile#L196

Only v1.31.0 is currently available
https://github.com/operator-framework/operator-sdk/releases
This PR sets it to 1.31.0 until a newer version becomes available.

https://github.com/operator-framework/operator-sdk/releases

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION

