### PR TITLE
add support for defining loadbalancer class

### DIFF
--- a/config/crd/bases/awx.ansible.com_awxs.yaml
+++ b/config/crd/bases/awx.ansible.com_awxs.yaml
@@ -159,6 +159,10 @@ spec:
                 description: Assign LoadBalancer IP address
                 type: string
                 default: ''
+              loadbalancer_class:
+                description: Class of LoadBalancer to use
+                type: string
+                default: ''
               route_host:
                 description: The DNS to use to points to the instance
                 type: string

--- a/config/manifests/bases/awx-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/awx-operator.clusterserviceversion.yaml
@@ -387,6 +387,12 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:string
         - urn:alm:descriptor:com.tectonic.ui:fieldDependency:service_type:LoadBalancer
+      - displayName: LoadBalancer Class
+        path: loadbalancer_class
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:string
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:service_type:LoadBalancer
       - displayName: Route API Version
         path: route_api_version
         x-descriptors:

--- a/docs/user-guide/network-and-tls-configuration.md
+++ b/docs/user-guide/network-and-tls-configuration.md
@@ -33,6 +33,7 @@ The following variables are customizable only when `service_type=LoadBalancer`
 | loadbalancer_protocol | Protocol to use for Loadbalancer ingress | http    |
 | loadbalancer_port     | Port used for Loadbalancer ingress       | 80      |
 | loadbalancer_ip       | Assign Loadbalancer IP                   | ''      |
+| loadbalancer_class    | LoadBalancer class to use                | ''      |
 
 ```yaml
 ---
@@ -42,6 +43,7 @@ spec:
   loadbalancer_ip: '192.168.10.25'
   loadbalancer_protocol: https
   loadbalancer_port: 443
+  loadbalancer_class: service.k8s.aws/nlb
   service_annotations: |
     environment: testing
   service_labels: |

--- a/roles/installer/defaults/main.yml
+++ b/roles/installer/defaults/main.yml
@@ -52,6 +52,7 @@ ingress_hosts: ''
 
 loadbalancer_protocol: 'http'
 loadbalancer_port: '80'
+loadbalancer_class: ''
 service_annotations: ''
 
 # Port to be used for NodePort configuration, default is to auto-assign a port between 30000-32768

--- a/roles/installer/templates/networking/service.yaml.j2
+++ b/roles/installer/templates/networking/service.yaml.j2
@@ -55,6 +55,9 @@ spec:
 {% if loadbalancer_ip is defined and loadbalancer_ip | length %}
   loadbalancerip: '{{ loadbalancer_ip }}'
 {% endif %}
+{% if loadbalancer_class is defined and loadbalancer_class | length %}
+  loadBalancerClass: {{ loadbalancer_class }}
+{% endif %}
 {% else %}
   type: ClusterIP
 {% endif %}


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Adds support to define the load balancer class in Kubernetes clusters that may have multiple load balancer controllers or if a load balancer controller supports multiple classes.

<!---
If you are fixing an existing issue, please include "fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New or Enhanced Feature

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
-->

This allows the `spec.loadBalancerClass` field to be specified in the operator-created service for AWX.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
