### PR TITLE
[draft] add empytdir mount to ee container in task pod

### DIFF
--- a/roles/installer/templates/deployments/task.yaml.j2
+++ b/roles/installer/templates/deployments/task.yaml.j2
@@ -319,6 +319,8 @@ spec:
               mountPath: "/var/run/receptor"
             - name: "{{ ansible_operator_meta.name }}-projects"
               mountPath: "/var/lib/awx/projects"
+            - name: "{{ ansible_operator_meta.name }}-receptor-tmp-volume"
+              mountPath: /tmp
 {% if ee_extra_volume_mounts -%}
             {{ ee_extra_volume_mounts | indent(width=12, first=True) }}
 {% endif %}
@@ -449,6 +451,9 @@ spec:
       terminationGracePeriodSeconds: {{ termination_grace_period_seconds }}
 {% endif %}
       volumes:
+        - name: "{{ ansible_operator_meta.name }}-receptor-tmp-volume"
+          emptyDir:
+          medium: Memory
 {% if bundle_ca_crt %}
         - name: "ca-trust-extracted"
           emptyDir: {}


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Mount a memory backed emptyDir to the ee container /tmp so receptor writes the job events its streaming back from job pods to memory instead of the container writable layer, which is copy-on-write. 

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
-->
so far **just works** in local kind cluster
would like to test out and compare apples:apples and measure RAM usage, job event processing performance

I've built the operator container here: quay.io/kdelee/awx-operator:receptor-emptydir

Doesn't require any special awx image