### PR TITLE
Remove the ability to customize the postgres_data_dir

### DIFF
--- a/.helm/starter/templates/storage/postgres-pv.yaml
+++ b/.helm/starter/templates/storage/postgres-pv.yaml
@@ -13,7 +13,7 @@ spec:
     storage: {{ default "8Gi" .size | quote }}
   storageClassName: {{ include "postgres.storageClassName" $ }}
   hostPath:
-    path: {{ required "customVolumes.postgres.hostPath or spec.postgres_data_path are required!" (default ($.Values.AWX.spec).postgres_data_path .hostPath) | quote }}
+    path: /var/lib/pgsql/data/userdata
 {{- end }}
 {{- end }}
 {{- end }}

--- a/config/crd/bases/awx.ansible.com_awxs.yaml
+++ b/config/crd/bases/awx.ansible.com_awxs.yaml
@@ -1807,9 +1807,6 @@ spec:
               postgres_priority_class:
                 description: Assign a preexisting priority class to the postgres pod
                 type: string
-              postgres_data_path:
-                description: Path where the PostgreSQL data are located
-                type: string
               postgres_extra_args:
                 type: array
                 items:

--- a/config/manifests/bases/awx-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/awx-operator.clusterserviceversion.yaml
@@ -637,11 +637,6 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:io.kubernetes:StorageClass
         - urn:alm:descriptor:com.tectonic.ui:advanced
-      - displayName: Postgres Datapath
-        path: postgres_data_path
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:advanced
-        - urn:alm:descriptor:com.tectonic.ui:hidden
       - displayName: Postgres Extra Arguments
         path: postgres_extra_args
         x-descriptors:

--- a/docs/user-guide/database-configuration.md
+++ b/docs/user-guide/database-configuration.md
@@ -58,12 +58,12 @@ The following variables are customizable for the managed PostgreSQL service
 
 | Name                                          | Description                                   | Default                                 |
 | --------------------------------------------- | --------------------------------------------- | --------------------------------------- |
-| postgres_image                                | Path of the image to pull                     | quay.io/sclorg/postgresql-15-c9s:latest |
+| postgres_image                                | Path of the image to pull                     | quay.io/sclorg/postgresql-15-c9s        |
+| postgres_image_version                        | Image version to pull                         | latest                                  |
 | postgres_init_container_resource_requirements | Database init container resource requirements | requests: {cpu: 10m, memory: 64Mi}      |
 | postgres_resource_requirements                | PostgreSQL container resource requirements    | requests: {cpu: 10m, memory: 64Mi}      |
 | postgres_storage_requirements                 | PostgreSQL container storage requirements     | requests: {storage: 8Gi}                |
 | postgres_storage_class                        | PostgreSQL PV storage class                   | Empty string                            |
-| postgres_data_path                            | PostgreSQL data path                          | `/var/lib/postgresql/data/pgdata`       |
 | postgres_priority_class                       | Priority class used for PostgreSQL pod        | Empty string                            |
 
 Example of customization could be:
@@ -91,3 +91,11 @@ spec:
 ```
 
 **Note**: If `postgres_storage_class` is not defined, PostgreSQL will store it's data on a volume using the default storage class for your cluster.
+
+#### Note about overriding the postgres image
+
+We recommend you use the default image sclorg image. If you are coming from a deployment using the old postgres image from dockerhub (postgres:13), upgrading from awx-operator version 2.12.2 and below to 2.15.0+ will handle migrating your data to the new postgresql image (postgresql-15-c9s).
+
+You can no longer configure a custom `postgres_data_path` because it is hardcoded in the quay.io/sclorg/postgresql-15-c9s image.
+
+If you override the postgres image to use a custom postgres image like postgres:15 for example, the default data directory path may be different. These images cannot be used interchangeably.

--- a/roles/installer/defaults/main.yml
+++ b/roles/installer/defaults/main.yml
@@ -401,7 +401,6 @@ postgres_init_container_resource_requirements:
     memory: 64Mi
 # Assign a preexisting priority class to the postgres pod
 postgres_priority_class: ''
-postgres_data_path: '/var/lib/pgsql/data/pgdata'
 
 # Persistence to the AWX project data folder
 # Whether or not the /var/lib/projects directory will be persistent

--- a/roles/installer/tasks/database_configuration.yml
+++ b/roles/installer/tasks/database_configuration.yml
@@ -162,8 +162,8 @@
         pod: "{{ old_postgres_pod['metadata']['name'] }}"
         command: |
           bash -c """
-          if [ -f "{{ postgres_data_path }}/PG_VERSION" ]; then
-            cat "{{ postgres_data_path }}/PG_VERSION"
+          if [ -f "{{ _postgres_data_path }}/PG_VERSION" ]; then
+            cat "{{ _postgres_data_path }}/PG_VERSION"
           elif [ -f '/var/lib/postgresql/data/pgdata/PG_VERSION' ]; then
             cat '/var/lib/postgresql/data/pgdata/PG_VERSION'
           fi

--- a/roles/installer/templates/statefulsets/postgres.yaml.j2
+++ b/roles/installer/templates/statefulsets/postgres.yaml.j2
@@ -94,7 +94,7 @@ spec:
                   name: '{{ __postgres_configuration_secret }}'
                   key: password
             - name: PGDATA
-              value: '{{ postgres_data_path }}'
+              value: '{{ _postgres_data_path }}'
             - name: POSTGRES_INITDB_ARGS
               value: '{{ postgres_initdb_args }}'
             - name: POSTGRES_HOST_AUTH_METHOD
@@ -111,8 +111,8 @@ spec:
               name: postgres-{{ supported_pg_version }}
           volumeMounts:
             - name: postgres-{{ supported_pg_version }}
-              mountPath: '{{ postgres_data_path | dirname }}'
-              subPath: '{{ postgres_data_path | dirname | basename }}'
+              mountPath: '{{ _postgres_data_path | dirname }}'
+              subPath: '{{ _postgres_data_path | dirname | basename }}'
 {% if postgres_extra_volume_mounts -%}
             {{ postgres_extra_volume_mounts | indent(width=12, first=True) }}
 {% endif %}

--- a/roles/installer/vars/main.yml
+++ b/roles/installer/vars/main.yml
@@ -7,3 +7,4 @@ projects_existing_claim: ''
 supported_pg_version: 15
 _previous_upgraded_pg_version: 0
 old_postgres_pod: []
+_postgres_data_path: '/var/lib/pgsql/data/userdata'


### PR DESCRIPTION
##### SUMMARY

Remove the ability to customize the postgres_data_dir
* in the sclorg Postgresql 15 image, the PGDATA directory is hardcoded
* if users were to modify this directory, they would only change the directory the pvc is mounted to, not the directory PostgreSQL uses. This would result in loss of data.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bug, Docs Fix or other nominal change


cc @kurokobo 