### PR TITLE
Add Bundle CA Cert volumeMount to migrations job pod

### DIFF
--- a/roles/installer/templates/jobs/migration.yaml.j2
+++ b/roles/installer/templates/jobs/migration.yaml.j2
@@ -29,6 +29,14 @@ spec:
               mountPath: "/etc/tower/settings.py"
               subPath: settings.py
               readOnly: true
+{% if bundle_ca_crt %}
+            - name: "ca-trust-extracted"
+              mountPath: "/etc/pki/ca-trust/extracted"
+            - name: "{{ ansible_operator_meta.name }}-bundle-cacert"
+              mountPath: /etc/pki/ca-trust/source/anchors/bundle-ca.crt
+              subPath: bundle-ca.crt
+              readOnly: true
+{% endif %}
 {% if development_mode | bool %}
             - name: awx-devel
               mountPath: "/awx_devel"
@@ -66,6 +74,16 @@ spec:
             items:
               - key: settings
                 path: settings.py
+{% if bundle_ca_crt %}
+        - name: "ca-trust-extracted"
+          emptyDir: {}
+        - name: "{{ ansible_operator_meta.name }}-bundle-cacert"
+          secret:
+            secretName: "{{ bundle_cacert_secret }}"
+            items:
+              - key: bundle-ca.crt
+                path: 'bundle-ca.crt'
+{% endif %}
 {% if development_mode | bool %}
         - name: awx-devel
           hostPath:


### PR DESCRIPTION
##### SUMMARY
Fixes: https://github.com/ansible/awx-operator/issues/1782

The bundle ca cert needed to be mounted into the k8s migration job pod for ssl support.  

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bug, Docs Fix or other nominal change

