### PR TITLE
Add postgres init container to resolve permissions for some k3s deployments

### DIFF
--- a/config/crd/bases/awx.ansible.com_awxs.yaml
+++ b/config/crd/bases/awx.ansible.com_awxs.yaml
@@ -1459,28 +1459,6 @@ spec:
                         type: string
                     type: object
                 type: object
-              postgres_init_container_resource_requirements:
-                description: Resource requirements for the postgres init container
-                properties:
-                  requests:
-                    properties:
-                      cpu:
-                        type: string
-                      memory:
-                        type: string
-                      storage:
-                        type: string
-                    type: object
-                  limits:
-                    properties:
-                      cpu:
-                        type: string
-                      memory:
-                        type: string
-                      storage:
-                        type: string
-                    type: object
-                type: object
               redis_resource_requirements:
                 description: Resource requirements for the redis container
                 properties:
@@ -1811,6 +1789,12 @@ spec:
                 type: array
                 items:
                   type: string
+              postgres_data_volume_init:
+                description: Sets permissions on the /var/lib/postgresql/data for postgres container using an init container (not Openshift)
+                type: boolean
+              postgres_init_container_commands:
+                description: Customize the postgres init container commands (Non Openshift)
+                type: string
               postgres_extra_volumes:
                 description: Specify extra volumes to add to the application pod
                 type: string

--- a/config/crd/bases/awx.ansible.com_awxs.yaml
+++ b/config/crd/bases/awx.ansible.com_awxs.yaml
@@ -1459,6 +1459,28 @@ spec:
                         type: string
                     type: object
                 type: object
+              postgres_init_container_resource_requirements:
+                description: (Deprecated, use postgres_resource_requirements parameter) Resource requirements for the postgres init container
+                properties:
+                  requests:
+                    properties:
+                      cpu:
+                        type: string
+                      memory:
+                        type: string
+                      storage:
+                        type: string
+                    type: object
+                  limits:
+                    properties:
+                      cpu:
+                        type: string
+                      memory:
+                        type: string
+                      storage:
+                        type: string
+                    type: object
+                type: object
               redis_resource_requirements:
                 description: Resource requirements for the redis container
                 properties:
@@ -1790,7 +1812,7 @@ spec:
                 items:
                   type: string
               postgres_data_volume_init:
-                description: Sets permissions on the /var/lib/postgresql/data for postgres container using an init container (not Openshift)
+                description: Sets permissions on the /var/lib/pgdata/data for postgres container using an init container (not Openshift)
                 type: boolean
               postgres_init_container_commands:
                 description: Customize the postgres init container commands (Non Openshift)

--- a/config/manifests/bases/awx-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/awx-operator.clusterserviceversion.yaml
@@ -456,13 +456,16 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
-      - description: The PostgreSQL init container is not used when an external DB
-          is configured
-        displayName: PostgreSQL Init Container Resource Requirements
-        path: postgres_init_container_resource_requirements
+      - description: Sets permissions on the /var/lib/postgresql/data for postgres container using an init container (not Openshift)
+        displayName: PostgreSQL initialize data volume
+        path: postgres_data_volume_init
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:advanced
-        - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Customize the postgres init container commands (Non Openshift)
+        displayName: PostgreSQL Init Container Commands
+        path: postgres_init_container_commands
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
       - displayName: Redis Container Resource Requirements
         path: redis_resource_requirements
         x-descriptors:

--- a/config/manifests/bases/awx-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/awx-operator.clusterserviceversion.yaml
@@ -456,7 +456,7 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
-      - description: Sets permissions on the /var/lib/postgresql/data for postgres container using an init container (not Openshift)
+      - description: Sets permissions on the /var/lib/pgsql/data for postgres container using an init container (not Openshift)
         displayName: PostgreSQL initialize data volume
         path: postgres_data_volume_init
         x-descriptors:
@@ -466,6 +466,12 @@ spec:
         path: postgres_init_container_commands
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: (Deprecated, use postgres_resource_requirements parameter instead)
+        displayName: PostgreSQL Init Container Resource Requirements
+        path: postgres_init_container_resource_requirements
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+        - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
       - displayName: Redis Container Resource Requirements
         path: redis_resource_requirements
         x-descriptors:

