### PR TITLE
fix: correct readinessProbe for web pod

### DIFF
--- a/roles/installer/templates/deployments/web.yaml.j2
+++ b/roles/installer/templates/deployments/web.yaml.j2
@@ -178,11 +178,10 @@ spec:
 {% endif %}
 {% if web_readiness_period|int > 0 %}
           readinessProbe:
-            exec:
-              httpGet:
-                path: /api/v2/ping/
-                scheme: HTTP
-                port: 8052
+            httpGet:
+              path: /api/v2/ping/
+              scheme: HTTP
+              port: 8052
             initialDelaySeconds: {{ web_readiness_initial_delay }}
             periodSeconds: {{ web_readiness_period }}
             failureThreshold: {{ web_readiness_failure_threshold }}


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

Closes #1785 

This PR corrects `readinessProbe` for web pod.

<!---
If you are fixing an existing issue, please include "fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
-->

Tested locally:

```bash
# Build and deploy custom Operator
$ IMG=registry.example.com/ansible/awx-operator:readiness \
  BUILD_ARGS="--build-arg DEFAULT_AWX_VERSION=24.0.0" \
  make docker-build docker-push deploy

# Deploy minimal AWX CR
$ cat ./minimal-awx.yaml 
---
apiVersion: awx.ansible.com/v1beta1
kind: AWX
metadata:
  namespace: awx
  name: awx-demo
spec:
  service_type: nodeport
  web_readiness_period: 5
  web_liveness_period: 5

$ kubectl apply -f ./minimal-awx.yaml 
```

Result:

```bash
$ kubectl -n awx get deployment awx-demo-web -o yaml
apiVersion: apps/v1
kind: Deployment
...
spec:
  ...
  template:
    ...
    spec:
      containers:
      - args:
        ...
      - args:
        - /usr/bin/launch_awx_web.sh
        env:
        - name: AWX_COMPONENT
          value: web
        - name: SUPERVISOR_CONFIG_PATH
          value: /etc/supervisord_web.conf
        - name: MY_POD_NAMESPACE
          valueFrom:
            fieldRef:
              apiVersion: v1
              fieldPath: metadata.namespace
        - name: MY_POD_IP
          valueFrom:
            fieldRef:
              apiVersion: v1
              fieldPath: status.podIP
        - name: UWSGI_MOUNT_PATH
          value: /
        image: quay.io/ansible/awx:24.0.0
        imagePullPolicy: IfNotPresent
        livenessProbe:   ✅
          exec:
            command:
            - sh
            - -c
            - |
              (exit $(/usr/bin/supervisorctl -c /etc/supervisord_task.conf status | grep -vc RUNNING))
          failureThreshold: 3
          initialDelaySeconds: 5
          periodSeconds: 5
          successThreshold: 1
          timeoutSeconds: 1
        name: awx-demo-web
        ports:
        - containerPort: 8052
          protocol: TCP
        readinessProbe:   ✅
          failureThreshold: 3
          httpGet:
            path: /api/v2/ping/
            port: 8052
            scheme: HTTP
          initialDelaySeconds: 20
          periodSeconds: 5
          successThreshold: 1
          timeoutSeconds: 1
        resources:
          requests:
            cpu: 100m
            memory: 128Mi
        terminationMessagePath: /dev/termination-log
        terminationMessagePolicy: File
        ...
```