### PR TITLE
Add the ability to delete the old postgres pvc automatically if desired

### DIFF
--- a/docs/upgrade/upgrading.md
+++ b/docs/upgrade/upgrading.md
@@ -22,13 +22,13 @@ In the event you need to recover the backup see the [restore role documentation]
 #### PostgreSQL Upgrade Considerations
 
 If there is a PostgreSQL major version upgrade, after the data directory on the PVC is migrated to the new version, the old PVC is kept by default.
-This provides the ability to roll back if needed, but can take up extra storage space in your cluster unnecessarily. You can configure it to be deleted automatically
+This provides the ability to roll back if needed, but can take up extra storage space in your cluster unnecessarily. By default, the postgres pvc from the previous version will remain unless you manually remove it, or have the `postgres_keep_pvc_after_upgrade` parameter set to false. You can configure it to be deleted automatically
 after a successful upgrade by setting the following variable on the AWX spec. 
 
 
 ```yaml
   spec:
-    postgres_keep_pvc_after_upgrade: False
+    postgres_keep_pvc_after_upgrade: false # this will delete your old database
 ```
 
 

--- a/roles/installer/defaults/main.yml
+++ b/roles/installer/defaults/main.yml
@@ -378,7 +378,7 @@ postgres_extra_volume_mounts: ''
 postgres_selector: ''
 
 # Specify whether or not to keep the old PVC after PostgreSQL upgrades
-postgres_keep_pvc_after_upgrade: True
+postgres_keep_pvc_after_upgrade: true
 
 # Add node tolerations for the Postgres pods.
 # Specify as literal block. E.g.:

--- a/roles/installer/tasks/upgrade_postgres.yml
+++ b/roles/installer/tasks/upgrade_postgres.yml
@@ -153,3 +153,15 @@
   loop:
     - "{{ ansible_operator_meta.name }}-postgres"
     - "{{ ansible_operator_meta.name }}-postgres-13"
+
+- name: Remove old persistent volume claim
+  k8s:
+    kind: PersistentVolumeClaim
+    api_version: v1
+    namespace: "{{ ansible_operator_meta.namespace }}"
+    name: "{{ item }}"
+    state: absent
+  loop:
+    - "postgres-{{ ansible_operator_meta.name }}-postgres-13-0"
+    - "postgres-13-{{ ansible_operator_meta.name }}-postgres-13-0"
+  when: not postgres_keep_pvc_after_upgrade


### PR DESCRIPTION
- this parameter will be hidden on the UI and should only be used for test runs etc. Users should be intention about deleting the old PVC, which is why by default, this will not delete the old PVC from the previous PostgreSQL version

##### SUMMARY
This adds back the functionality we had before, but with the correct boolean value...

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bug, Docs Fix or other nominal change
