### PR TITLE
Create a new postgres configuration secret when restoring a new instance

### DIFF
--- a/roles/restore/tasks/secrets.yml
+++ b/roles/restore/tasks/secrets.yml
@@ -19,6 +19,18 @@
   include_vars: "{{ tmp_secrets.path }}"
   no_log: "{{ no_log }}"
 
+- name: If deployment is managed, set the new postgres_configuration_secret name
+  block:
+  - name: Set new postgres_configuration_secret name
+    set_fact:
+      _generated_pg_secret_name: "{{ deployment_name }}-postgres-configuration"
+
+  - name: Override postgres_configuration_secret
+    set_fact:
+      spec:
+        "{{ spec | combine({'postgres_configuration_secret': _generated_pg_secret_name}, recursive=True) }}"
+  when: secrets['postgresConfigurationSecret']['data']['type'] | b64decode == 'managed'
+
 - name: If deployment is managed, set the database_host in the pg config secret
   block:
     - name: Set new database host
@@ -31,12 +43,18 @@
         _pg_secret: "{{ secrets['postgresConfigurationSecret'] }}"
       no_log: "{{ no_log }}"
 
-    - name: Change postgres host value
+    - name: Change postgres host and name value
       set_fact:
         _pg_data: "{{ _pg_secret['data'] | combine({'host': database_host | b64encode }) }}"
+        _pg_secret_name: "{{ deployment_name }}-postgres-configuration"
       no_log: "{{ no_log }}"
 
-    - name: Create a postgres secret with the new host value
+    - name: Override postgres secret name
+      set_fact:
+        _pg_secret: "{{ _pg_secret | combine({'name': _pg_secret_name}) }}"
+      no_log: "{{ no_log }}"
+
+    - name: Override postgres secret host with new Postgres service
       set_fact:
         _pg_secret: "{{ _pg_secret | combine({'data': _pg_data}) }}"
       no_log: "{{ no_log }}"


### PR DESCRIPTION
##### SUMMARY
Prior to this PR, when restoring:

- User has a working deployment of AWX (awx-1)
- User takes a backup
- (User does not delete the original deployment)
- User does a restore and ends up with a successful deployment of AWX by a new name (awx-2)
- At this point though, the postgres-configuration-secret's host value has been changed from `awx-1-postgres-13` --> `awx-2-postgres-13`.  This results in the second deployment working, but the first deployment failing because it cannot reach the database.

The user has a working deployment from the restore at this point, so they can safely delete the initial deployment.  It is a bug that the initial deployment is broken in the process, but the user is left with a working deployment.  

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION

**Expected Behavior**

The restore role attempts to inject the new host name for postgres into the existing secret.
This is the desired behavior if the name of the deployment is the same as the original deployment.

However, if the `deployment_name` is different (as we advise customers to do), the restore role should create a new secret with the new host name. 

**Verification Details**

After this change, the host and secret name are set appropriately for the new deployment.

```json
    "_pg_secret": {
        "data": {
            "database": "YXd4",
            "host": "bmV3LWF3eC1wb3N0Z3Jlcy0xMw==",
            "password": "SWxNYnNGR1JBeHJISm13clVYTW4zdHBOSExpTmpnUWI=",
            "port": "NTQzMg==",
            "type": "bWFuYWdlZA==",
            "username": "YXd4"
        },
        "name": "new-awx-postgres-configuration",
        "type": "Opaque"
    }
}
```

```bash
$ echo bmV3LWF3eC1wb3N0Z3Jlcy0xMw== | base64 -d
new-awx-postgres-13
```

After restoring, I am able to log in to my instance with a user from the old instance.