### PR TITLE
Tolerances and Affinity addition to Helm Chart

### DIFF
--- a/.helm/starter/values.yaml
+++ b/.helm/starter/values.yaml
@@ -17,3 +17,6 @@ AWX:
     password: Unset
     sslmode: prefer
     type: unmanaged
+
+tolerations: []
+affinity: {}

--- a/Makefile
+++ b/Makefile
@@ -375,6 +375,8 @@ helm-chart-generate: kustomize helm kubectl-slice yq charts
 	for file in $${cluster_scoped_files}; do\
 		$(YQ) -i '.metadata.name += "-{{ .Release.Name }}"' $${file};\
 	done
+	# Add tolerations and affinity to the deployment
+	$(SED_I) -E -e 's/^(      containers:)/{{- with .Values.tolerations }}\n      tolerations:\n{{- toYaml . | nindent 8 }}\n{{- end }}\n{{- with .Values.affinity }}\n      affinity:\n{{- toYaml . | nindent 8 }}\n{{- end }}\n\1/' charts/$(CHART_NAME)/raw-files/deployment-awx-operator-controller-manager.yaml
 
 	# Correct the reference for the clusterrolebinding
 	$(YQ) -i '.roleRef.name += "-{{ .Release.Name }}"' 'charts/$(CHART_NAME)/raw-files/clusterrolebinding-awx-operator-proxy-rolebinding.yaml'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This change introduces the ability to define tolerances and affinity to the AWX Operator.

The cluster on which I'm working is highly defined with taints to ensure workload placement, and the current helm chart does not allow it to be deployed. While adding support for tolerances, the other common placement option - affinity - was added at the same time.

##### ISSUE TYPE
 - New or Enhanced Feature

##### ADDITIONAL INFORMATION
When the current helm chart is deployed, on a cluster where all nodes have a taint (e.g. `xl:NoSchedule=true` or `clusterservices:NoSchedule=true`) the operator will go into a permanent "pending" state and in the events it will show:
```
  Type     Reason             Age                     From                Message
  ----     ------             ----                    ----                -------
  Warning  FailedScheduling   64s (x336 over 28h)     default-scheduler   0/6 nodes are available: 3 node(s) had untolerated taint {xl: true}, 3 node(s) had untolerated taint {clusterservices: true}. preemption: 0/6 nodes are available: 6 Preemption is not helpful for scheduling..
```

Adding toleration to the helm chart and implementing it will allow it to be scheduled.

I was unable to test this change with molecule as I don't have molecule installed or configured and the documentation for the operator points to an out-of-date link for molecule install guides, and the guides on ansible.com for molecule show an error about a driver not being configured. I did test the resulting helm chart on my cluster to show the tolerations were applied. I am happy to work with developers and contributors if any additional testing is required.