--- a/config/samples/awx_v1beta1_awx_resource_limits.yaml
+++ b/config/samples/awx_v1beta1_awx_resource_limits.yaml
@@ -46,10 +46,3 @@ spec:
     limits:
       cpu: 1000m
       memory: 2Gi
-  postgres_init_container_resource_requirements:
-    requests:
-      cpu: 10m
-      memory: 64Mi
-    limits:
-      cpu: 1000m
-      memory: 2Gi

--- a/docs/user-guide/advanced-configuration/containers-resource-requirements.md
+++ b/docs/user-guide/advanced-configuration/containers-resource-requirements.md
@@ -22,15 +22,15 @@ spec:
 
 The resource requirements for both, the task and the web containers are configurable - both the lower end (requests) and the upper end (limits).
 
-| Name                       | Description                                      | Default                              |
-| -------------------------- | ------------------------------------------------ | ------------------------------------ |
-| web_resource_requirements  | Web container resource requirements              | requests: {cpu: 100m, memory: 128Mi} |
-| task_resource_requirements | Task container resource requirements             | requests: {cpu: 100m, memory: 128Mi} |
-| ee_resource_requirements   | EE control plane container resource requirements | requests: {cpu: 50m, memory: 64Mi} |
-| redis_resource_requirements   | Redis container resource requirements | requests: {cpu: 100m, memory: 128Mi} |
-| postgres_resource_requirements   | Postgres container resource requirements | requests: {cpu: 10m, memory: 64Mi} |
-| rsyslog_resource_requirements   | Rsyslog container resource requirements | requests: {cpu: 100m, memory: 128Mi} |
-| init_container_resource_requirements   | Init Container resource requirements | requests: {cpu: 100m, memory: 128Mi} |
+| Name                                 | Description                                                  | Default                              |
+| ------------------------------------ | ------------------------------------------------------------ | ------------------------------------ |
+| web_resource_requirements            | Web container resource requirements                          | requests: {cpu: 100m, memory: 128Mi} |
+| task_resource_requirements           | Task container resource requirements                         | requests: {cpu: 100m, memory: 128Mi} |
+| ee_resource_requirements             | EE control plane container resource requirements             | requests: {cpu: 50m, memory: 64Mi} |
+| redis_resource_requirements          | Redis container resource requirements                        | requests: {cpu: 100m, memory: 128Mi} |
+| postgres_resource_requirements       | Postgres container (and initContainer) resource requirements | requests: {cpu: 10m, memory: 64Mi}   |
+| rsyslog_resource_requirements        | Rsyslog container resource requirements                      | requests: {cpu: 100m, memory: 128Mi} |
+| init_container_resource_requirements | Init Container resource requirements                         | requests: {cpu: 100m, memory: 128Mi} |
 
 
 Example of customization could be:

--- a/docs/user-guide/advanced-configuration/containers-resource-requirements.md
+++ b/docs/user-guide/advanced-configuration/containers-resource-requirements.md
@@ -31,7 +31,6 @@ The resource requirements for both, the task and the web containers are configur
 | postgres_resource_requirements   | Postgres container resource requirements | requests: {cpu: 10m, memory: 64Mi} |
 | rsyslog_resource_requirements   | Rsyslog container resource requirements | requests: {cpu: 100m, memory: 128Mi} |
 | init_container_resource_requirements   | Init Container resource requirements | requests: {cpu: 100m, memory: 128Mi} |
-| postgres_init_container_resource_requirements   | Postgres Init Container resource requirements | requests: {cpu: 10m, memory: 64Mi} |
 
 
 Example of customization could be:
@@ -82,13 +81,6 @@ spec:
     requests:
       cpu: 100m
       memory: 128Mi
-    limits:
-      cpu: 1000m
-      memory: 2Gi
-  postgres_init_container_resource_requirements:
-    requests:
-      cpu: 10m
-      memory: 64Mi
     limits:
       cpu: 1000m
       memory: 2Gi

