### PR TITLE
Remove empty statusDescriptor because it fails validation

### DIFF
--- a/config/manifests/bases/awx-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/awx-operator.clusterserviceversion.yaml
@@ -58,7 +58,6 @@ spec:
         path: ingress_controller
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
-      statusDescriptors: {}
       version: v1alpha1
     - description: Back up a deployment of the awx, including jobs, inventories, and
         credentials
@@ -637,8 +636,8 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:hidden
-      - displayName: Postgres Extra Volumes
-        description: Specify extra volumes to add to the postgres pod
+      - description: Specify extra volumes to add to the postgres pod
+        displayName: Postgres Extra Volumes
         path: postgres_extra_volumes
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced


### PR DESCRIPTION
##### SUMMARY

The following PR introduced an empty `statusDescriptor` entry which causes the bundle generation validation to fail.
* https://github.com/ansible/awx-operator/pull/1703/files#diff-2a4968792da0598da409c1e5bbc604542cdf7b2b52bbbf4179dd018fcf9baaf4R61

```
$ make bundle
Warning: Permanently added 'github.com' (ED25519) to the list of known hosts.
/home/chadams/bin/operator-sdk generate kustomize manifests -q
FATA[0000] Error generating kustomize files: error getting ClusterServiceVersion base: error reading existing ClusterServiceVersion base config/manifests/bases/awx-operator.clusterserviceversion.yaml: error unmarshaling ClusterServiceVersion from manifest config/manifests/bases/awx-operator.clusterserviceversion.yaml: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal object into Go struct field CRDDescription.spec.customresourcedefinitions.owned.statusDescriptors of type []v1alpha1.StatusDescriptor 
make: *** [Makefile:206: bundle] Error 1
```

This is unneeded and after removing it the validator passes.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION

After removing the empty statusDescriptor entry:

```
[chadams@awx awx-operator]$ make bundle
Warning: Permanently added 'github.com' (ED25519) to the list of known hosts.
/home/chadams/bin/operator-sdk generate kustomize manifests -q
cd config/manager && /home/chadams/awx-operator/bin/kustomize edit set image controller=quay.io/ansible/awx-operator:2.11.0-5-g368f786
/home/chadams/awx-operator/bin/kustomize build config/manifests | /home/chadams/bin/operator-sdk generate bundle -q --overwrite --version 2.11.0-5-g368f786  
INFO[0000] Creating bundle.Dockerfile                   
INFO[0000] Creating bundle/metadata/annotations.yaml    
INFO[0000] Bundle metadata generated suceessfully       
/home/chadams/bin/operator-sdk bundle validate ./bundle
INFO[0000] All validation tests have completed successfully 
```
