### PR TITLE
fix: revert removal trim symbol before endif

### DIFF
--- a/roles/installer/templates/networking/ingress.yaml.j2
+++ b/roles/installer/templates/networking/ingress.yaml.j2
@@ -13,7 +13,7 @@ metadata:
   annotations:
 {% if ingress_annotations %}
     {{ ingress_annotations | indent(width=4) }}
-{%- endif %}
+{% endif %}
 {% if ingress_controller|lower == "contour" %}
     projectcontour.io/websocket-routes: "/websocket"
     kubernetes.io/ingress.class: contour


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

Closes #1713 

<!---
If you are fixing an existing issue, please include "fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

By #1377, trim symbol (`-`) before `endif` was added. If we have defined `ingress_annotations` in one of the following way, this change will cause the `spec` for Ingress resource to break and the deployment to fail.

1. Defining `ingress_annotations` at the end of YAML file **without** trailing new line:

   ```yaml
   ---
   spec:
     ...
     ingress_type: ingress
     ingress_hosts:
       - hostname: awx-demo.example.com
     ingress_annotations: |
       environment: testing⛔
   ```

2. Defining `ingress_annotations` as single line strings:

   ```yaml
   ---
   spec:
     ...
     ingress_type: ingress
     ingress_hosts:
       - hostname: awx-demo.example.com
     ingress_annotations: 'environment: testing'
   ```

This PR restores the trim symbols that were removed in #1377.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
-->

See https://github.com/ansible/awx-operator/issues/1713#issuecomment-1946361666 for details.
