### PR TITLE
Add command when specifying args for postgres

### DIFF
--- a/roles/installer/templates/statefulsets/postgres.yaml.j2
+++ b/roles/installer/templates/statefulsets/postgres.yaml.j2
@@ -56,6 +56,7 @@ spec:
             {{ postgres_security_context_settings | to_nice_yaml | indent(12) }}
 {% endif %}
 {% if postgres_extra_args %}
+          command: ["run-postgresql"]
           args: {{ postgres_extra_args }}
 {% endif %}
           env:


### PR DESCRIPTION
##### SUMMARY
fixes https://github.com/ansible/awx-operator/issues/1760

When using args the container defaults to the entrypoint instead of command
causing postgres to be in a crashloop

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
