### PR TITLE
Bind EE images version with DEFAULT_AWX_VERSION

### DIFF
--- a/docs/user-guide/advanced-configuration/deploying-a-specific-version-of-awx.md
+++ b/docs/user-guide/advanced-configuration/deploying-a-specific-version-of-awx.md
@@ -2,15 +2,15 @@
 
 There are a few variables that are customizable for awx the image management.
 
-| Name                | Description               | Default                                 |
-| ------------------- | ------------------------- | --------------------------------------  |
-| image               | Path of the image to pull | quay.io/ansible/awx                     |
-| image_version       | Image version to pull     | value of DEFAULT_AWX_VERSION or latest  |
-| image_pull_policy   | The pull policy to adopt  | IfNotPresent                            |
-| image_pull_secrets  | The pull secrets to use   | None                                    |
-| ee_images           | A list of EEs to register | quay.io/ansible/awx-ee:latest           |
-| redis_image         | Path of the image to pull | docker.io/redis                         |
-| redis_image_version | Image version to pull     | latest                                  |
+| Name                | Description               | Default                                    |
+| ------------------- | ------------------------- | -----------------------------------------  |
+| image               | Path of the image to pull | quay.io/ansible/awx                        |
+| image_version       | Image version to pull     | value of DEFAULT_AWX_VERSION or latest     |
+| image_pull_policy   | The pull policy to adopt  | IfNotPresent                               |
+| image_pull_secrets  | The pull secrets to use   | None                                       |
+| ee_images           | A list of EEs to register | quay.io/ansible/awx-ee:DEFAULT_AWX_VERSION |
+| redis_image         | Path of the image to pull | docker.io/redis                            |
+| redis_image_version | Image version to pull     | latest                                     |
 
 Example of customization could be:
 

--- a/roles/installer/defaults/main.yml
+++ b/roles/installer/defaults/main.yml
@@ -278,10 +278,10 @@ init_container_extra_commands: ''
 init_container_extra_volume_mounts: ''
 
 ee_images:
-  - name: AWX EE (latest)
-    image: quay.io/ansible/awx-ee:latest
+  - name: "AWX EE ({{ _image_version }})"
+    image: "quay.io/ansible/awx-ee:{{ _image_version }}"
 
-_control_plane_ee_image: quay.io/ansible/awx-ee:latest
+_control_plane_ee_image: "quay.io/ansible/awx-ee:{{ _image_version }}"
 
 _init_container_image: "{{ _control_plane_ee_image.split(':')[0] }}"
 _init_container_image_version: "{{ _control_plane_ee_image.split(':')[1] }}"

--- a/roles/installer/defaults/main.yml
+++ b/roles/installer/defaults/main.yml
@@ -278,6 +278,8 @@ init_container_extra_commands: ''
 init_container_extra_volume_mounts: ''
 
 ee_images:
+  - name: "AWX EE (latest)"
+    image: "quay.io/ansible/awx-ee:latest"
   - name: "AWX EE ({{ _image_version }})"
     image: "quay.io/ansible/awx-ee:{{ _image_version }}"
 

--- a/roles/installer/tasks/set_images.yml
+++ b/roles/installer/tasks/set_images.yml
@@ -8,8 +8,8 @@
   set_fact:
     _custom_init_container_image: "{{ init_container_image }}:{{ init_container_image_version }}"
   when:
-    - init_container_image | default([]) | length
-    - init_container_image_version is defined or init_container_image_version != ''
+    - init_container_image | default('_undefined',true) != '_undefined'
+    - init_container_image_version | default('_undefined',true) != '_undefined'
 
 - name: Set Init image URL
   set_fact:

--- a/roles/mesh_ingress/defaults/main.yml
+++ b/roles/mesh_ingress/defaults/main.yml
@@ -9,7 +9,7 @@ ingress_controller: ''
 
 set_self_owneref: true
 
-_control_plane_ee_image: quay.io/ansible/awx-ee:latest
+_control_plane_ee_image: "quay.io/ansible/awx-ee:{{ lookup('env', 'DEFAULT_AWX_VERSION') or 'latest' }}"
 _image_pull_policy: Always
 image_pull_secrets: []
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

This PR fixes #1484 by binding following images to `DEFAULT_AWX_VERSION` instead of current `latest` tag:
- `ee_images` - default execution environment (will add new EE with each upgrade, leaving previous as-is)
- `control_plane_ee_image` - will switch it to new version with each update
- `init_container_image` - will be also switched to new version with each update

<!---
If you are fixing an existing issue, please include "fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
-->
Currently those were linked with `latest` version of images which might resulted in unexpected effects for ee_image once the `latest` tag was updated.
For `control_plane_ee_image` and `init_container_image` - they were not changed until container re-create, but should this happen they would also be updated (possibly unaware/unexpected)

In order to prevent switching to updated image versions on upgrade it is possible to define `control_plane_ee_image` and (AFAIK undocumented) `init_container_image`/`init_container_image_version` in AWX resource spec.

New EE image will always be added upon upgrade, but it will be clearly marked with AWX version.

Additionally it also makes small fix for 'or' in check of `init_container_image_version` presence which could leave to errors when init_container_image_version would not be specified and `init_container_image` be defined (separate commit)

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
