### PR TITLE
Unified Annotation Handling without Duplicates

### DIFF
--- a/roles/installer/templates/deployments/task.yaml.j2
+++ b/roles/installer/templates/deployments/task.yaml.j2
@@ -44,11 +44,14 @@ spec:
   ] %}
         checksum-secret-{{ secret }}: "{{ lookup('ansible.builtin.vars', secret, default='')["resources"][0]["data"] | default('') | sha1 }}"
 {% endfor %}
-{% if task_annotations %}
-        {{ task_annotations | indent(width=8) }}
-{% elif annotations %}
-        {{ annotations | indent(width=8) }}
-{% endif %}
+{% set combined_annotations = web_annotations + annotations %}
+{% set seen = [] %}
+{% for annotation in combined_annotations %}
+    {% if annotation not in seen %}
+        {{ annotation | indent(width=8) }}
+        {% do seen.append(annotation) %}
+    {% endif %}
+{% endfor %}
     spec:
       serviceAccountName: '{{ ansible_operator_meta.name }}'
 {% if image_pull_secret is defined %}

--- a/roles/installer/templates/deployments/web.yaml.j2
+++ b/roles/installer/templates/deployments/web.yaml.j2
@@ -44,11 +44,14 @@ spec:
   ] %}
         checksum-secret-{{ secret }}: "{{ lookup('ansible.builtin.vars', secret, default='')["resources"][0]["data"] | default('') | sha1 }}"
 {% endfor %}
-{% if web_annotations %}
-        {{ web_annotations | indent(width=8) }}
-{% elif annotations %}
-        {{ annotations | indent(width=8) }}
-{% endif %}
+{% set combined_annotations = web_annotations + annotations %}
+{% set seen = [] %}
+{% for annotation in combined_annotations %}
+    {% if annotation not in seen %}
+        {{ annotation | indent(width=8) }}
+        {% do seen.append(annotation) %}
+    {% endif %}
+{% endfor %}
     spec:
 {% if uwsgi_listen_queue_size is defined and uwsgi_listen_queue_size|int > 128 %}
       securityContext:

--- a/roles/installer/templates/deployments/web.yaml.j2
+++ b/roles/installer/templates/deployments/web.yaml.j2
@@ -47,7 +47,7 @@ spec:
 {% for annotation in web_annotations %}
         {{ annotation | indent(width=8) }}
 {% endfor %}
-{% for annotation in  annotations %}
+{% for annotation in annotations %}
         {{ annotation | indent(width=8) }}
 {% endfor %}
     spec:

--- a/roles/installer/templates/deployments/web.yaml.j2
+++ b/roles/installer/templates/deployments/web.yaml.j2
@@ -44,11 +44,13 @@ spec:
   ] %}
         checksum-secret-{{ secret }}: "{{ lookup('ansible.builtin.vars', secret, default='')["resources"][0]["data"] | default('') | sha1 }}"
 {% endfor %}
-{% for annotation in web_annotations %}
+{% set combined_annotations = web_annotations + annotations %}
+{% set seen = [] %}
+{% for annotation in combined_annotations %}
+    {% if annotation not in seen %}
         {{ annotation | indent(width=8) }}
-{% endfor %}
-{% for annotation in annotations %}
-        {{ annotation | indent(width=8) }}
+        {% do seen.append(annotation) %}
+    {% endif %}
 {% endfor %}
     spec:
 {% if uwsgi_listen_queue_size is defined and uwsgi_listen_queue_size|int > 128 %}

--- a/roles/installer/templates/deployments/web.yaml.j2
+++ b/roles/installer/templates/deployments/web.yaml.j2
@@ -44,11 +44,12 @@ spec:
   ] %}
         checksum-secret-{{ secret }}: "{{ lookup('ansible.builtin.vars', secret, default='')["resources"][0]["data"] | default('') | sha1 }}"
 {% endfor %}
-{% if web_annotations %}
-        {{ web_annotations | indent(width=8) }}
-{% elif annotations %}
-        {{ annotations | indent(width=8) }}
-{% endif %}
+{% for annotation in web_annotations %}
+        {{ annotation | indent(width=8) }}
+{% endfor %}
+{% for annotation in  annotations %}
+        {{ annotation | indent(width=8) }}
+{% endfor %}
     spec:
 {% if uwsgi_listen_queue_size is defined and uwsgi_listen_queue_size|int > 128 %}
       securityContext:


### PR DESCRIPTION
The objective here is to manage multiple entries and unify **web_annotations** and **annotations** while avoiding duplicates.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change