### PR TITLE
Don't delete old postgres 13 volume automatically

### DIFF
--- a/roles/installer/tasks/upgrade_postgres.yml
+++ b/roles/installer/tasks/upgrade_postgres.yml
@@ -153,16 +153,3 @@
   loop:
     - "{{ ansible_operator_meta.name }}-postgres"
     - "{{ ansible_operator_meta.name }}-postgres-13"
-
-- name: Remove old persistent volume claim
-  k8s:
-    kind: PersistentVolumeClaim
-    api_version: v1
-    namespace: "{{ ansible_operator_meta.namespace }}"
-    name: "{{ item }}"
-    state: absent
-  loop:
-    - "postgres-{{ ansible_operator_meta.name }}-postgres-0"
-    - "postgres-{{ ansible_operator_meta.name }}-postgres-13-0"
-    - "postgres-13-{{ ansible_operator_meta.name }}-postgres-13-0"
-  when: postgres_keep_pvc_after_upgrade


### PR DESCRIPTION
##### SUMMARY
Leave old postgres-13 volume alone in case of unforseen upgrade failure for restore purposes

User can manually delete old PVC after verifying upgrade is completed


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
