### PR TITLE
Fixing postgres upgrade conditional

### DIFF
--- a/molecule/default/tasks/awx_replicas_test.yml
+++ b/molecule/default/tasks/awx_replicas_test.yml
@@ -61,4 +61,4 @@
         expected_web_replicas: 3
         expected_task_replicas: 3
   tags:
-  - replicas
+    - replicas

--- a/roles/installer/tasks/database_configuration.yml
+++ b/roles/installer/tasks/database_configuration.yml
@@ -117,26 +117,26 @@
   register: _running_pods
 
 - block:
-  - name: Filter pods by name
-    set_fact:
-      filtered_old_postgres_pods: "{{ _running_pods.resources |
-        selectattr('metadata.name', 'match', ansible_operator_meta.name + '-postgres.*-0') |
-        rejectattr('metadata.name', 'search', '-' + supported_pg_version | string + '-0') |
-        list }}"
+    - name: Filter pods by name
+      set_fact:
+        filtered_old_postgres_pods: "{{ _running_pods.resources |
+          selectattr('metadata.name', 'match', ansible_operator_meta.name + '-postgres.*-0') |
+          rejectattr('metadata.name', 'search', '-' + supported_pg_version | string + '-0') |
+          list }}"
 
   # Sort pods by name in reverse order (most recent PG version first) and set
-  - name: Set info for previous postgres pod
-    set_fact:
-      sorted_old_postgres_pods: "{{ filtered_old_postgres_pods |
-        sort(attribute='metadata.name') |
-        reverse }}"
-    when: filtered_old_postgres_pods | length
+    - name: Set info for previous postgres pod
+      set_fact:
+        sorted_old_postgres_pods: "{{ filtered_old_postgres_pods |
+          sort(attribute='metadata.name') |
+          reverse }}"
+      when: filtered_old_postgres_pods | length
 
 
-  - name: Set info for previous postgres pod
-    set_fact:
-      old_postgres_pod: "{{ sorted_old_postgres_pods | first }}"
-    when: filtered_old_postgres_pods | length
+    - name: Set info for previous postgres pod
+      set_fact:
+        old_postgres_pod: "{{ sorted_old_postgres_pods | first }}"
+      when: filtered_old_postgres_pods | length
   when: _running_pods.resources | length
 
 - name: Look up details for this deployment
@@ -179,7 +179,7 @@
         - (_old_pg_version.stdout | default(0) | int ) < supported_pg_version
   when:
     - managed_database
-    - (_previous_upgraded_pg_version | default(false)) | ternary(_previous_upgraded_pg_version < supported_pg_version, true)
+    - (_previous_upgraded_pg_version | default(false)) | ternary(_previous_upgraded_pg_version | int < supported_pg_version, true)
     - old_postgres_pod | length  # If empty, then old pg pod has been removed and we can assume the upgrade is complete
 
 - block:

--- a/roles/installer/tasks/update_status.yml
+++ b/roles/installer/tasks/update_status.yml
@@ -111,5 +111,5 @@
     name: "{{ ansible_operator_meta.name }}"
     namespace: "{{ ansible_operator_meta.namespace }}"
     status:
-      upgradedPostgresVersion: "{{ upgraded_postgres_version | string }}"
+      upgradedPostgresVersion: "{{ upgraded_postgres_version }}"
   when: upgraded_postgres_version is defined

--- a/roles/installer/tasks/upgrade_postgres.yml
+++ b/roles/installer/tasks/upgrade_postgres.yml
@@ -164,4 +164,5 @@
   loop:
     - "postgres-{{ ansible_operator_meta.name }}-postgres-0"
     - "postgres-{{ ansible_operator_meta.name }}-postgres-13-0"
+    - "postgres-13-{{ ansible_operator_meta.name }}-postgres-13-0"
   when: postgres_keep_pvc_after_upgrade


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This fixes the bug introduced by https://github.com/ansible/awx-operator/pull/1486

<!---
If you are fixing an existing issue, please include "fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Tested upgrade locally successfully (awx-postgres-13-0 was replaced with awx-postgres-15-0).  Confirmed data migrated to new pvc.

