### PR TITLE
fix: correct indentation for annotations for awxmeshingress

### DIFF
--- a/roles/mesh_ingress/templates/ingress.yml.j2
+++ b/roles/mesh_ingress/templates/ingress.yml.j2
@@ -12,7 +12,7 @@ metadata:
     {{ ingress_annotations | indent(width=4) }}
 {% endif %}
 {% if ingress_controller|lower == "nginx" %}
-      nginx.ingress.kubernetes.io/ssl-passthrough: "true"
+    nginx.ingress.kubernetes.io/ssl-passthrough: "true"
 {% endif %}
 spec:
 {% if ingress_class_name %}


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

This PR fixes incorrect indentation for `annotations`. Deploying following CR:

```yaml
...
spec:
  ingress_class_name: nginx
  ingress_annotations: |
    test_anotation: test_value
  ...
```

causes deployment failure due to incorrect indentation:

```yaml
...
kind: Ingress
metadata:
  ...
  annotations:
    test_anotation: test_value
      nginx.ingress.kubernetes.io/ssl-passthrough: "true"     👈👈👈
spec:
  ...
```

<!---
If you are fixing an existing issue, please include "fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change
