### PR TITLE
Update Dockerfile operator-framework/ansible-operator to v1.34.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/operator-framework/ansible-operator:v1.32.0
+FROM quay.io/operator-framework/ansible-operator:v1.34.0
 
 USER root
 RUN dnf update --security --bugfix -y && \


### PR DESCRIPTION
Vulnerability scans against this image when deployed shows: CVE-2023-4911

https://quay.io/repository/operator-framework/ansible-operator/manifest/sha256:f08f675976f42dc3a8ebbb8482acea153a8f57232e2ee48940e3d40ca40d24d9?tab=vulnerabilities

It appears if https://github.com/ansible/awx-operator/blob/5f3d9ed96f05b25b3c7f38df550d9f2bce0ec199/Dockerfile#L1C14-L1C49 is updated to `v1.34.0` this vulnerability is mitigated.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
