### PR TITLE
Add container level security context for task and web deployments

### DIFF
--- a/config/crd/bases/awx.ansible.com_awxs.yaml
+++ b/config/crd/bases/awx.ansible.com_awxs.yaml
@@ -47,9 +47,13 @@ spec:
                 description: apiVersion of the deployment type
                 type: string
               task_privileged:
-                description: If a privileged security context should be enabled
+                description: (Deprecated) If a privileged security context should be enabled
                 type: boolean
                 default: false
+              task_security_context:
+                description: Key/values that will be set under the container-level securityContext field
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
               admin_user:
                 description: Username to use for the admin account
                 type: string
@@ -1715,12 +1719,20 @@ spec:
               ee_extra_volume_mounts:
                 description: Specify volume mounts to be added to Execution container
                 type: string
+              ee_security_context:
+                description: Key/values that will be set under the container-level securityContext field
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
               task_extra_volume_mounts:
                 description: Specify volume mounts to be added to Task container
                 type: string
               web_extra_volume_mounts:
                 description: Specify volume mounts to be added to the Web container
                 type: string
+              web_security_context:
+                description: Key/values that will be set under the container-level securityContext field
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
               postgres_extra_volume_mounts:
                 description: Specify volume mounts to be added to Postgres container
                 type: string
@@ -1745,6 +1757,10 @@ spec:
               rsyslog_extra_volume_mounts:
                 description: Specify volume mounts to be added to the Rsyslog container
                 type: string
+              rsyslog_security_context:
+                description: Key/values that will be set under the container-level securityContext field
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
               redis_image:
                 description: Registry path to the redis container to use
                 type: string
@@ -1752,10 +1768,14 @@ spec:
                 description: Redis container image version to use
                 type: string
               redis_capabilities:
-                description: Redis container capabilities
+                description: (Deprecated) Redis container capabilities
                 type: array
                 items:
                   type: string
+              redis_security_context:
+                description: Key/values that will be set under the container-level securityContext field
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
               init_container_image:
                 description: Registry path to the init container to use
                 type: string
@@ -1768,6 +1788,10 @@ spec:
               init_container_extra_volume_mounts:
                 description: Specify volume mounts to be added to the init container
                 type: string
+              init_security_context:
+                description: Key/values that will be set under the container-level securityContext field
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
               init_projects_container_image:
                 description: Registry path to the init projects container to use
                 type: string
@@ -1902,7 +1926,11 @@ spec:
                 description: Set session cookie secure mode for web
                 type: string
               postgres_security_context_settings:
-                description: Key/values that will be set under the pod-level securityContext field
+                description: (Deprecated) Key/values that will be set under the pod-level securityContext field
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              postgres_security_context:
+                description: Key/values that will be set under the container-level securityContext field
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
               receptor_log_level:

--- a/config/manifests/bases/awx-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/awx-operator.clusterserviceversion.yaml
@@ -134,8 +134,13 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:hidden
-      - displayName: PostgreSQL Security Context Settings
+      - displayName: PostgreSQL Security Context Settings (Deprecated)
         path: postgres_security_context_settings
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - displayName: PostgreSQL Security Context
+        path: postgres_security_context
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:hidden
@@ -486,6 +491,11 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
+      - displayName: Web Security Context Settings
+        path: web_security_context
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:hidden 
       - displayName: Task Container Resource Requirements
         path: task_resource_requirements
         x-descriptors:
@@ -517,11 +527,21 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
+      - displayName: Redis Security Context Settings
+        path: redis_security_context
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:hidden 
       - displayName: Rsyslog Container Resource Requirements
         path: rsyslog_resource_requirements
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
+      - displayName: Rsyslog Security Context Settings
+        path: rsyslog_security_context
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:hidden 
       - description: The PostgreSQL container is not used when an external DB is configured
         displayName: PostgreSQL Container Resource Requirements
         path: postgres_resource_requirements
@@ -605,7 +625,7 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
         - urn:alm:descriptor:com.tectonic.ui:hidden
-      - displayName: Should the task container deployed with privileged level?
+      - displayName: Should the task container deployed with privileged level? (Deprecated)
         path: task_privileged
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
@@ -646,7 +666,7 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:hidden
-      - displayName: Redis Capabilities
+      - displayName: Redis Capabilities (Deprecated)
         path: redis_capabilities
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
@@ -800,6 +820,11 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:hidden
+      - displayName: EE Security Context Settings
+        path: ee_security_context
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:hidden 
       - description: Registry path to the Execution Environment container to use
         displayName: EE Images
         path: ee_images
@@ -831,6 +856,11 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:hidden
+      - displayName: Task Security Context Settings
+        path: task_security_context
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:hidden 
       - displayName: Web Args
         path: web_args
         x-descriptors:
