### PR TITLE
CSV Change Descriptor of StorageClass From Text to StorageClass

### DIFF
--- a/config/manifests/bases/awx-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/awx-operator.clusterserviceversion.yaml
@@ -91,7 +91,7 @@ spec:
       - displayName: Backup PVC Storage Class
         path: backup_storage_class
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:text
+        - urn:alm:descriptor:io.kubernetes:StorageClass
         - urn:alm:descriptor:com.tectonic.ui:advanced
       - displayName: Precreate Partition Hours
         path: precreate_partition_hours
@@ -713,7 +713,7 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:fieldDependency:projects_use_existing_claim:_No_
-        - urn:alm:descriptor:com.tectonic.ui:text
+        - urn:alm:descriptor:io.kubernetes:StorageClass
       - description: Projects Storage Size
         displayName: Projects Storage Size
         path: projects_storage_size


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Update only awx-operator.clusterserviceversion.yaml:
Some descriptors for StorageClasses were set as text and not Storage Class:
<!---
If you are fixing an existing issue, please include "fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
-->
Before: 
```
- displayName: Backup PVC Storage Class
        path: backup_storage_class
        x-descriptors:
        - urn:alm:descriptor:com.tectonic.ui:text
        - urn:alm:descriptor:com.tectonic.ui:advanced
```

After:
```
- displayName: Backup PVC Storage Class
        path: backup_storage_class
        x-descriptors:
        - urn:alm:descriptor:io.kubernetes:StorageClass
        - urn:alm:descriptor:com.tectonic.ui:advanced
```

