### PR TITLE
add tolerations/nodeselector to migration job template (fixes #1774)

### DIFF
--- a/docs/user-guide/advanced-configuration/assigning-awx-pods-to-specific-nodes.md
+++ b/docs/user-guide/advanced-configuration/assigning-awx-pods-to-specific-nodes.md
@@ -88,3 +88,8 @@ spec:
               - S2
           topologyKey: topology.kubernetes.io/zone
 ```
+
+#### Special Note on DB-Migration Job Scheduling
+
+For the **db-migration job**, which applies database migrations at cluster startup, you can specify scheduling settings using the `task_*` configurations such as `task_node_selector`, `task_tolerations`, etc.  
+If these task-specific settings are not defined, the job will automatically use the global AWX configurations like `node_selector` and `tolerations`.

--- a/roles/installer/templates/jobs/migration.yaml.j2
+++ b/roles/installer/templates/jobs/migration.yaml.j2
@@ -43,6 +43,34 @@ spec:
         - name: {{ secret }}
 {% endfor %}
 {% endif %}
+{% if task_node_selector %}
+      nodeSelector:
+        {{ task_node_selector | indent(width=8) }}
+{% elif node_selector %}
+      nodeSelector:
+        {{ node_selector | indent(width=8) }}
+{% endif %}
+{% if task_topology_spread_constraints %}
+      topologySpreadConstraints:
+        {{ task_topology_spread_constraints | indent(width=8) }}
+{% elif topology_spread_constraints %}
+      topologySpreadConstraints:
+        {{ topology_spread_constraints | indent(width=8) }}
+{% endif %}
+{% if task_tolerations %}
+      tolerations:
+        {{ task_tolerations | indent(width=8) }}
+{% elif tolerations %}
+      tolerations:
+        {{ tolerations | indent(width=8) }}
+{% endif %}
+{% if task_affinity %}
+      affinity:
+        {{ task_affinity | to_nice_yaml | indent(width=8) }}
+{% elif affinity %}
+      affinity:
+        {{ affinity | to_nice_yaml | indent(width=8) }}
+{% endif %}
       volumes:
         - name: "{{ ansible_operator_meta.name }}-application-credentials"
           secret:


### PR DESCRIPTION
##### SUMMARY
As described in https://github.com/ansible/awx-operator/issues/1774, the migration pod has no provisions to add tolerations to it. This PR's solution is to use the postgres pod's toleration/selector on the migration job. 

The docs would need to be updated to alert the user about this relationship between postgres and the migration pod

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change
