### PR TITLE
1301 parametrize image locations

### DIFF
--- a/.helm/starter/values.yaml
+++ b/.helm/starter/values.yaml
@@ -5,6 +5,12 @@ operator_image: quay.io/ansible/awx-operator
 operator_version: latest
 
 
+# if you are using a private registry requiring authentication, replace the default imagePullSecrets here.
+# Those need to be defined already within the namespace to which you release this helm chart.
+# Keep in mind you also need to pass those for resources you define via the operator - defined in roles/installer/defaults/main.yml
+imagePullSecrets:
+  - redhat-operators-pull-secret
+
 rbac_proxy_image: gcr.io/kubebuilder/kube-rbac-proxy
 rbac_proxy_version: v0.15.0
 

--- a/.helm/starter/values.yaml
+++ b/.helm/starter/values.yaml
@@ -1,3 +1,13 @@
+# images for the operator itself, not the AWX deployment
+# For airgapped installs, modify both those and the AWX.spec - you can pass the 
+# variables as defined in https://github.com/ansible/awx-operator/blob/devel/roles/installer/tasks/resources_configuration.yml
+operator_image: quay.io/ansible/awx-operator
+operator_version: latest
+
+
+rbac_proxy_image: gcr.io/kubebuilder/kube-rbac-proxy
+rbac_proxy_version: v0.15.0
+
 AWX:
   # enable use of awx-deploy template
   enabled: false

--- a/Makefile
+++ b/Makefile
@@ -332,8 +332,9 @@ helm-chart: helm-chart-generate
 .PHONY: helm-chart-generate
 helm-chart-generate: kustomize helm kubectl-slice yq charts
 	@echo "== KUSTOMIZE: Set image and chart label =="
-	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
+	cd config/manager && $(KUSTOMIZE) edit set image controller="{{ .Values.operator_image }}:{{ .Values.operator_version }}"
 	cd config/manager && $(KUSTOMIZE) edit set label helm.sh/chart:$(CHART_NAME)
+	cd config/default && $(KUSTOMIZE) edit set image rbac_proxy="{{ .Values.rbac_proxy_image }}:{{ .Values.rbac_proxy_version }}"
 	cd config/default && $(KUSTOMIZE) edit set label helm.sh/chart:$(CHART_NAME)
 
 	@echo "== Gather Helm Chart Metadata =="

--- a/Makefile
+++ b/Makefile
@@ -379,6 +379,9 @@ helm-chart-generate: kustomize helm kubectl-slice yq charts
 
 	# Correct the reference for the clusterrolebinding
 	$(YQ) -i -y '.roleRef.name += "-{{ .Release.Name }}"' 'charts/$(CHART_NAME)/raw-files/clusterrolebinding-awx-operator-proxy-rolebinding.yaml'
+	# Add ImagePullSecrets Helm value template to the operator Deployment
+	$(YQ) -i -y '.spec.template.spec.imagePullSecrets = "{{ .Values.imagePullSecrets }}"' charts/$(CHART_NAME)/raw-files/deployment-awx-operator-controller-manager.yaml
+
 	# move all custom resource definitions to crds folder
 	mkdir charts/$(CHART_NAME)/crds
 	mv charts/$(CHART_NAME)/raw-files/customresourcedefinition*.yaml charts/$(CHART_NAME)/crds/.

--- a/Makefile
+++ b/Makefile
@@ -342,9 +342,9 @@ helm-chart-generate: kustomize helm kubectl-slice yq charts
 	# create new chart metadata in Chart.yaml
 	cd charts && \
 		$(HELM) create awx-operator --starter $(shell pwd)/.helm/starter ;\
-		$(YQ) -i '.version = "$(VERSION)"' $(CHART_NAME)/Chart.yaml ;\
-		$(YQ) -i '.appVersion = "$(VERSION)" | .appVersion style="double"' $(CHART_NAME)/Chart.yaml ;\
-		$(YQ) -i '.description = "$(CHART_DESCRIPTION)"' $(CHART_NAME)/Chart.yaml ;\
+		$(YQ) -i -y '.version = "$(VERSION)"' $(CHART_NAME)/Chart.yaml ;\
+		$(YQ) -i -y '.appVersion = "$(VERSION)" | .appVersion style="double"' $(CHART_NAME)/Chart.yaml ;\
+		$(YQ) -i -y '.description = "$(CHART_DESCRIPTION)"' $(CHART_NAME)/Chart.yaml ;\
 
 	@echo "Generated chart metadata:"
 	@cat charts/$(CHART_NAME)/Chart.yaml
