### PR TITLE
Revert change to cast settings values to strings as they could be nested

### DIFF
--- a/config/crd/bases/awx.ansible.com_awxs.yaml
+++ b/config/crd/bases/awx.ansible.com_awxs.yaml
@@ -1889,13 +1889,12 @@ spec:
                 description: Set log level of receptor service
                 type: string
               extra_settings:
-                description: Extra settings to specify for the API
+                description: Extra settings to specify for AWX
                 items:
                   properties:
                     setting:
                       type: string
                     value:
-                      type: string
                       x-kubernetes-preserve-unknown-fields: true
                   type: object
                 type: array

--- a/config/manifests/bases/awx-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/awx-operator.clusterserviceversion.yaml
@@ -952,6 +952,7 @@ spec:
         path: extra_settings
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:hidden
       - displayName: No Log Configuration
         path: no_log
         x-descriptors:


### PR DESCRIPTION
##### SUMMARY
Reverts https://github.com/ansible/awx-operator/pull/1732/

We cast the settings value to a string so that it would display properly in the Openshift UI. Unfortunately, the k8s validator will no longer allow arrays for settings values.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bug, Docs Fix or other nominal change

