### PR TITLE
fix: revert type of status.upgradedPostgresVersion to string

### DIFF
--- a/roles/installer/tasks/update_status.yml
+++ b/roles/installer/tasks/update_status.yml
@@ -111,5 +111,5 @@
     name: "{{ ansible_operator_meta.name }}"
     namespace: "{{ ansible_operator_meta.namespace }}"
     status:
-      upgradedPostgresVersion: "{{ upgraded_postgres_version }}"
+      upgradedPostgresVersion: "{{ upgraded_postgres_version | string }}"
   when: upgraded_postgres_version is defined


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Closes #1738 

As follow-up for #1741, this PR changes to store `status.upgradedPostgresVersion` as a `string`, to keep backward compatibility.

<!---
If you are fixing an existing issue, please include "fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
-->

Tested by following reproducible steps in https://github.com/ansible/awx-operator/issues/1738#issuecomment-1975209920.

In step 7, deploy customized Operator with this PR instead of `devel` image:

```bash
$ IMG=registry.example.com/ansible/awx-operator:pg make docker-build docker-push deploy
```

In step 8, I can confirm there is no `failed` task.

```bash
$ kubectl -n awx logs deployments/awx-operator-controller-manager | grep -e "^PLAY RECAP" -A 1
PLAY RECAP *********************************************************************
localhost                  : ok=112  changed=16   unreachable=0    failed=0    skipped=75   rescued=0    ignored=1   
--
PLAY RECAP *********************************************************************
localhost                  : ok=85   changed=1    unreachable=0    failed=0    skipped=83   rescued=0    ignored=1 
```

In step 10. I can confirm PSQL 15 is running.

```bash
$ kubectl -n awx get pod
NAME                                              READY   STATUS    RESTARTS   AGE
awx-operator-controller-manager-984cd5d6f-jqwgw   2/2     Running   0          4m43s
awx-demo-postgres-15-0                            1/1     Running   0          3m50s
awx-demo-task-57d668d7b5-bmjrv                    4/4     Running   0          3m19s
awx-demo-web-6777767f5b-6lcwt                     3/3     Running   0          3m18s
```

In step 11, the `status` has `upgradedPostgresVersion`.

```bash
$ kubectl -n awx get awx awx-demo -o yaml
...
status:
  adminPasswordSecret: awx-demo-admin-password
  adminUser: admin
  broadcastWebsocketSecret: awx-demo-broadcast-websocket
  conditions:
  - lastTransitionTime: "2024-03-03T16:24:35Z"
    reason: ""
    status: "False"
    type: Failure
  - lastTransitionTime: "2024-03-03T16:21:12Z"
    reason: Successful
    status: "True"
    type: Running
  - lastTransitionTime: "2024-03-03T16:28:51Z"
    reason: Successful
    status: "True"
    type: Successful
  image: quay.io/ansible/awx:latest
  postgresConfigurationSecret: awx-demo-postgres-configuration
  secretKeySecret: awx-demo-secret-key
  upgradedPostgresVersion: "15"
  version: 23.9.0
```

In addition, just to be sure, I restarted Operator to trigger new reconciliation loop for existing AWX that has `upgradedPostgresVersion` and verified that the loop completes without any errors.