### PR TITLE
Fix "external_hostname" should not be required while using Route ingress

### DIFF
--- a/roles/mesh_ingress/templates/ingress.yml.j2
+++ b/roles/mesh_ingress/templates/ingress.yml.j2
@@ -70,7 +70,7 @@ metadata:
   name: {{ ansible_operator_meta.name }}
   namespace: {{ ansible_operator_meta.namespace }}
 spec:
-{% if external_hostname %}
+{% if external_hostname is defined %}
   host: {{ external_hostname }}
 {% endif %}
   port:


### PR DESCRIPTION
##### SUMMARY
Fix "external_hostname" should not be required while using Route ingress

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
