### PR TITLE
fix: extend expiration date for the certs for receptor nodes to 10 years

### DIFF
--- a/roles/installer/templates/deployments/task.yaml.j2
+++ b/roles/installer/templates/deployments/task.yaml.j2
@@ -104,8 +104,20 @@ spec:
             - -c
             - |
               hostname=$MY_POD_NAME
-              receptor --cert-makereq bits=2048 commonname=$hostname dnsname=$hostname nodeid=$hostname outreq=/etc/receptor/tls/receptor.req outkey=/etc/receptor/tls/receptor.key
-              receptor --cert-signreq req=/etc/receptor/tls/receptor.req cacert=/etc/receptor/tls/ca/mesh-CA.crt cakey=/etc/receptor/tls/ca/mesh-CA.key outcert=/etc/receptor/tls/receptor.crt verify=yes
+              receptor --cert-makereq \
+                bits=2048 \
+                commonname=$hostname \
+                dnsname=$hostname \
+                nodeid=$hostname \
+                outreq=/etc/receptor/tls/receptor.req \
+                outkey=/etc/receptor/tls/receptor.key
+              receptor --cert-signreq \
+                req=/etc/receptor/tls/receptor.req \
+                cacert=/etc/receptor/tls/ca/mesh-CA.crt \
+                cakey=/etc/receptor/tls/ca/mesh-CA.key \
+                outcert=/etc/receptor/tls/receptor.crt \
+                notafter=$(date --iso-8601=seconds --utc --date "10 years") \
+                verify=yes
 {% if bundle_ca_crt  %}
               mkdir -p /etc/pki/ca-trust/extracted/{java,pem,openssl,edk2}
               update-ca-trust

--- a/roles/mesh_ingress/templates/deployment.yml.j2
+++ b/roles/mesh_ingress/templates/deployment.yml.j2
@@ -24,7 +24,8 @@ spec:
 {% if external_ipaddress is defined %}
           external_ipaddress={{ external_ipaddress }}
 {% endif %}
-          receptor --cert-makereq bits=2048 \
+          receptor --cert-makereq \
+            bits=2048 \
             commonname=$internal_hostname \
             dnsname=$internal_hostname \
             nodeid=$internal_hostname \
@@ -41,6 +42,7 @@ spec:
             cacert=/etc/receptor/tls/ca/mesh-CA.crt \
             cakey=/etc/receptor/tls/ca/mesh-CA.key \
             outcert=/etc/receptor/tls/receptor.crt \
+            notafter=$(date --iso-8601=seconds --utc --date "10 years") \
             verify=yes
           exec receptor --config /etc/receptor/receptor.conf
         image: '{{ _control_plane_ee_image }}'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Closes #1722 

Changes:

- Add `notafter` for `receptor --cert-makereq` command for control plane ee and mesh ingress
- Format long `receptor` command with line breaks

<!---
If you are fixing an existing issue, please include "fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->

Tested by deploying custom Operator includes this PR:

```bash
$ IMG=registry.example.com/ansible/awx-operator:certs make docker-build docker-push deploy
```

Deploy AWX and Mesh Ingress:

```bash
$ cat minimal-awx.yaml 
---
apiVersion: awx.ansible.com/v1beta1
kind: AWX
metadata:
  namespace: awx
  name: awx-demo
spec:
  service_type: nodeport

$ kubectl apply -f minimal-awx.yaml 

$ cat minimal-meshingress.yaml 
---
apiVersion: awx.ansible.com/v1alpha1
kind: AWXMeshIngress
metadata:
  namespace: awx
  name: inbound-hop01
spec:
  deployment_name: awx-demo

  ingress_type: IngressRouteTCP
  ingress_controller: traefik
  ingress_class_name: traefik
  ingress_api_version: traefik.io/v1alpha1

  external_hostname: inbound-hop01.ansible.internal

$ kubectl apply -f minimal-meshingress.yaml 
```

Ensure expiration date is extended for control plane ee and mesh ingress.

```bash
$ kubectl -n awx exec deployment/awx-demo-task -c awx-demo-ee -- openssl x509 -text -in /etc/receptor/tls/receptor.crt -noout
Certificate:
    Data:
        Version: 3 (0x2)
        Serial Number: 1709483251 (0x65e4a4f3)
        Signature Algorithm: sha256WithRSAEncryption
        Issuer: CN = awx-demo Receptor Root CA
        Validity
            Not Before: Mar  3 16:27:31 2024 GMT
            Not After : Mar  3 16:27:31 2034 GMT   ✅
...

$ kubectl -n awx exec -it deployment/inbound-hop01 -- openssl x509 -text -in /etc/receptor/tls/receptor.crt -noout
Certificate:
    Data:
        Version: 3 (0x2)
        Serial Number: 1709484394 (0x65e4a96a)
        Signature Algorithm: sha256WithRSAEncryption
        Issuer: CN = awx-demo Receptor Root CA
        Validity
            Not Before: Mar  3 16:46:34 2024 GMT
            Not After : Mar  3 16:46:34 2034 GMT   ✅
...
```


