### PR TITLE
Change docker-buildx to not push by default

### DIFF
--- a/.github/workflows/devel.yaml
+++ b/.github/workflows/devel.yaml
@@ -39,6 +39,8 @@ jobs:
       - name: Build and Store Image @ghcr
         run: |
           IMG=ghcr.io/${{ github.repository }}:${{ github.sha }} make docker-buildx
+        env:
+          DOCKER_BUILDX_PUSH: true
 
 
       - name: Publish Image to quay.io

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -61,6 +61,8 @@ jobs:
               --build-arg OPERATOR_VERSION=${{ github.event.inputs.version }}" \
           IMG=ghcr.io/${{ github.repository }}:${{ github.event.inputs.version }} \
           make docker-buildx
+        env:
+          DOCKER_BUILDX_PUSH: true
 
       - name: Run test deployment
         working-directory: awx-operator

--- a/Makefile
+++ b/Makefile
@@ -114,13 +114,14 @@ docker-push: ## Push docker image with the manager.
 # - be able to push the image for your registry (i.e. if you do not inform a valid value via IMG=<myregistry/image:<tag>> than the export will fail)
 # To properly provided solutions that supports more than one platform you should use this option.
 PLATFORMS ?= linux/arm64,linux/amd64,linux/s390x,linux/ppc64le
+# Set DOCKER_BUILDX_PUSH to "true" to push the image, set to any other value to load image to docker instead of pushing
+DOCKER_BUILDX_PUSH ?= false
 .PHONY: docker-buildx
 docker-buildx: ## Build and push docker image for the manager for cross-platform support
-	- docker buildx create --name project-v3-builder
-	docker buildx use project-v3-builder
-	- docker buildx build --push $(BUILD_ARGS) --platform=$(PLATFORMS) --tag ${IMG} -f Dockerfile .
-	- docker buildx rm project-v3-builder
-
+	- docker buildx create --name awx-operator-v3-builder
+	docker buildx use awx-operator-v3-builder
+	- docker buildx build $(if $(filter true,$(DOCKER_BUILDX_PUSH)),--push,--load) $(BUILD_ARGS) --platform=$(PLATFORMS) --tag ${IMG} -f Dockerfile .
+	- docker buildx rm awx-operator-v3-builder
 
 ##@ Deployment
 


### PR DESCRIPTION
##### SUMMARY
To enable push set DOCKER_BUILDX_PUSH to true

this prevents accidentally pushing to the quay.io/ansible/awx-operator image registry (for those who have permission_

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