--- a/docs/user-guide/database-configuration.md
+++ b/docs/user-guide/database-configuration.md
@@ -56,14 +56,14 @@ If you don't have access to an external PostgreSQL service, the AWX operator can
 
 The following variables are customizable for the managed PostgreSQL service
 
-| Name                                          | Description                                   | Default                                 |
-| --------------------------------------------- | --------------------------------------------- | --------------------------------------- |
-| postgres_image                                | Path of the image to pull                     | quay.io/sclorg/postgresql-15-c9s        |
-| postgres_image_version                        | Image version to pull                         | latest                                  |
-| postgres_resource_requirements                | PostgreSQL container resource requirements    | requests: {cpu: 10m, memory: 64Mi}      |
-| postgres_storage_requirements                 | PostgreSQL container storage requirements     | requests: {storage: 8Gi}                |
-| postgres_storage_class                        | PostgreSQL PV storage class                   | Empty string                            |
-| postgres_priority_class                       | Priority class used for PostgreSQL pod        | Empty string                            |
+| Name                                          | Description                                                     | Default                                 |
+| --------------------------------------------- | --------------------------------------------------------------- | --------------------------------------- |
+| postgres_image                                | Path of the image to pull                                       | quay.io/sclorg/postgresql-15-c9s        |
+| postgres_image_version                        | Image version to pull                                           | latest                                  |
+| postgres_resource_requirements                | PostgreSQL container (and initContainer) resource requirements  | requests: {cpu: 10m, memory: 64Mi}      |
+| postgres_storage_requirements                 | PostgreSQL container storage requirements                       | requests: {storage: 8Gi}                |
+| postgres_storage_class                        | PostgreSQL PV storage class                                     | Empty string                            |
+| postgres_priority_class                       | Priority class used for PostgreSQL pod                          | Empty string                            |
 
 Example of customization could be:
 

--- a/docs/user-guide/database-configuration.md
+++ b/docs/user-guide/database-configuration.md
@@ -60,7 +60,6 @@ The following variables are customizable for the managed PostgreSQL service
 | --------------------------------------------- | --------------------------------------------- | --------------------------------------- |
 | postgres_image                                | Path of the image to pull                     | quay.io/sclorg/postgresql-15-c9s        |
 | postgres_image_version                        | Image version to pull                         | latest                                  |
-| postgres_init_container_resource_requirements | Database init container resource requirements | requests: {cpu: 10m, memory: 64Mi}      |
 | postgres_resource_requirements                | PostgreSQL container resource requirements    | requests: {cpu: 10m, memory: 64Mi}      |
 | postgres_storage_requirements                 | PostgreSQL container storage requirements     | requests: {storage: 8Gi}                |
 | postgres_storage_class                        | PostgreSQL PV storage class                   | Empty string                            |
@@ -99,3 +98,22 @@ We recommend you use the default image sclorg image. If you are coming from a de
 You can no longer configure a custom `postgres_data_path` because it is hardcoded in the quay.io/sclorg/postgresql-15-c9s image.
 
 If you override the postgres image to use a custom postgres image like postgres:15 for example, the default data directory path may be different. These images cannot be used interchangeably.
+
+#### Initialize Postgres data volume
+
+When using a hostPath backed PVC and some other storage classes like longhorn storagfe, the postgres data directory needs to be accessible by the user in the postgres pod (UID 26).
+
+To initialize this directory with the correct permissions, configure the following setting, which will use an init container to set the permissions in the postgres volume.
+
+```yaml
+spec:
+  postgres_data_volume_init: true
+```
+
+Should you need to modify the init container commands, there is an example below.
+
+```yaml
+postgres_init_container_commands: |
+  chown 26:0 /var/lib/pgsql/data
+  chmod 700 /var/lib/pgsql/data
+```

--- a/molecule/default/templates/awx_cr_molecule.yml.j2
+++ b/molecule/default/templates/awx_cr_molecule.yml.j2
@@ -32,7 +32,6 @@ spec:
       memory: 16M
   no_log: false
   postgres_resource_requirements: {}
-  postgres_init_container_resource_requirements: {}
   redis_resource_requirements: {}
   additional_labels:
   - my/team

