### PR TITLE
docs: add description of init container image definition

### DIFF
--- a/docs/user-guide/advanced-configuration/deploying-a-specific-version-of-awx.md
+++ b/docs/user-guide/advanced-configuration/deploying-a-specific-version-of-awx.md
@@ -28,7 +28,10 @@ spec:
   ee_images:
     - name: my-custom-awx-ee
       image: myorg/my-custom-awx-ee
+  control_plane_ee_image: myorg/my-custom-awx-ee:latest
   init_container_image: myorg/my-custom-awx-ee
+  init_container_image_version: latest
+  init_projects_container_image: myorg/my-mirrored-centos:stream9
 ```
 
 **Note**: The `image` and `image_version` are intended for local mirroring scenarios. Please note that using a version of AWX other than the one bundled with the `awx-operator` is **not** supported. For the default values, check the [main.yml](https://github.com/ansible/awx-operator/blob/devel/roles/installer/defaults/main.yml) file.

--- a/docs/user-guide/advanced-configuration/deploying-a-specific-version-of-awx.md
+++ b/docs/user-guide/advanced-configuration/deploying-a-specific-version-of-awx.md
@@ -2,17 +2,19 @@
 
 There are a few variables that are customizable for awx the image management.
 
-| Name                         | Description               | Default                                    |
-| ---------------------------- | ------------------------- | ------------------------------------------ |
-| image                        | Path of the image to pull | quay.io/ansible/awx                        |
-| image_version                | Image version to pull     | value of DEFAULT_AWX_VERSION or latest     |
-| image_pull_policy            | The pull policy to adopt  | IfNotPresent                               |
-| image_pull_secrets           | The pull secrets to use   | None                                       |
-| ee_images                    | A list of EEs to register | quay.io/ansible/awx-ee:DEFAULT_AWX_VERSION |
-| redis_image                  | Path of the image to pull | docker.io/redis                            |
-| redis_image_version          | Image version to pull     | latest                                     |
-| init_container_image         | Path of the image to pull | quay.io/ansible/awx-ee                     |
-| init_container_image_version | Image version to pull     | value of DEFAULT_AWX_VERSION or latest     |
+| Name                          | Description               | Default                                    |
+| ----------------------------- | ------------------------- | ------------------------------------------ |
+| image                         | Path of the image to pull | quay.io/ansible/awx                        |
+| image_version                 | Image version to pull     | value of DEFAULT_AWX_VERSION or latest     |
+| image_pull_policy             | The pull policy to adopt  | IfNotPresent                               |
+| image_pull_secrets            | The pull secrets to use   | None                                       |
+| ee_images                     | A list of EEs to register | quay.io/ansible/awx-ee:DEFAULT_AWX_VERSION |
+| redis_image                   | Path of the image to pull | docker.io/redis                            |
+| redis_image_version           | Image version to pull     | latest                                     |
+| control_plane_ee_image        | Image version to pull     | quay.io/ansible/awx-ee:DEFAULT_AWX_VERSION |
+| init_container_image          | Path of the image to pull | quay.io/ansible/awx-ee                     |
+| init_container_image_version  | Image version to pull     | value of DEFAULT_AWX_VERSION or latest     |
+| init_projects_container_image | Image version to pull     | quay.io/centos/centos:stream9              |
 
 Example of customization could be:
 

--- a/docs/user-guide/advanced-configuration/deploying-a-specific-version-of-awx.md
+++ b/docs/user-guide/advanced-configuration/deploying-a-specific-version-of-awx.md
@@ -2,15 +2,17 @@
 
 There are a few variables that are customizable for awx the image management.
 
-| Name                | Description               | Default                                    |
-| ------------------- | ------------------------- | -----------------------------------------  |
-| image               | Path of the image to pull | quay.io/ansible/awx                        |
-| image_version       | Image version to pull     | value of DEFAULT_AWX_VERSION or latest     |
-| image_pull_policy   | The pull policy to adopt  | IfNotPresent                               |
-| image_pull_secrets  | The pull secrets to use   | None                                       |
-| ee_images           | A list of EEs to register | quay.io/ansible/awx-ee:DEFAULT_AWX_VERSION |
-| redis_image         | Path of the image to pull | docker.io/redis                            |
-| redis_image_version | Image version to pull     | latest                                     |
+| Name                         | Description               | Default                                    |
+| ---------------------------- | ------------------------- | ------------------------------------------ |
+| image                        | Path of the image to pull | quay.io/ansible/awx                        |
+| image_version                | Image version to pull     | value of DEFAULT_AWX_VERSION or latest     |
+| image_pull_policy            | The pull policy to adopt  | IfNotPresent                               |
+| image_pull_secrets           | The pull secrets to use   | None                                       |
+| ee_images                    | A list of EEs to register | quay.io/ansible/awx-ee:DEFAULT_AWX_VERSION |
+| redis_image                  | Path of the image to pull | docker.io/redis                            |
+| redis_image_version          | Image version to pull     | latest                                     |
+| init_container_image         | Path of the image to pull | quay.io/ansible/awx-ee                     |
+| init_container_image_version | Image version to pull     | value of DEFAULT_AWX_VERSION or latest     |
 
 Example of customization could be:
 
@@ -26,6 +28,7 @@ spec:
   ee_images:
     - name: my-custom-awx-ee
       image: myorg/my-custom-awx-ee
+  init_container_image: myorg/my-custom-awx-ee
 ```
 
 **Note**: The `image` and `image_version` are intended for local mirroring scenarios. Please note that using a version of AWX other than the one bundled with the `awx-operator` is **not** supported. For the default values, check the [main.yml](https://github.com/ansible/awx-operator/blob/devel/roles/installer/defaults/main.yml) file.


### PR DESCRIPTION
##### SUMMARY

Add `init_container_image` parameter.
This parameter is not dependent of `ee_images` settings. Therefore, use it when we want to pull a custom image or from private cotainer registry (e.g. disconnected internet).

##### ISSUE TYPE

 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION
