### PR TITLE
Fix undefined external_hostname when using Route

### DIFF
--- a/roles/mesh_ingress/templates/ingress.yml.j2
+++ b/roles/mesh_ingress/templates/ingress.yml.j2
@@ -28,7 +28,7 @@ spec:
                 name: {{ ansible_operator_meta.name }}
                 port:
                   number: 27199
-{% if external_hostname %}
+{% if external_hostname is defined %}
       host: {{ external_hostname }}
 {% endif %}
 {% endif %}
@@ -53,7 +53,7 @@ spec:
     - services:
       - name: {{ ansible_operator_meta.name }}
         port: 27199
-{% if external_hostname %}
+{% if external_hostname is defined %}
       match: HostSNI(`{{ external_hostname }}`)
 {% endif %}
   tls:


### PR DESCRIPTION
##### SUMMARY
fix bug introduced in https://github.com/ansible/awx-operator/pull/1752 
causing undefine error when external_hostname is not defined while using Route on OpenShift

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
