### PR TITLE
Updating image pull policy for awx-operator to IfNotPresent

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -39,7 +39,7 @@ spec:
         - --leader-elect
         - --leader-election-id=awx-operator
         image: controller:latest
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         name: awx-manager
         env:
         - name: ANSIBLE_GATHERING


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

Updating awx-operator's image pull policy to be IfNotPresent to match our other operators (EDA, Galaxy)


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bug, Docs Fix or other nominal change