### PR TITLE
installer: nginx: add missing locales location required by ui_next

### DIFF
--- a/roles/installer/templates/configmaps/config.yaml.j2
+++ b/roles/installer/templates/configmaps/config.yaml.j2
@@ -184,6 +184,10 @@ data:
                 alias /var/lib/awx/public/static/;
             }
 
+            location {{ (ingress_path + '/locales').replace('//', '/') }} {
+                alias /var/lib/awx/public/static/awx/locales;
+            }
+
             location {{ (ingress_path + '/favicon.ico').replace('//', '/') }} {
                 alias /var/lib/awx/public/static/media/favicon.ico;
             }


### PR DESCRIPTION
##### SUMMARY
The new UI depends on the locales available via ingress/locales which is being served as static file and not via Django.

A change in the nginx.conf was already done for the dev environment in commit ec4f10d86881389af12371f90cb75af03417d109 (AWX), but not here.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change