@@ -1047,6 +1077,11 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:hidden
+      - displayName: Init Security Context Settings
+        path: init_security_context
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:hidden 
       - description: Secret where can be found the trusted Certificate Authority Bundle
         path: bundle_cacert_secret
         x-descriptors:

--- a/docs/user-guide/advanced-configuration/security-context.md
+++ b/docs/user-guide/advanced-configuration/security-context.md
@@ -1,11 +1,18 @@
-# Security Context
+#### Service Account
 
-It is possible to modify some `SecurityContext` proprieties of the various deployments and stateful sets if needed.
+It is possible to modify some `SecurityContext` properties of the various deployments and stateful sets if needed.
 
-| Name                               | Description                                  | Default |
-| ---------------------------------- | -------------------------------------------- | ------- |
-| security_context_settings          | SecurityContext for Task and Web deployments | {}      |
-| postgres_security_context_settings | SecurityContext for PostgreSQL container | {}      |
+| Name                               | Description                                                          | Default |
+| ---------------------------------- | -------------------------------------------------------------------- | ------- |
+| security_context_settings          | Pod Level SecurityContext for Task and Web deployments               | {}      |
+| postgres_security_context | SecurityContext for Task and Web deployments                         | {}      |
+| web_security_context      | Container Level SecurityContext for Web deployment                   | {}      |
+| redis_security_context    | Redis Container Level SecurityContext for Task and Web deployments   | {}      |
+| rsyslog_security_context  | Rsyslog Container Level SecurityContext for Task and Web deployments | {}      |
+| ee_security_context      | EE Container Level SecurityContext for Task deployments              | {}      |
+| task_security_context     | Container Level SecurityContext for Task deployment                  | {}      |
+| init_security_context     | Init Container Level SecurityContext for Task and Web deployments    | {}      |
+
 
 Example configuration securityContext for the Task and Web deployments:
 

--- a/roles/installer/defaults/main.yml
+++ b/roles/installer/defaults/main.yml
@@ -463,7 +463,14 @@ garbage_collect_secrets: false
 development_mode: false
 
 security_context_settings: {}
-postgres_security_context_settings: {}
+postgres_security_context_settings: {} # Deprecated
+postgres_security_context: {}
+redis_security_context: {}
+init_security_context: {}
+task_security_context: {}
+rsyslog_security_context: {}
+web_security_context: {}
+ee_security_context: {}
 
 # Set no_log settings on certain tasks
 no_log: true

--- a/roles/installer/templates/deployments/task.yaml.j2
+++ b/roles/installer/templates/deployments/task.yaml.j2
@@ -127,6 +127,10 @@ spec:
           image: '{{ _init_container_image }}'
           imagePullPolicy: '{{ image_pull_policy }}'
           resources: {{ init_container_resource_requirements }}
+{% if init_security_context|length %}
+          securityContext:
+{{ init_security_context | to_yaml | indent(12,true) }}
+{%- endif %}
           command:
             - /bin/sh
             - -c
@@ -177,6 +181,10 @@ spec:
           image: '{{ _init_projects_container_image }}'
           imagePullPolicy: '{{ image_pull_policy }}'
           resources: {{ init_container_resource_requirements }}
+{% if init_security_context|length %}
+          securityContext:
+{{ init_security_context | to_yaml | indent(12,true) }}
+{%- endif %}
           command:
             - /bin/sh
             - -c
@@ -196,10 +204,16 @@ spec:
         - image: '{{ _redis_image }}'
           imagePullPolicy: '{{ image_pull_policy }}'
           name: redis
-{% if redis_capabilities is defined and redis_capabilities %}
+{% if redis_security_context|length or redis_capabilities is defined %}
           securityContext:
+{% if redis_security_context|length %}
+{{ redis_security_context | to_nice_yaml | indent(12,true) }}
+{%- endif %}
+{% if redis_capabilities is defined and redis_capabilities %}
             capabilities:
-              add: {{ redis_capabilities }}
+              add: 
+{{ redis_capabilities | to_yaml | indent(16,true) }}
+{%- endif %}
 {% endif %}
           args: ["redis-server", "/etc/redis.conf"]
           volumeMounts:
@@ -232,9 +246,14 @@ spec:
         - image: '{{ _image }}'
           name: '{{ ansible_operator_meta.name }}-task'
           imagePullPolicy: '{{ image_pull_policy }}'
-{% if task_privileged == true %}
+{% if task_security_context|length or task_privileged == true %}
           securityContext:
+{% if task_security_context|length %}
+{{ task_security_context | to_yaml | indent(12,true) }}
+{%- endif %}
+{% if task_privileged == true %}
             privileged: true
+{% endif %}
 {% endif %}
 {% if task_command %}
           command: {{ task_command }}
@@ -356,6 +375,10 @@ spec:
           name: '{{ ansible_operator_meta.name }}-ee'
           imagePullPolicy: '{{ image_pull_policy }}'
           resources: {{ ee_resource_requirements }}
