### PR TITLE
Separate out the custom receptor CA section to its own section.

### DIFF
--- a/docs/user-guide/advanced-configuration/adding-execution-nodes.md
+++ b/docs/user-guide/advanced-configuration/adding-execution-nodes.md
@@ -1,26 +1,4 @@
 ### Adding Execution Nodes
 Starting with AWX Operator v0.30.0 and AWX v21.7.0, standalone execution nodes can be added to your deployments.
-See [AWX execution nodes docs](https://github.com/ansible/awx/blob/devel/docs/execution_nodes.md) for information about this feature.
+See [Managing Capacity With Instances](https://ansible.readthedocs.io/projects/awx/en/latest/administration/instances.html) chapter of the AWX Administration Guide for information about this feature.
 
-#### Custom Receptor CA
-The control nodes on the K8S cluster will communicate with execution nodes via mutual TLS TCP connections, running via Receptor.
-Execution nodes will verify incoming connections by ensuring the x509 certificate was issued by a trusted Certificate Authority (CA).
-
-A user may wish to provide their own CA for this validation. If no CA is provided, AWX Operator will automatically generate one using OpenSSL.
-
-Given custom `ca.crt` and `ca.key` stored locally, run the following,
-
-```bash
-kubectl create secret tls awx-demo-receptor-ca \
-   --cert=/path/to/ca.crt --key=/path/to/ca.key
-```
-
-The secret should be named `{AWX Custom Resource name}-receptor-ca`. In the above the AWX CR name is "awx-demo". Please replace "awx-demo" with your AWX Custom Resource name.
-
-If this secret is created after AWX is deployed, run the following to restart the deployment,
-
-```bash
-kubectl rollout restart deployment awx-demo
-```
-
-**Important Note**, changing the receptor CA will break connections to any existing execution nodes. These nodes will enter an `unavailable` state, and jobs will not be able to run on them. Users will need to download and re-run the install bundle for each execution node. This will replace the TLS certificate files with those signed by the new CA. The execution nodes should then appear in a `ready` state after a few minutes.

--- a/docs/user-guide/advanced-configuration/custom-receptor-certs.md
+++ b/docs/user-guide/advanced-configuration/custom-receptor-certs.md
@@ -1,0 +1,24 @@
+
+### Custom Receptor CA
+
+The control nodes on the K8S cluster will communicate with execution nodes via mutual TLS TCP connections, running via Receptor.
+Execution nodes will verify incoming connections by ensuring the x509 certificate was issued by a trusted Certificate Authority (CA).
+
+A user may wish to provide their own CA for this validation. If no CA is provided, AWX Operator will automatically generate one using OpenSSL.
+
+Given custom `ca.crt` and `ca.key` stored locally, run the following,
+
+```bash
+kubectl create secret tls awx-demo-receptor-ca \
+   --cert=/path/to/ca.crt --key=/path/to/ca.key
+```
+
+The secret should be named `{AWX Custom Resource name}-receptor-ca`. In the above the AWX CR name is "awx-demo". Please replace "awx-demo" with your AWX Custom Resource name.
+
+If this secret is created after AWX is deployed, run the following to restart the deployment,
+
+```bash
+kubectl rollout restart deployment awx-demo
+```
+
+**Important Note**, changing the receptor CA will break connections to any existing execution nodes. These nodes will enter an `unavailable` state, and jobs will not be able to run on them. Users will need to download and re-run the install bundle for each execution node. This will replace the TLS certificate files with those signed by the new CA. The execution nodes should then appear in a `ready` state after a few minutes.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -67,6 +67,7 @@ nav:
       - user-guide/advanced-configuration/scaling-the-web-and-task-pods-independently.md
       - user-guide/advanced-configuration/assigning-awx-pods-to-specific-nodes.md
       - user-guide/advanced-configuration/trusting-a-custom-certificate-authority.md
+      - user-guide/advanced-configuration/custom-receptor-certs.md
       - user-guide/advanced-configuration/enabling-ldap-integration-at-awx-bootstrap.md
       - user-guide/advanced-configuration/persisting-projects-directory.md
       - user-guide/advanced-configuration/custom-volume-and-volume-mount-options.md


### PR DESCRIPTION
##### SUMMARY
This PR separates the Custom Receptor CA section into its own section because it doesn't belong in the chapter for Adding Execution Nodes. This will become the external link: https://ansible.readthedocs.io/projects/awx-operator/en/latest/user-guide/advanced-configuration/custom-receptor-certs.html

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

