### PR TITLE
Fix syntax error in mesh ingress docs

### DIFF
--- a/docs/user-guide/advanced-configuration/mesh-ingress.md
+++ b/docs/user-guide/advanced-configuration/mesh-ingress.md
@@ -131,7 +131,7 @@ AWXMeshIngressStatus describe the current state of the AWXMeshIngress.
 
 AWXMeshIngressList is a collection of AWXMeshIngress.
 
-- **items** ([][AWXMeshIngress](#awxmeshingress))
+- **items** ([AWXMeshIngress](#awxmeshingress))
 
   items is the list of Ingress.
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
readthedocs build is failing, as @kurokobo pointed out in #1718 

this should fix it
<!---
If you are fixing an existing issue, please include "fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change
