### PR TITLE
Expose extra_settings in OLM UI form

### DIFF
--- a/config/crd/bases/awx.ansible.com_awxs.yaml
+++ b/config/crd/bases/awx.ansible.com_awxs.yaml
@@ -1811,6 +1811,7 @@ spec:
                     setting:
                       type: string
                     value:
+                      type: string
                       x-kubernetes-preserve-unknown-fields: true
                   type: object
                 type: array

--- a/config/manifests/bases/awx-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/awx-operator.clusterserviceversion.yaml
@@ -937,11 +937,10 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:hidden
-      - displayName: API Extra Settings
+      - displayName: Extra Settings
         path: extra_settings
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
-        - urn:alm:descriptor:com.tectonic.ui:hidden
       - displayName: No Log Configuration
         path: no_log
         x-descriptors:


### PR DESCRIPTION
##### SUMMARY
With this change, we can now configure extra_settings from the Openshift/OKD UI.

For example:

![image](https://github.com/ansible/awx-operator/assets/11698892/731ba34f-36a9-4b32-82a8-ee9e00b1aaa0)


```yaml
spec:
  extra_settings:
    - setting: LOG_AGGREGATOR_LEVEL
      value: '"DEBUG"'
```

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - New or Enhanced Feature


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