@@ -364,20 +364,20 @@ helm-chart-generate: kustomize helm kubectl-slice yq charts
 	@echo "== Build Templates and CRDS =="
 	# Delete metadata.namespace, release namespace will be automatically inserted by helm
 	for file in charts/$(CHART_NAME)/raw-files/*; do\
-		$(YQ) -i 'del(.metadata.namespace)' $${file};\
+		$(YQ) -i -y 'del(.metadata.namespace)' $${file};\
 	done
 	# Correct namespace for rolebinding to be release namespace, this must be explicit
 	for file in charts/$(CHART_NAME)/raw-files/*rolebinding*; do\
-		$(YQ) -i '.subjects[0].namespace = "{{ .Release.Namespace }}"' $${file};\
+		$(YQ) -i -y '.subjects[0].namespace = "{{ .Release.Namespace }}"' $${file};\
 	done
 	# Correct .metadata.name for cluster scoped resources
 	cluster_scoped_files="charts/$(CHART_NAME)/raw-files/clusterrolebinding-awx-operator-proxy-rolebinding.yaml charts/$(CHART_NAME)/raw-files/clusterrole-awx-operator-metrics-reader.yaml charts/$(CHART_NAME)/raw-files/clusterrole-awx-operator-proxy-role.yaml";\
 	for file in $${cluster_scoped_files}; do\
-		$(YQ) -i '.metadata.name += "-{{ .Release.Name }}"' $${file};\
+		$(YQ) -i -y '.metadata.name += "-{{ .Release.Name }}"' $${file};\
 	done
 
 	# Correct the reference for the clusterrolebinding
-	$(YQ) -i '.roleRef.name += "-{{ .Release.Name }}"' 'charts/$(CHART_NAME)/raw-files/clusterrolebinding-awx-operator-proxy-rolebinding.yaml'
+	$(YQ) -i -y '.roleRef.name += "-{{ .Release.Name }}"' 'charts/$(CHART_NAME)/raw-files/clusterrolebinding-awx-operator-proxy-rolebinding.yaml'
 	# move all custom resource definitions to crds folder
 	mkdir charts/$(CHART_NAME)/crds
 	mv charts/$(CHART_NAME)/raw-files/customresourcedefinition*.yaml charts/$(CHART_NAME)/crds/.

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -28,3 +28,10 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 patches:
 - path: manager_auth_proxy_patch.yaml
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+images:
+- name: rbac_proxy
+  newName: gcr.io/kubebuilder/kube-rbac-proxy
+  newTag: v0.15.0

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -15,7 +15,7 @@ spec:
           capabilities:
             drop:
             - "ALL"
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.15.0
+        image: "rbac_proxy"
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -15,7 +15,7 @@ spec:
           capabilities:
             drop:
             - "ALL"
-        image: "rbac_proxy"
+        image: rbac_proxy
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -38,7 +38,7 @@ spec:
       - args:
         - --leader-elect
         - --leader-election-id=awx-operator
-        image: controller:latest
+        image: controller
         imagePullPolicy: Always
         name: awx-manager
         env:


### PR DESCRIPTION
##### SUMMARY

This allows users of private registries to use Values.yml to configure the operator and rbac proxy images and point at their images, while keeping the default behaviour same as on the current chart.

It removes the need to constantly rebuild the chart in-house and makes it reusable across organizations.

It also includes a separate commit with a minor yq fix - a missing `-y` flag was causing it to error when testing the `helm-chart` make target.

##### ISSUE TYPE
 - New or Enhanced Feature

##### ADDITIONAL INFORMATION

Issue link:
https://github.com/ansible/awx-operator/issues/1301

Comparison of the resulting charts - ../../awx-operator is an unpacked official chart for 2.11.0:

```
➜  awx-operator git:(1301-parametrize-image-locations) diff ../../awx-operator/ charts/awx-operator
diff --color ../../awx-operator/Chart.yaml charts/awx-operator/Chart.yaml
2c2
< appVersion: 2.11.0
---
> appVersion: 0.1.0
6c6
< version: 2.11.0
---
> version: 2.11.0-5-g165d099
Common subdirectories: ../../awx-operator/crds and charts/awx-operator/crds
Common subdirectories: ../../awx-operator/templates and charts/awx-operator/templates
diff --color ../../awx-operator/values.yaml charts/awx-operator/values.yaml
0a1,10
> # images for the operator itself, not the AWX deployment
> # For airgapped installs, modify both those and the AWX.spec - you can pass the 
> # variables as defined in https://github.com/ansible/awx-operator/blob/devel/roles/installer/tasks/resources_configuration.yml
> operator_image: quay.io/ansible/awx-operator
> operator_version: latest
> 
> 
> rbac_proxy_image: gcr.io/kubebuilder/kube-rbac-proxy
> rbac_proxy_version: v0.15.0
```