### PR TITLE
add dependabot config to bump doc dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/docs"
+    groups:
+      dependencies:
+        patterns:
+          - "*"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "component:docs"
+      - "dependencies"


### PR DESCRIPTION
##### SUMMARY
Follows up on #1727 by adding dependabot config to automatically open PRs that update doc requirements.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION
N/A
