### PR TITLE
setting Metrics-Utility Image to only display when enabled

### DIFF
--- a/config/manifests/bases/awx-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/awx-operator.clusterserviceversion.yaml
@@ -1034,6 +1034,7 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:text
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:metrics_utility_enabled:true
       - displayName: Metrics-Utlity Image Version
         path: metrics_utility_image_version
         x-descriptors:


### PR DESCRIPTION
##### SUMMARY

setting Metrics-Utility Image to only display when enabled

##### ISSUE TYPE

 - Bug, Docs Fix or other nominal change

