### PR TITLE
docs: add a tip to add extra settings through configmaps or secrets and improve an example for that

### DIFF
--- a/docs/user-guide/advanced-configuration/custom-volume-and-volume-mount-options.md
+++ b/docs/user-guide/advanced-configuration/custom-volume-and-volume-mount-options.md
@@ -26,59 +26,64 @@ metadata:
   namespace: <target namespace>
 data:
   ansible.cfg: |
-     [defaults]
-     remote_tmp = /tmp
-     [ssh_connection]
-     ssh_args = -C -o ControlMaster=auto -o ControlPersist=60s
+    [defaults]
+    remote_tmp = /tmp
+    [ssh_connection]
+    ssh_args = -C -o ControlMaster=auto -o ControlPersist=60s
   custom.py:  |
-      INSIGHTS_URL_BASE = "example.org"
-      AWX_CLEANUP_PATHS = True
+    INSIGHTS_URL_BASE = "example.org"
+    AWX_CLEANUP_PATHS = True
 ```
 Example spec file for volumes and volume mounts
 
 ```yaml
 ---
-    spec:
-    ...
-      extra_volumes: |
-        - name: ansible-cfg
-          configMap:
-            defaultMode: 420
-            items:
-              - key: ansible.cfg
-                path: ansible.cfg
-            name: <resourcename>-extra-config
-        - name: custom-py
-          configMap:
-            defaultMode: 420
-            items:
-              - key: custom.py
-                path: custom.py
-            name: <resourcename>-extra-config
-        - name: shared-volume
-          persistentVolumeClaim:
-            claimName: my-external-volume-claim
+spec:
+  ...
+  extra_volumes: |
+    - name: ansible-cfg
+      configMap:
+        defaultMode: 420
+        items:
+          - key: ansible.cfg
+            path: ansible.cfg
+        name: <resourcename>-extra-config
+    - name: custom-py
+      configMap:
+        defaultMode: 420
+        items:
+          - key: custom.py
+            path: custom.py
+        name: <resourcename>-extra-config
+    - name: shared-volume
+      persistentVolumeClaim:
+        claimName: my-external-volume-claim
 
-      init_container_extra_volume_mounts: |
-        - name: shared-volume
-          mountPath: /shared
+  init_container_extra_volume_mounts: |
+    - name: shared-volume
+      mountPath: /shared
 
-      init_container_extra_commands: |
-        # set proper permissions (rwx) for the awx user
-        chmod 775 /shared
-        chgrp 1000 /shared
+  init_container_extra_commands: |
+    # set proper permissions (rwx) for the awx user
+    chmod 775 /shared
+    chgrp 1000 /shared
 
-      ee_extra_volume_mounts: |
-        - name: ansible-cfg
-          mountPath: /etc/ansible/ansible.cfg
-          subPath: ansible.cfg
+  ee_extra_volume_mounts: |
+    - name: ansible-cfg
+      mountPath: /etc/ansible/ansible.cfg
+      subPath: ansible.cfg
 
-      task_extra_volume_mounts: |
-        - name: custom-py
-          mountPath: /etc/tower/conf.d/custom.py
-          subPath: custom.py
-        - name: shared-volume
-          mountPath: /shared
+  web_extra_volume_mounts: |
+    - name: custom-py
+      mountPath: /etc/tower/conf.d/custom.py
+      subPath: custom.py
+
+  task_extra_volume_mounts: |
+    - name: custom-py
+      mountPath: /etc/tower/conf.d/custom.py
+      subPath: custom.py
+    - name: shared-volume
+      mountPath: /shared
 ```
 
 > :warning: **Volume and VolumeMount names cannot contain underscores(_)**
@@ -143,7 +148,9 @@ $ oc create configmap favicon-configmap --from-file favicon.ico
 Then specify the extra_volume and web_extra_volume_mounts on your AWX CR spec
 
 ```yaml
+---
 spec:
+  ...
   extra_volumes: |
     - name: favicon
       configMap:

--- a/docs/user-guide/advanced-configuration/custom-volume-and-volume-mount-options.md
+++ b/docs/user-guide/advanced-configuration/custom-volume-and-volume-mount-options.md
@@ -87,7 +87,8 @@ spec:
       mountPath: /shared
 ```
 
-> :warning: **Volume and VolumeMount names cannot contain underscores(_)**
+!!! warning
+    **Volume and VolumeMount names cannot contain underscores(_)**
 
 ##### Custom UWSGI Configuration
 We allow the customization of two UWSGI parameters:

--- a/docs/user-guide/advanced-configuration/custom-volume-and-volume-mount-options.md
+++ b/docs/user-guide/advanced-configuration/custom-volume-and-volume-mount-options.md
@@ -13,7 +13,8 @@ In a scenario where custom volumes and volume mounts are required to either over
 | init_container_extra_commands      | Specify additional commands for Init container           | ''      |
 
 
-> :warning: The `ee_extra_volume_mounts` and `extra_volumes` will only take effect to the globally available Execution Environments. For custom `ee`, please [customize the Pod spec](https://docs.ansible.com/ansible-tower/latest/html/administration/external_execution_envs.html#customize-the-pod-spec).
+!!! warning
+    The `ee_extra_volume_mounts` and `extra_volumes` will only take effect to the globally available Execution Environments. For custom `ee`, please [customize the Pod spec](https://docs.ansible.com/ansible-tower/latest/html/administration/external_execution_envs.html#customize-the-pod-spec).
 
 Example configuration for ConfigMap
 

--- a/docs/user-guide/advanced-configuration/extra-settings.md
+++ b/docs/user-guide/advanced-configuration/extra-settings.md
@@ -24,3 +24,7 @@ Example configuration of `extra_settings` parameter
 ```
 
 Note for some settings, such as `LOG_AGGREGATOR_LEVEL`, the value may need double quotes.
+
+!!! tip
+    Alternatively, you can pass any additional settings by mounting ConfigMaps or Secrets of the python files (`*.py`) that contain custom settings to under `/etc/tower/conf.d/` in the web and task pods.
+    See the example of `custom.py` in the [Custom Volume and Volume Mount Options](custom-volume-and-volume-mount-options.md) section.


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

The page "[Custom volume and volume mount options](https://ansible.readthedocs.io/projects/awx-operator/en/latest/user-guide/advanced-configuration/custom-volume-and-volume-mount-options.html)" contains an example of mounting `custom.py` under `/etc/tower/conf.d/` that contains extra settings for AWX.

This is very handy way if users' `exta_settings` is too big, but there is less information about this way. I think the page for `exta_settings` should contain this alternative handy way.

This PR changes:

- Add a tip to provide alternative way to add extra settings by mounting configmaps or secrets of `*.py` files.
- Add `web_extra_volume_mounts` in the example in `custom-volume-and-volume-mount-options.md` to ensure `custom.py` is mounted on both task and web pods.
- Fix minor issues
  - Correct indentation for the code blocks in `custom-volume-and-volume-mount-options.md`.
  - Correct `warning` block in `custom-volume-and-volume-mount-options.md`.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
-->

**The main setting file `/etc/tower/settings.py` is also mounted on the migration job pods and the metrics utility job pods, and currently there is no way to add custom volumes to migration job pod and metrics utility job pods.**

**Mounting `custom.py` may cause inconsistencies between the setting files in the task/web pods and migration/metrics utility pods, but I do not expect that `custom.py` will provide any settings that would affect migrations or metrics utilities. Please let me know if I am wrong (in which case I should rather remove the `custom.py` from this examples).**