### PR TITLE
Add ServiceAccount and ImagePullSecet to migration job

### DIFF
--- a/roles/installer/templates/jobs/migration.yaml.j2
+++ b/roles/installer/templates/jobs/migration.yaml.j2
@@ -33,6 +33,16 @@ spec:
             - name: awx-devel
               mountPath: "/awx_devel"
 {% endif %}
+      serviceAccountName: '{{ ansible_operator_meta.name }}'
+{% if image_pull_secret is defined %}
+      imagePullSecrets:
+        - name: {{ image_pull_secret }}
+{% elif image_pull_secrets | length > 0 %}
+      imagePullSecrets:
+{% for secret in image_pull_secrets %}
+        - name: {{ secret }}
+{% endfor %}
+{% endif %}
       volumes:
         - name: "{{ ansible_operator_meta.name }}-application-credentials"
           secret:


### PR DESCRIPTION
##### SUMMARY
Fix the following
- DB migration job does not use correct service account
- DB migration job does not respect image pull secret

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
