### PR TITLE
The pg service label_selector now uses the deployment_type variable

### DIFF
--- a/roles/installer/tasks/upgrade_postgres.yml
+++ b/roles/installer/tasks/upgrade_postgres.yml
@@ -69,7 +69,7 @@
     label_selectors:
       - "app.kubernetes.io/component=database"
       - "app.kubernetes.io/instance={{ old_postgres_pod.metadata.labels['app.kubernetes.io/instance'] }}"
-      - "app.kubernetes.io/managed-by=awx-operator"
+      - "app.kubernetes.io/managed-by={{ deployment_type }}-operator"
   register: old_postgres_svc
 
 - name: Set full resolvable host name for postgres pod


### PR DESCRIPTION
##### SUMMARY

The `{{ deployment_type }}-operator` should be used for the postgres stateful set label_selectors here.  

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bug, Docs Fix or other nominal change
