### PR TITLE
Whitelist test and enforce test order

### DIFF
--- a/molecule/default/tasks/awx_replicas_test.yml
+++ b/molecule/default/tasks/awx_replicas_test.yml
@@ -49,16 +49,16 @@
 ####
 
     - debug:
-        msg: test - replicas=3 should give 3 of each
+        msg: test - replicas=2 should give 2 of each
 
     - include_tasks: apply_awx_spec.yml
       vars:
         additional_fields:
-          replicas: 3
+          replicas: 2
 
     - include_tasks: _test_case_replicas.yml
       vars:
-        expected_web_replicas: 3
-        expected_task_replicas: 3
+        expected_web_replicas: 2
+        expected_task_replicas: 2
   tags:
     - replicas

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -14,7 +14,8 @@
         - name: Import all test files from tasks/
           include_tasks: '{{ item }}'
           with_fileglob:
-            - tasks/*_test.yml
+            - tasks/awx_test.yml
+            - tasks/awx_replicas_test.yml
           tags:
             - always
       rescue:


### PR DESCRIPTION
##### SUMMARY
occasionally we get CI failure when running the test with 

awx_test.yml testcase fail with 

```
"job_explanation": "Job reaped due to instance shutdown",
```

I suspect that this is due to the fact that `awx_replicas_test.yml` is run before `awx_test.yml` (and we end up with 3 replicas) and during `awx_test.yml` we scale down the replica back to 1, if we try to run job too early we end up with job being potentially schedule to one of the replica that will get scaled down 

causing flaky CI

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
