### PR TITLE
docs: enable search feature

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,6 +18,9 @@ theme:
     - navigation.indexes
     - navigation.tracking
     - toc.integrate
+    - search.highlight
+    - search.share
+    - search.suggest
   palette:
     - media: "(prefers-color-scheme: light)"
       primary: teal
@@ -92,7 +95,8 @@ exclude_docs:
 plugins:
   - autorefs
   - markdown-exec
-  - search
+  - material/search:
+      separator: '[\s\-,:!=\[\]()"`/]+|\.(?!\d)|&[lg]t;|(?!\b)(?=[A-Z][a-z])'
   - mkdocstrings:
       handlers:
         python:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

This PR enables search feature on the docs page:

![image](https://github.com/ansible/awx-operator/assets/2920259/ea0603cc-22ed-4efe-93d3-f7a9e0855fd6)

![image](https://github.com/ansible/awx-operator/assets/2920259/d162f982-5775-4c2b-83b9-e01776606da9)

<!---
If you are fixing an existing issue, please include "fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
-->

The plugin configuration for mkdocs is based on the [ansible-lint repo](https://github.com/ansible/ansible-lint/blob/main/mkdocs.yml).