Before:
```
 $ kubectl get all -n awx
NAME                                                   READY   STATUS      RESTARTS   AGE
pod/automation-job-1-mstbh                             0/1     Completed   0          60s
pod/awx-operator-controller-manager-7f44c57b4d-lpghj   2/2     Running     0          8m5s
pod/awx-postgres-13-0                                  1/1     Running     0          7m2s
pod/awx-task-6bbf6bb5d6-jv29h                          4/4     Running     0          6m34s
pod/awx-web-6fbdc6df6d-8vpbp                           3/3     Running     0          6m26s

NAME                                                      TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)    AGE
service/awx-operator-controller-manager-metrics-service   ClusterIP   10.103.144.126   <none>        8443/TCP   8m5s
service/awx-postgres-13                                   ClusterIP   None             <none>        5432/TCP   7m1s
service/awx-service                                       ClusterIP   10.105.155.35    <none>        80/TCP     6m37s

NAME                                              READY   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/awx-operator-controller-manager   1/1     1            1           8m5s
deployment.apps/awx-task                          1/1     1            1           6m34s
deployment.apps/awx-web                           1/1     1            1           6m26s

NAME                                                         DESIRED   CURRENT   READY   AGE
replicaset.apps/awx-operator-controller-manager-7f44c57b4d   1         1         1       8m5s
replicaset.apps/awx-task-6bbf6bb5d6                          1         1         1       6m34s
replicaset.apps/awx-web-6fbdc6df6d                           1         1         1       6m26s

NAME                               READY   AGE
statefulset.apps/awx-postgres-13   1/1     7m2s
```

After:
```
 $ kubectl get all -n awx
NAME                                                   READY   STATUS      RESTARTS   AGE
pod/automation-job-3-2j2kp                             0/1     Completed   0          19s
pod/awx-operator-controller-manager-797dbfff78-xw4qr   2/2     Running     0          5m22s
pod/awx-postgres-15-0                                  1/1     Running     0          4m24s
pod/awx-task-95df76d6c-pblqf                           4/4     Running     0          3m49s
pod/awx-web-69d94f8c4f-fl2sj                           3/3     Running     0          3m40s

NAME                                                      TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)    AGE
service/awx-operator-controller-manager-metrics-service   ClusterIP   10.103.144.126   <none>        8443/TCP   18m
service/awx-postgres-15                                   ClusterIP   None             <none>        5432/TCP   4m19s
service/awx-service                                       ClusterIP   10.105.155.35    <none>        80/TCP     17m

NAME                                              READY   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/awx-operator-controller-manager   1/1     1            1           18m
deployment.apps/awx-task                          1/1     1            1           17m
deployment.apps/awx-web                           1/1     1            1           16m

NAME                                                         DESIRED   CURRENT   READY   AGE
replicaset.apps/awx-operator-controller-manager-797dbfff78   1         1         1       5m22s
replicaset.apps/awx-operator-controller-manager-7f44c57b4d   0         0         0       18m
replicaset.apps/awx-task-6bbf6bb5d6                          0         0         0       17m
replicaset.apps/awx-task-95df76d6c                           1         1         1       3m49s
replicaset.apps/awx-web-69d94f8c4f                           1         1         1       3m40s
replicaset.apps/awx-web-6fbdc6df6d                           0         0         0       16m

NAME                               READY   AGE
statefulset.apps/awx-postgres-15   1/1     4m24s

```

The PVC is also migrated/updated:

Before: 
```
 $ kubectl get pvc -n awx
NAME                            STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
postgres-13-awx-postgres-13-0   Bound    pvc-59237498-94c2-425b-a00e-a5d315b27360   8Gi        RWO            standard       7m
```

After:
```
 $ kubectl get pvc -n awx
NAME                            STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
postgres-15-awx-postgres-15-0   Bound    pvc-25501b6f-0299-43e4-9136-1afd1981e455   8Gi        RWO            standard       2m37s
```

Job history confirms migration success: (Job 1 is pre-upgrade and Job 2 is post-upgrade):
<img width="1243" alt="image" src="https://github.com/ansible/awx-operator/assets/87674982/4393ecbd-1dcc-4558-ba13-a6f24aae1b7a">
