### PR TITLE
postgresql: Cast sorted_old_postgres_pods as list

### DIFF
--- a/roles/installer/tasks/database_configuration.yml
+++ b/roles/installer/tasks/database_configuration.yml
@@ -129,7 +129,7 @@
       set_fact:
         sorted_old_postgres_pods: "{{ filtered_old_postgres_pods |
           sort(attribute='metadata.name') |
-          reverse }}"
+          reverse | list }}"
       when: filtered_old_postgres_pods | length
 
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

With ansible 2.9.27 (operator-sdk v1.27.0) then the reverse filter returns an iterator so we need to cast it to list. The behavior doesn't exist when using a more recent operator-sdk version like v1.34.0 (ansible-core 2.15.8) but using the list filter on that version works too (even if not needed)

<!---
If you are fixing an existing issue, please include "fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION

```console
TASK [Set info for previous postgres pod] **************************************
task path: /opt/ansible/roles/installer/tasks/database_configuration.yml:130
ok: [localhost] => {"ansible_facts": {"sorted_old_postgres_pods": "<list_reverseiterator object at 0x7f512f251fd0>"}, "changed": false}

TASK [Set info for previous postgres pod] **************************************
task path: /opt/ansible/roles/installer/tasks/database_configuration.yml:138
ok: [localhost] => {"ansible_facts": {"old_postgres_pod": "<"}, "changed": false}

(...)

TASK [postgres : Get old PostgreSQL version] ***********************************
task path: /opt/ansible/roles/installer/tasks/database_configuration.yml:159
fatal: [localhost]: FAILED! => {
    "msg": "The task includes an option with an undefined variable. The error was: 'ansible.utils.unsafe_proxy.AnsibleUnsafeText object' has no attribute 'metadata'\n\nThe error appears to be in '/opt/ansible/roles/installer/tasks/database_configuration.yml': line 159, column 7, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n    - name: Get old PostgreSQL version\n      ^ here\n"
```