### PR TITLE
Fix bug where uppercase Route fails

### DIFF
--- a/roles/mesh_ingress/tasks/creation.yml
+++ b/roles/mesh_ingress/tasks/creation.yml
@@ -61,7 +61,7 @@
 - name: Default ingress_type to Route if OpenShift
   set_fact:
     ingress_type: route
-  when: is_openshift | bool and ingress_type == 'none'
+  when: is_openshift | bool and ingress_type | lower == 'none'
 
 - name: Apply Ingress resource
   k8s:
@@ -77,7 +77,7 @@
 - name: Set external_hostname
   set_fact:
     external_hostname: "{{ ingress.result.status.ingress[0].host }}"
-  when: ingress_type == 'route'
+  when: ingress_type | lower == 'route'
 
 - name: Create other resources
   k8s:


### PR DESCRIPTION
##### SUMMARY
Uppercase Route fails with 

```
- ansibleResult:
      changed: 2
      completion: 2024-02-26T16:32:16.241811
      failures: 1
      ok: 18
      skipped: 4
    lastTransitionTime: "2024-02-26T16:32:16Z"
    message: |
      The task includes an option with an undefined variable. The error was: 'external_hostname' is undefined

      The error appears to be in '/opt/ansible/roles/mesh_ingress/tasks/creation.yml': line 141, column 3, but may
      be elsewhere in the file depending on the exact syntax problem.

      The offending line appears to be:


      - name: Add external receptor address
        ^ here
        ```

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
