### PR TITLE
More locked down websocket path

### DIFF
--- a/roles/installer/templates/configmaps/config.yaml.j2
+++ b/roles/installer/templates/configmaps/config.yaml.j2
@@ -188,7 +188,7 @@ data:
                 alias /var/lib/awx/public/static/media/favicon.ico;
             }
 
-            location ~ ({{ (ingress_path + '/websocket').replace('//', '/') }}|{{ (ingress_path + '/api/websocket').replace('//', '/') }}) {
+            location ~ ^({{ (ingress_path + '/websocket/').replace('//', '/') }}|{{ (ingress_path + '/api/websocket/').replace('//', '/') }}) {
                 # Pass request to the upstream alias
                 proxy_pass http://daphne;
                 # Require http version 1.1 to allow for upgrade requests


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
* Previously, the nginx location would match on /foo/websocket... or /foo/api/websocket... Now, we require these two paths to start at the root i.e. <host>/websocket/... /api/websocket/...
* Note: We now also require an ending / and do NOT support <host>/websocket_foobar but DO support <host>/websocket/foobar. This was always the intended behavior. We want to keep <host>/api/websocket/... "open" and routing to daphne in case we want to add more websocket urls in the future.
<!---
If you are fixing an existing issue, please include "fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
