### PR TITLE
DRAFT: Add the possibility of split crds and templates inside the helm chart

### DIFF
--- a/config/splitted-chart/Chart-cdrs.yaml
+++ b/config/splitted-chart/Chart-cdrs.yaml
@@ -1,0 +1,4 @@
+apiVersion: v2
+description: CRDs for for the AWX Operator
+name: crds
+version: 0.0.0

--- a/config/splitted-chart/dependencies.yaml
+++ b/config/splitted-chart/dependencies.yaml
@@ -1,0 +1,4 @@
+dependencies:
+  - name: crds
+    condition: crds.enabled
+    version: 0.0.0

--- a/config/splitted-chart/values-cdrs.yaml
+++ b/config/splitted-chart/values-cdrs.yaml
@@ -1,0 +1,3 @@
+---
+# annotations -- (dict) Optional annotations to include in the CRDs
+annotations: {}

--- a/config/splitted-chart/values.yaml
+++ b/config/splitted-chart/values.yaml
@@ -1,0 +1,3 @@
+---
+crds:
+  enabled: true


### PR DESCRIPTION
this helps with upgrades on multi tenant clusters since it separates the lifecycle of CRDs and templates

##### SUMMARY
This change adds a new Makefile target which splits templates and crds which helps with upgrades on multi tenant k8s clusters (many awx instances on different namespaces)

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New or Enhanced Feature

##### ADDITIONAL INFORMATION
Described [here](https://helm.sh/docs/chart_best_practices/custom_resource_definitions/#method-2-separate-charts) in helm documentation

the naming is consistent but ugly, i welcome suggestions of better naming