+{% if ee_security_context|length %}
+          securityContext:
+{{ ee_security_context | to_yaml | indent(12,true) }}
+{%- endif %}
           args:
             - /bin/sh
             - -c
@@ -424,6 +447,10 @@ spec:
 {% endif %}
           imagePullPolicy: '{{ image_pull_policy }}'
           resources: {{ rsyslog_resource_requirements }}
+{% if rsyslog_security_context|length %}
+          securityContext:
+{{ rsyslog_security_context | to_yaml | indent(12,true) }}
+{%- endif %}
           volumeMounts:
             - name: "{{ ansible_operator_meta.name }}-application-credentials"
               mountPath: "/etc/tower/conf.d/credentials.py"

--- a/roles/installer/templates/deployments/web.yaml.j2
+++ b/roles/installer/templates/deployments/web.yaml.j2
@@ -107,6 +107,10 @@ spec:
           image: '{{ _init_container_image }}'
           imagePullPolicy: '{{ image_pull_policy }}'
           resources: {{ init_container_resource_requirements }}
+{% if init_security_context|length %}
+          securityContext:
+{{ init_security_context | to_yaml | indent(12,true) }}
+{%- endif %}
           command:
             - /bin/sh
             - -c
@@ -126,6 +130,10 @@ spec:
           image: '{{ _init_projects_container_image }}'
           imagePullPolicy: '{{ image_pull_policy }}'
           resources: {{ init_container_resource_requirements }}
+{% if init_security_context|length %}
+          securityContext:
+{{ init_security_context | to_yaml | indent(12,true) }}
+{%- endif %}
           command:
             - /bin/sh
             - -c
@@ -145,10 +153,16 @@ spec:
         - image: '{{ _redis_image }}'
           imagePullPolicy: '{{ image_pull_policy }}'
           name: redis
-{% if redis_capabilities is defined and redis_capabilities %}
+{% if redis_security_context|length or redis_capabilities is defined %}
           securityContext:
+{% if redis_security_context|length %}
+{{ redis_security_context | to_nice_yaml | indent(12,true) }}
+{%- endif %}
+{% if redis_capabilities is defined and redis_capabilities %}
             capabilities:
-              add: {{ redis_capabilities }}
+              add: 
+{{ redis_capabilities | to_yaml | indent(16,true) }}
+{%- endif %}
 {% endif %}
           args: ["redis-server", "/etc/redis.conf"]
           volumeMounts:
@@ -301,6 +315,10 @@ spec:
             {{ web_extra_env | indent(width=12, first=True) }}
 {% endif %}
           resources: {{ web_resource_requirements }}
+{% if web_security_context|length %}
+          securityContext:
+{{ web_security_context | to_yaml | indent(12,true) }}
+{%- endif %}
         - image: '{{ _image }}'
           name: '{{ ansible_operator_meta.name }}-rsyslog'
 {% if rsyslog_command %}
@@ -310,6 +328,11 @@ spec:
           args: {{ rsyslog_args }}
 {% endif %}
           imagePullPolicy: '{{ image_pull_policy }}'
+          resources: {{ rsyslog_resource_requirements }}
+{% if rsyslog_security_context|length %}
+          securityContext:
+{{ rsyslog_security_context | to_yaml | indent(12,true) }}
+{%- endif %}
           volumeMounts:
             - name: "{{ ansible_operator_meta.name }}-application-credentials"
               mountPath: "/etc/tower/conf.d/credentials.py"

--- a/roles/installer/templates/statefulsets/postgres.yaml.j2
+++ b/roles/installer/templates/statefulsets/postgres.yaml.j2
@@ -75,7 +75,10 @@ spec:
         - image: '{{ _postgres_image }}'
           imagePullPolicy: '{{ image_pull_policy }}'
           name: postgres
-{% if postgres_security_context_settings|length %}
+{% if postgres_security_context|length %}
+          securityContext:
+            {{ postgres_security_context | to_nice_yaml | indent(12) }}
+{% elif postgres_security_context_settings|length %}
           securityContext:
             {{ postgres_security_context_settings | to_nice_yaml | indent(12) }}
 {% endif %}


### PR DESCRIPTION
##### SUMMARY
The security context settings offered today only provide the option to set pod level security context for web and task deployments. This PR adds the option to allow container level security context for all of the containers under web and task deployments.

fixes: #1413
fixes: #890
fixes: #571
fixes: #383

**This change doesn't dictate the values and let the users decide and configure the values on need basis. This makes it a safer approach to implement without breaking any functionality**

<!---
If you are fixing an existing issue, please include "fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New or Enhanced Feature

##### ADDITIONAL INFORMATION
Two of the existing variable settings will become irrelevant after this change: 
* `redis_capabilities` can be covered under `redis_security_context_settings` after this change
* `task_privileged` can be covered under `task_security_context_settings` after this change