--- a/roles/installer/defaults/main.yml
+++ b/roles/installer/defaults/main.yml
@@ -395,10 +395,7 @@ postgres_resource_requirements:
   requests:
     cpu: 10m
     memory: 64Mi
-postgres_init_container_resource_requirements:
-  requests:
-    cpu: 10m
-    memory: 64Mi
+
 # Assign a preexisting priority class to the postgres pod
 postgres_priority_class: ''
 
@@ -411,6 +408,11 @@ projects_existing_claim: ''
 #
 # Define postgres configuration arguments to use
 postgres_extra_args: ''
+
+postgres_data_volume_init: false
+postgres_init_container_commands: |
+  chown 26:0 /var/lib/pgsql/data
+  chmod 700 /var/lib/pgsql/data
 
 # Configure postgres connection keepalive
 postgres_keepalives: true

--- a/roles/installer/templates/statefulsets/postgres.yaml.j2
+++ b/roles/installer/templates/statefulsets/postgres.yaml.j2
@@ -47,6 +47,27 @@ spec:
 {% if postgres_priority_class is defined %}
       priorityClassName: '{{ postgres_priority_class }}'
 {% endif %}
+{% if postgres_data_volume_init is defined and not is_openshift %}
+      initContainers:
+        - name: init
+          image: '{{ _postgres_image }}'
+          imagePullPolicy: '{{ image_pull_policy }}'
+          securityContext:
+            runAsUser: 0
+          command:
+            - /bin/sh
+            - -c
+            - |
+              {{ postgres_init_container_commands | indent(width=14) }}
+          resources: {{ postgres_resource_requirements }}
+          volumeMounts:
+            - name: postgres-{{ supported_pg_version }}
+              mountPath: '{{ _postgres_data_path | dirname }}'
+              subPath: '{{ _postgres_data_path | dirname | basename }}'
+{% if postgres_extra_volume_mounts %}
+            {{ postgres_extra_volume_mounts | indent(width=12, first=True) }}
+{% endif %}
+{% endif %}
       containers:
         - image: '{{ _postgres_image }}'
           imagePullPolicy: '{{ image_pull_policy }}'
@@ -113,7 +134,7 @@ spec:
             - name: postgres-{{ supported_pg_version }}
               mountPath: '{{ _postgres_data_path | dirname }}'
               subPath: '{{ _postgres_data_path | dirname | basename }}'
-{% if postgres_extra_volume_mounts -%}
+{% if postgres_extra_volume_mounts %}
             {{ postgres_extra_volume_mounts | indent(width=12, first=True) }}
 {% endif %}
           resources: {{ postgres_resource_requirements }}

--- a/roles/installer/templates/statefulsets/postgres.yaml.j2
+++ b/roles/installer/templates/statefulsets/postgres.yaml.j2
@@ -47,7 +47,7 @@ spec:
 {% if postgres_priority_class is defined %}
       priorityClassName: '{{ postgres_priority_class }}'
 {% endif %}
-{% if postgres_data_volume_init is defined and not is_openshift %}
+{% if postgres_data_volume_init and not is_openshift %}
       initContainers:
         - name: init
           image: '{{ _postgres_image }}'
@@ -59,7 +59,7 @@ spec:
             - -c
             - |
               {{ postgres_init_container_commands | indent(width=14) }}
-          resources: {{ postgres_resource_requirements }}
+          resources: {{ postgres_init_container_resource_requirements | default(postgres_resource_requirements) }}
           volumeMounts:
             - name: postgres-{{ supported_pg_version }}
               mountPath: '{{ _postgres_data_path | dirname }}'


### PR DESCRIPTION
Alternate PR for https://github.com/ansible/awx-operator/pull/1799

Resolves:
* https://github.com/ansible/awx-operator/issues/1770
* https://github.com/ansible/awx-operator/issues/1775

This approach allows users to simply set:

```
spec:
  postgres_data_volume_init: true
```

This removes the unused `postgres_init_container_resource_requirements` parameter which was never removed when the last postgres init container was removed.  I cannot think of a good reason to not just use `postgres_resource_requirements`.

cc @kurokobo 

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New or Enhanced Feature

