### PR TITLE
feat: implement extra_settings_files

### DIFF
--- a/config/crd/bases/awx.ansible.com_awxs.yaml
+++ b/config/crd/bases/awx.ansible.com_awxs.yaml
@@ -1904,6 +1904,28 @@ spec:
                       x-kubernetes-preserve-unknown-fields: true
                   type: object
                 type: array
+              extra_settings_files:
+                description: Extra ConfigMaps or Secrets of settings files to specify for AWX
+                properties:
+                  configmaps:
+                    items:
+                      properties:
+                        name:
+                          type: string
+                        key:
+                          type: string
+                      type: object
+                    type: array
+                  secrets:
+                    items:
+                      properties:
+                        name:
+                          type: string
+                        key:
+                          type: string
+                      type: object
+                    type: array
+                type: object
               no_log:
                 description: Configure no_log for no_log tasks
                 type: boolean

--- a/config/manifests/bases/awx-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/awx-operator.clusterserviceversion.yaml
@@ -966,6 +966,11 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:hidden
+      - displayName: Extra Settings Files
+        path: extra_settings_files
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:hidden
       - displayName: No Log Configuration
         path: no_log
         x-descriptors:

--- a/docs/user-guide/advanced-configuration/custom-volume-and-volume-mount-options.md
+++ b/docs/user-guide/advanced-configuration/custom-volume-and-volume-mount-options.md
@@ -1,4 +1,4 @@
-## Custom Volume and Volume Mount Options
+# Custom Volume and Volume Mount Options
 
 In a scenario where custom volumes and volume mounts are required to either overwrite defaults or mount configuration files.
 
@@ -68,11 +68,7 @@ spec:
 !!! warning
     **Volume and VolumeMount names cannot contain underscores(_)**
 
-### Custom AWX Configuration
-
-Refer to the [Extra Settings](./extra-settings.md) documentation for customizing the AWX configuration.
-
-### Custom UWSGI Configuration
+## Custom UWSGI Configuration
 
 We allow the customization of two UWSGI parameters:
 
@@ -93,7 +89,7 @@ requests (more than 128) tend to come in a short period of time, but can all be
 handled before any other time outs may apply. Also see related nginx
 configuration.
 
-### Custom Nginx Configuration
+## Custom Nginx Configuration
 
 Using the [extra_volumes feature](#custom-volume-and-volume-mount-options), it is possible to extend the nginx.conf.
 
@@ -120,7 +116,7 @@ configuration.
 * [worker_connections](http://nginx.org/en/docs/ngx_core_module.html#worker_connections) with `nginx_worker_connections` (minimum of 1024)
 * [listen](https://nginx.org/en/docs/http/ngx_http_core_module.html#listen) with `nginx_listen_queue_size` (default same as uwsgi listen queue size)
 
-### Custom Logos
+## Custom Logos
 
 You can use custom volume mounts to mount in your own logos to be displayed instead of the AWX logo.
 There are two different logos, one to be displayed on page headers, and one for the login screen.
@@ -162,7 +158,7 @@ spec:
       subPath: logo-header.svg
 ```
 
-### Custom Favicon
+## Custom Favicon
 
 You can also use custom volume mounts to mount in your own favicon to be displayed in your AWX browser tab.
 
@@ -191,3 +187,7 @@ spec:
       mountPath: /var/lib/awx/public/static/media/favicon.ico
       subPath: favicon.ico
 ```
+
+## Custom AWX Configuration
+
+Refer to the [Extra Settings](./extra-settings.md) documentation for customizing the AWX configuration.

--- a/docs/user-guide/advanced-configuration/custom-volume-and-volume-mount-options.md
+++ b/docs/user-guide/advanced-configuration/custom-volume-and-volume-mount-options.md
@@ -1,4 +1,4 @@
-#### Custom Volume and Volume Mount Options
+## Custom Volume and Volume Mount Options
 
 In a scenario where custom volumes and volume mounts are required to either overwrite defaults or mount configuration files.
 
@@ -11,7 +11,6 @@ In a scenario where custom volumes and volume mounts are required to either over
 | ee_extra_volume_mounts             | Specify volume mounts to be added to Execution container | ''      |
 | init_container_extra_volume_mounts | Specify volume mounts to be added to Init container      | ''      |
 | init_container_extra_commands      | Specify additional commands for Init container           | ''      |
-
 
 !!! warning
     The `ee_extra_volume_mounts` and `extra_volumes` will only take effect to the globally available Execution Environments. For custom `ee`, please [customize the Pod spec](https://docs.ansible.com/ansible-tower/latest/html/administration/external_execution_envs.html#customize-the-pod-spec).
@@ -31,10 +30,8 @@ data:
     remote_tmp = /tmp
     [ssh_connection]
     ssh_args = -C -o ControlMaster=auto -o ControlPersist=60s
-  custom.py:  |
-    INSIGHTS_URL_BASE = "example.org"
-    AWX_CLEANUP_PATHS = True
 ```
+
 Example spec file for volumes and volume mounts
 
 ```yaml
@@ -48,13 +45,6 @@ spec:
         items:
           - key: ansible.cfg
             path: ansible.cfg
-        name: <resourcename>-extra-config
-    - name: custom-py
-      configMap:
-        defaultMode: 420
-        items:
-          - key: custom.py
-            path: custom.py
         name: <resourcename>-extra-config
     - name: shared-volume
       persistentVolumeClaim:
@@ -73,24 +63,17 @@ spec:
     - name: ansible-cfg
       mountPath: /etc/ansible/ansible.cfg
       subPath: ansible.cfg
-
-  web_extra_volume_mounts: |
-    - name: custom-py
-      mountPath: /etc/tower/conf.d/custom.py
-      subPath: custom.py
-
-  task_extra_volume_mounts: |
-    - name: custom-py
-      mountPath: /etc/tower/conf.d/custom.py
-      subPath: custom.py
-    - name: shared-volume
-      mountPath: /shared
 ```
 
 !!! warning
     **Volume and VolumeMount names cannot contain underscores(_)**
 
-##### Custom UWSGI Configuration
+### Custom AWX Configuration
+
+Refer to the [Extra Settings](./extra-settings.md) documentation for customizing the AWX configuration.
+
+### Custom UWSGI Configuration
+
 We allow the customization of two UWSGI parameters:
 
 * [processes](https://uwsgi-docs.readthedocs.io/en/latest/Options.html#processes) with `uwsgi_processes` (default 5)
@@ -110,7 +93,7 @@ requests (more than 128) tend to come in a short period of time, but can all be
 handled before any other time outs may apply. Also see related nginx
 configuration.
 
-##### Custom Nginx Configuration
+### Custom Nginx Configuration
 
 Using the [extra_volumes feature](#custom-volume-and-volume-mount-options), it is possible to extend the nginx.conf.
 
@@ -131,13 +114,13 @@ may allow the web pods to handle more "bursty" request patterns if many
 requests (more than 128) tend to come in a short period of time, but can all be
 handled before any other time outs may apply. Also see related uwsgi
 configuration.
+
 * [worker_processes](http://nginx.org/en/docs/ngx_core_module.html#worker_processes) with `nginx_worker_processes` (default of 1)
 * [worker_cpu_affinity](http://nginx.org/en/docs/ngx_core_module.html#worker_cpu_affinity) with `nginx_worker_cpu_affinity` (default "auto")
 * [worker_connections](http://nginx.org/en/docs/ngx_core_module.html#worker_connections) with `nginx_worker_connections` (minimum of 1024)
 * [listen](https://nginx.org/en/docs/http/ngx_http_core_module.html#listen) with `nginx_listen_queue_size` (default same as uwsgi listen queue size)
 
-
-##### Custom Logos
+### Custom Logos
 
 You can use custom volume mounts to mount in your own logos to be displayed instead of the AWX logo.
 There are two different logos, one to be displayed on page headers, and one for the login screen.
@@ -145,8 +128,8 @@ There are two different logos, one to be displayed on page headers, and one for 
 First, create configmaps for the logos from local `logo-login.svg` and `logo-header.svg` files.
 
 ```bash
-$ kubectl create configmap logo-login-configmap --from-file logo-login.svg
-$ kubectl create configmap logo-header-configmap --from-file logo-header.svg
+kubectl create configmap logo-login-configmap --from-file logo-login.svg
+kubectl create configmap logo-header-configmap --from-file logo-header.svg
 ```
 
 Then specify the extra_volume and web_extra_volume_mounts on your AWX CR spec
@@ -179,15 +162,14 @@ spec:
       subPath: logo-header.svg
 ```
 
-
-##### Custom Favicon
+### Custom Favicon
 
 You can also use custom volume mounts to mount in your own favicon to be displayed in your AWX browser tab.
 
 First, create the configmap from a local `favicon.ico` file.
 
 ```bash
-$ kubectl create configmap favicon-configmap --from-file favicon.ico
+kubectl create configmap favicon-configmap --from-file favicon.ico
 ```
 
 Then specify the extra_volume and web_extra_volume_mounts on your AWX CR spec

--- a/docs/user-guide/advanced-configuration/extra-settings.md
+++ b/docs/user-guide/advanced-configuration/extra-settings.md
@@ -1,4 +1,4 @@
-## Extra Settings
+# Extra Settings
 
 With `extra_settings` and `extra_settings_files`, you can pass multiple custom settings to AWX via the AWX Operator.
 
@@ -7,7 +7,10 @@ With `extra_settings` and `extra_settings_files`, you can pass multiple custom s
 
     If you need to change the setting after the initial deployment, you need to change it on the AWX CR spec (for `extra_settings`) or corresponding ConfigMap or Secret (for `extra_settings_files`). After updating ConfigMap or Secret, you need to restart the AWX pods to apply the changes.
 
-### Add extra settings with `extra_settings`
+!!! note
+    If the same setting is set in both `extra_settings` and `extra_settings_files`, the setting in `extra_settings_files` will take precedence.
+
+## Add extra settings with `extra_settings`
 
 You can pass extra settings by specifying the pair of the setting name and value as the `extra_settings` parameter.
 
@@ -34,7 +37,7 @@ spec:
 
 Note for some settings, such as `LOG_AGGREGATOR_LEVEL`, the value may need double quotes.
 
-### Add extra settings with `extra_settings_files`
+## Add extra settings with `extra_settings_files`
 
 You can pass extra settings by specifying the additional settings files in the ConfigMaps or Secrets as the `extra_settings_files` parameter.
 
@@ -43,6 +46,9 @@ The settings files passed via `extra_settings_files` will be mounted as the file
 | Name                 | Description          | Default   |
 | -------------------- | -------------------- | --------- |
 | extra_settings_files | Extra settings files | `{}`      |
+
+!!! note
+    If the same setting is set in multiple files in `extra_settings_files`, it would be difficult to predict which would be adopted since these files are loaded in arbitrary order that [`glob`](https://docs.python.org/3/library/glob.html) returns. For a reliable setting, do not include the same key in more than one file.
 
 Create ConfigMaps or Secrets that contain custom settings files (`*.py`).
 

--- a/docs/user-guide/advanced-configuration/extra-settings.md
+++ b/docs/user-guide/advanced-configuration/extra-settings.md
@@ -1,30 +1,113 @@
-#### Extra Settings
+## Extra Settings
 
-With`extra_settings`, you can pass multiple custom settings via the `awx-operator`. The parameter `extra_settings`  will be appended to the `/etc/tower/settings.py` and can be an alternative to the `extra_volumes` parameter.
+With `extra_settings` and `extra_settings_files`, you can pass multiple custom settings to AWX via the AWX Operator.
 
-| Name           | Description    | Default |
-| -------------- | -------------- | ------- |
-| extra_settings | Extra settings | ''      |
+!!! note
+    Parameters configured in `extra_settings` or `extra_settings_files` are set as read-only settings in AWX. As a result, they cannot be changed in the UI after deployment.
 
-**Note:** Parameters configured in `extra_settings` are set as read-only settings in AWX.  As a result, they cannot be changed in the UI after deployment. If you need to change the setting after the initial deployment, you need to change it on the AWX CR spec.  
+    If you need to change the setting after the initial deployment, you need to change it on the AWX CR spec (for `extra_settings`) or corresponding ConfigMap or Secret (for `extra_settings_files`). After updating ConfigMap or Secret, you need to restart the AWX pods to apply the changes.
+
+### Add extra settings with `extra_settings`
+
+You can pass extra settings by specifying the pair of the setting name and value as the `extra_settings` parameter.
+
+The settings passed via `extra_settings` will be appended to the `/etc/tower/settings.py`.
+
+| Name           | Description    | Default   |
+| -------------- | -------------- | --------- |
+| extra_settings | Extra settings | `[]`      |
 
 Example configuration of `extra_settings` parameter
 
 ```yaml
-  spec:
-    extra_settings:
-      - setting: MAX_PAGE_SIZE
-        value: "500"
+spec:
+  extra_settings:
+    - setting: MAX_PAGE_SIZE
+      value: "500"
 
-      - setting: AUTH_LDAP_BIND_DN
-        value: "cn=admin,dc=example,dc=com"
+    - setting: AUTH_LDAP_BIND_DN
+      value: "cn=admin,dc=example,dc=com"
 
-      - setting: LOG_AGGREGATOR_LEVEL
-        value: "'DEBUG'"
+    - setting: LOG_AGGREGATOR_LEVEL
+      value: "'DEBUG'"
 ```
 
 Note for some settings, such as `LOG_AGGREGATOR_LEVEL`, the value may need double quotes.
 
-!!! tip
-    Alternatively, you can pass any additional settings by mounting ConfigMaps or Secrets of the python files (`*.py`) that contain custom settings to under `/etc/tower/conf.d/` in the web and task pods.
-    See the example of `custom.py` in the [Custom Volume and Volume Mount Options](custom-volume-and-volume-mount-options.md) section.
+### Add extra settings with `extra_settings_files`
+
+You can pass extra settings by specifying the additional settings files in the ConfigMaps or Secrets as the `extra_settings_files` parameter.
+
+The settings files passed via `extra_settings_files` will be mounted as the files under the `/etc/tower/conf.d`.
+
+| Name                 | Description          | Default   |
+| -------------------- | -------------------- | --------- |
+| extra_settings_files | Extra settings files | `{}`      |
+
+Create ConfigMaps or Secrets that contain custom settings files (`*.py`).
+
+```python title="custom_job_settings.py"
+AWX_TASK_ENV = {
+    "HTTPS_PROXY": "http://proxy.example.com:3128",
+    "HTTP_PROXY": "http://proxy.example.com:3128",
+    "NO_PROXY": "127.0.0.1,localhost,.example.com"
+}
+GALAXY_TASK_ENV = {
+    "ANSIBLE_FORCE_COLOR": "false",
+    "GIT_SSH_COMMAND": "ssh -o StrictHostKeyChecking=no",
+}
+```
+
+```python title="custom_system_settings.py"
+REMOTE_HOST_HEADERS = [
+    "HTTP_X_FORWARDED_FOR",
+    "REMOTE_ADDR",
+    "REMOTE_HOST",
+]
+```
+
+```python title="custom_passwords.py"
+SUBSCRIPTIONS_PASSWORD = "my-super-secure-subscription-password123!"
+REDHAT_PASSWORD = "my-super-secure-redhat-password123!"
+```
+
+```bash title="Create ConfigMap and Secret"
+# Create ConfigMap
+kubectl create configmap my-custom-settings \
+  --from-file=custom_job_settings.py=/PATH/TO/YOUR/custom_job_settings.py \
+  --from-file=custom_system_settings.py=/PATH/TO/YOUR/custom_system_settings.py
+
+# Create Secret
+kubectl create secret generic my-custom-passwords \
+  --from-file=custom_passwords.py=/PATH/TO/YOUR/custom_passwords.py
+```
+
+Then specify them in the AWX CR spec. Here is an example configuration of `extra_settings_files` parameter.
+
+```yaml
+spec:
+  extra_settings_files:
+    configmaps:
+      - name: my-custom-settings        # The name of the ConfigMap
+        key: custom_job_settings.py     # The key in the ConfigMap, which means the file name
+      - name: my-custom-settings
+        key: custom_system_settings.py
+    secrets:
+      - name: my-custom-passwords       # The name of the Secret
+        key: custom_passwords.py        # The key in the Secret, which means the file name
+```
+
+!!! Warning "Restriction"
+    There are some restrictions on the ConfigMaps or Secrets used in `extra_settings_files`.
+
+    - The keys in ConfigMaps or Secrets MUST be the name of python files and MUST end with `.py`
+    - The keys in ConfigMaps or Secrets MUST consists of alphanumeric characters, `-`, `_` or `.`
+    - The keys in ConfigMaps or Secrets are converted to the following strings, which MUST not exceed 63 characters
+        - Keys in ConfigMaps: `<instance name>-<KEY>-configmap`
+        - Keys in Secrets: `<instance name>-<KEY>-secret`
+    - Following keys are reserved and MUST NOT be used in ConfigMaps or Secrets
+        - `credentials.py`
+        - `execution_environments.py`
+        - `ldap.py`
+
+    Refer to the Kubernetes documentations ([[1]](https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/config-map-v1/), [[2]](https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/secret-v1/), [[3]](https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/volume/), [[4]](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/)) for more information about character types and length restrictions.

--- a/docs/user-guide/advanced-configuration/extra-settings.md
+++ b/docs/user-guide/advanced-configuration/extra-settings.md
@@ -74,12 +74,12 @@ REDHAT_PASSWORD = "my-super-secure-redhat-password123!"
 ```bash title="Create ConfigMap and Secret"
 # Create ConfigMap
 kubectl create configmap my-custom-settings \
-  --from-file=custom_job_settings.py=/PATH/TO/YOUR/custom_job_settings.py \
-  --from-file=custom_system_settings.py=/PATH/TO/YOUR/custom_system_settings.py
+  --from-file /PATH/TO/YOUR/custom_job_settings.py \
+  --from-file /PATH/TO/YOUR/custom_system_settings.py
 
 # Create Secret
 kubectl create secret generic my-custom-passwords \
-  --from-file=custom_passwords.py=/PATH/TO/YOUR/custom_passwords.py
+  --from-file /PATH/TO/YOUR/custom_passwords.py
 ```
 
 Then specify them in the AWX CR spec. Here is an example configuration of `extra_settings_files` parameter.

--- a/roles/installer/defaults/main.yml
+++ b/roles/installer/defaults/main.yml
@@ -491,3 +491,5 @@ nginx_worker_processes: 1
 nginx_worker_connections: "{{ uwsgi_listen_queue_size }}"
 nginx_worker_cpu_affinity: 'auto'
 nginx_listen_queue_size: "{{ uwsgi_listen_queue_size }}"
+
+extra_settings_files: {}

--- a/roles/installer/templates/common/volume_mounts/extra_settings_files.yaml.j2
+++ b/roles/installer/templates/common/volume_mounts/extra_settings_files.yaml.j2
@@ -1,0 +1,16 @@
+{% if extra_settings_files.configmaps is defined and extra_settings_files.configmaps | length %}
+{% for configmap in extra_settings_files.configmaps %}
+- name: {{ ansible_operator_meta.name }}-{{ configmap.key | replace('_', '-') | replace('.', '-') | lower }}-configmap
+  mountPath: "/etc/tower/conf.d/{{ configmap.key }}"
+  subPath: {{ configmap.key }}
+  readOnly: true
+{% endfor %}
+{% endif %}
+{% if extra_settings_files.secrets is defined and extra_settings_files.secrets | length %}
+{% for secret in extra_settings_files.secrets %}
+- name: {{ ansible_operator_meta.name }}-{{ secret.key | replace('_', '-') | replace('.', '-') | lower }}-secret
+  mountPath: "/etc/tower/conf.d/{{ secret.key }}"
+  subPath: {{ secret.key }}
+  readOnly: true
+{% endfor %}
+{% endif %}

--- a/roles/installer/templates/common/volumes/extra_settings_files.yaml.j2
+++ b/roles/installer/templates/common/volumes/extra_settings_files.yaml.j2
@@ -1,0 +1,20 @@
+{% if extra_settings_files.configmaps is defined and extra_settings_files.configmaps | length %}
+{% for configmap in extra_settings_files.configmaps %}
+- name: {{ ansible_operator_meta.name }}-{{ configmap.key | replace('_', '-') | replace('.', '-') | lower }}-configmap
+  configMap:
+    name: {{ configmap.name }}
+    items:
+      - key: {{ configmap.key }}
+        path: {{ configmap.key }}
+{% endfor %}
+{% endif %}
+{% if extra_settings_files.secrets is defined and extra_settings_files.secrets | length %}
+{% for secret in extra_settings_files.secrets %}
+- name: {{ ansible_operator_meta.name }}-{{ secret.key | replace('_', '-') | replace('.', '-') | lower }}-secret
+  secret:
+    secretName: {{ secret.name }}
+    items:
+      - key: {{ secret.key }}
+        path: {{ secret.key }}
+{% endfor %}
+{% endif %}

--- a/roles/installer/templates/cronjobs/metrics-utility-gather.yaml.j2
+++ b/roles/installer/templates/cronjobs/metrics-utility-gather.yaml.j2
@@ -67,6 +67,22 @@ spec:
               mountPath: /etc/tower/settings.py
               subPath: settings.py
               readOnly: true
+{% if extra_settings_files.configmaps is defined and extra_settings_files.configmaps | length %}
+{% for configmap in extra_settings_files.configmaps %}
+            - name: {{ ansible_operator_meta.name }}-{{ configmap.key | replace('_', '-') | replace('.', '-') | lower }}-configmap
+              mountPath: "/etc/tower/conf.d/{{ configmap.key }}"
+              subPath: {{ configmap.key }}
+              readOnly: true
+{% endfor %}
+{% endif %}
+{% if extra_settings_files.secrets is defined and extra_settings_files.secrets | length %}
+{% for secret in extra_settings_files.secrets %}
+            - name: {{ ansible_operator_meta.name }}-{{ secret.key | replace('_', '-') | replace('.', '-') | lower }}-secret
+              mountPath: "/etc/tower/conf.d/{{ secret.key }}"
+              subPath: {{ secret.key }}
+              readOnly: true
+{% endfor %}
+{% endif %}
           volumes:
           - name: {{ ansible_operator_meta.name }}-metrics-utility
             persistentVolumeClaim:
@@ -90,4 +106,24 @@ spec:
               items:
                 - key: settings
                   path: settings.py
+{% if extra_settings_files.configmaps is defined and extra_settings_files.configmaps | length %}
+{% for configmap in extra_settings_files.configmaps %}
+          - name: {{ ansible_operator_meta.name }}-{{ configmap.key | replace('_', '-') | replace('.', '-') | lower }}-configmap
+            configMap:
+              name: {{ configmap.name }}
+              items:
+                - key: {{ configmap.key }}
+                  path: {{ configmap.key }}
+{% endfor %}
+{% endif %}
+{% if extra_settings_files.secrets is defined and extra_settings_files.secrets | length %}
+{% for secret in extra_settings_files.secrets %}
+          - name: {{ ansible_operator_meta.name }}-{{ secret.key | replace('_', '-') | replace('.', '-') | lower }}-secret
+            secret:
+              secretName: {{ secret.name }}
+              items:
+                - key: {{ secret.key }}
+                  path: {{ secret.key }}
+{% endfor %}
+{% endif %}
           restartPolicy: OnFailure

--- a/roles/installer/templates/cronjobs/metrics-utility-gather.yaml.j2
+++ b/roles/installer/templates/cronjobs/metrics-utility-gather.yaml.j2
@@ -67,22 +67,7 @@ spec:
               mountPath: /etc/tower/settings.py
               subPath: settings.py
               readOnly: true
-{% if extra_settings_files.configmaps is defined and extra_settings_files.configmaps | length %}
-{% for configmap in extra_settings_files.configmaps %}
-            - name: {{ ansible_operator_meta.name }}-{{ configmap.key | replace('_', '-') | replace('.', '-') | lower }}-configmap
-              mountPath: "/etc/tower/conf.d/{{ configmap.key }}"
-              subPath: {{ configmap.key }}
-              readOnly: true
-{% endfor %}
-{% endif %}
-{% if extra_settings_files.secrets is defined and extra_settings_files.secrets | length %}
-{% for secret in extra_settings_files.secrets %}
-            - name: {{ ansible_operator_meta.name }}-{{ secret.key | replace('_', '-') | replace('.', '-') | lower }}-secret
-              mountPath: "/etc/tower/conf.d/{{ secret.key }}"
-              subPath: {{ secret.key }}
-              readOnly: true
-{% endfor %}
-{% endif %}
+            {{ lookup("template", "common/volume_mounts/extra_settings_files.yaml.j2")  | indent(width=12) | trim }}
           volumes:
           - name: {{ ansible_operator_meta.name }}-metrics-utility
             persistentVolumeClaim:
@@ -106,24 +91,5 @@ spec:
               items:
                 - key: settings
                   path: settings.py
-{% if extra_settings_files.configmaps is defined and extra_settings_files.configmaps | length %}
-{% for configmap in extra_settings_files.configmaps %}
-          - name: {{ ansible_operator_meta.name }}-{{ configmap.key | replace('_', '-') | replace('.', '-') | lower }}-configmap
-            configMap:
-              name: {{ configmap.name }}
-              items:
-                - key: {{ configmap.key }}
-                  path: {{ configmap.key }}
-{% endfor %}
-{% endif %}
-{% if extra_settings_files.secrets is defined and extra_settings_files.secrets | length %}
-{% for secret in extra_settings_files.secrets %}
-          - name: {{ ansible_operator_meta.name }}-{{ secret.key | replace('_', '-') | replace('.', '-') | lower }}-secret
-            secret:
-              secretName: {{ secret.name }}
-              items:
-                - key: {{ secret.key }}
-                  path: {{ secret.key }}
-{% endfor %}
-{% endif %}
+          {{ lookup("template", "common/volumes/extra_settings_files.yaml.j2")  | indent(width=10) | trim }}
           restartPolicy: OnFailure

--- a/roles/installer/templates/cronjobs/metrics-utility-report.yaml.j2
+++ b/roles/installer/templates/cronjobs/metrics-utility-report.yaml.j2
@@ -64,6 +64,22 @@ spec:
               mountPath: /etc/tower/settings.py
               subPath: settings.py
               readOnly: true
+{% if extra_settings_files.configmaps is defined and extra_settings_files.configmaps | length %}
+{% for configmap in extra_settings_files.configmaps %}
+            - name: {{ ansible_operator_meta.name }}-{{ configmap.key | replace('_', '-') | replace('.', '-') | lower }}-configmap
+              mountPath: "/etc/tower/conf.d/{{ configmap.key }}"
+              subPath: {{ configmap.key }}
+              readOnly: true
+{% endfor %}
+{% endif %}
+{% if extra_settings_files.secrets is defined and extra_settings_files.secrets | length %}
+{% for secret in extra_settings_files.secrets %}
+            - name: {{ ansible_operator_meta.name }}-{{ secret.key | replace('_', '-') | replace('.', '-') | lower }}-secret
+              mountPath: "/etc/tower/conf.d/{{ secret.key }}"
+              subPath: {{ secret.key }}
+              readOnly: true
+{% endfor %}
+{% endif %}
           volumes:
           - name: {{ ansible_operator_meta.name }}-metrics-utility
             persistentVolumeClaim:
@@ -87,4 +103,24 @@ spec:
               items:
                 - key: settings
                   path: settings.py
+{% if extra_settings_files.configmaps is defined and extra_settings_files.configmaps | length %}
+{% for configmap in extra_settings_files.configmaps %}
+          - name: {{ ansible_operator_meta.name }}-{{ configmap.key | replace('_', '-') | replace('.', '-') | lower }}-configmap
+            configMap:
+              name: {{ configmap.name }}
+              items:
+                - key: {{ configmap.key }}
+                  path: {{ configmap.key }}
+{% endfor %}
+{% endif %}
+{% if extra_settings_files.secrets is defined and extra_settings_files.secrets | length %}
+{% for secret in extra_settings_files.secrets %}
+          - name: {{ ansible_operator_meta.name }}-{{ secret.key | replace('_', '-') | replace('.', '-') | lower }}-secret
+            secret:
+              secretName: {{ secret.name }}
+              items:
+                - key: {{ secret.key }}
+                  path: {{ secret.key }}
+{% endfor %}
+{% endif %}
           restartPolicy: OnFailure

--- a/roles/installer/templates/cronjobs/metrics-utility-report.yaml.j2
+++ b/roles/installer/templates/cronjobs/metrics-utility-report.yaml.j2
@@ -64,22 +64,7 @@ spec:
               mountPath: /etc/tower/settings.py
               subPath: settings.py
               readOnly: true
-{% if extra_settings_files.configmaps is defined and extra_settings_files.configmaps | length %}
-{% for configmap in extra_settings_files.configmaps %}
-            - name: {{ ansible_operator_meta.name }}-{{ configmap.key | replace('_', '-') | replace('.', '-') | lower }}-configmap
-              mountPath: "/etc/tower/conf.d/{{ configmap.key }}"
-              subPath: {{ configmap.key }}
-              readOnly: true
-{% endfor %}
-{% endif %}
-{% if extra_settings_files.secrets is defined and extra_settings_files.secrets | length %}
-{% for secret in extra_settings_files.secrets %}
-            - name: {{ ansible_operator_meta.name }}-{{ secret.key | replace('_', '-') | replace('.', '-') | lower }}-secret
-              mountPath: "/etc/tower/conf.d/{{ secret.key }}"
-              subPath: {{ secret.key }}
-              readOnly: true
-{% endfor %}
-{% endif %}
+            {{ lookup("template", "common/volume_mounts/extra_settings_files.yaml.j2")  | indent(width=12) | trim }}
           volumes:
           - name: {{ ansible_operator_meta.name }}-metrics-utility
             persistentVolumeClaim:
@@ -103,24 +88,5 @@ spec:
               items:
                 - key: settings
                   path: settings.py
-{% if extra_settings_files.configmaps is defined and extra_settings_files.configmaps | length %}
-{% for configmap in extra_settings_files.configmaps %}
-          - name: {{ ansible_operator_meta.name }}-{{ configmap.key | replace('_', '-') | replace('.', '-') | lower }}-configmap
-            configMap:
-              name: {{ configmap.name }}
-              items:
-                - key: {{ configmap.key }}
-                  path: {{ configmap.key }}
-{% endfor %}
-{% endif %}
-{% if extra_settings_files.secrets is defined and extra_settings_files.secrets | length %}
-{% for secret in extra_settings_files.secrets %}
-          - name: {{ ansible_operator_meta.name }}-{{ secret.key | replace('_', '-') | replace('.', '-') | lower }}-secret
-            secret:
-              secretName: {{ secret.name }}
-              items:
-                - key: {{ secret.key }}
-                  path: {{ secret.key }}
-{% endfor %}
-{% endif %}
+          {{ lookup("template", "common/volumes/extra_settings_files.yaml.j2")  | indent(width=10) | trim }}
           restartPolicy: OnFailure

--- a/roles/installer/templates/deployments/task.yaml.j2
+++ b/roles/installer/templates/deployments/task.yaml.j2
@@ -95,22 +95,7 @@ spec:
               mountPath: "/etc/tower/settings.py"
               subPath: settings.py
               readOnly: true
-{% if extra_settings_files.configmaps is defined and extra_settings_files.configmaps | length %}
-{% for configmap in extra_settings_files.configmaps %}
-            - name: {{ ansible_operator_meta.name }}-{{ configmap.key | replace('_', '-') | replace('.', '-') | lower }}-configmap
-              mountPath: "/etc/tower/conf.d/{{ configmap.key }}"
-              subPath: {{ configmap.key }}
-              readOnly: true
-{% endfor %}
-{% endif %}
-{% if extra_settings_files.secrets is defined and extra_settings_files.secrets | length %}
-{% for secret in extra_settings_files.secrets %}
-            - name: {{ ansible_operator_meta.name }}-{{ secret.key | replace('_', '-') | replace('.', '-') | lower }}-secret
-              mountPath: "/etc/tower/conf.d/{{ secret.key }}"
-              subPath: {{ secret.key }}
-              readOnly: true
-{% endfor %}
-{% endif %}
+            {{ lookup("template", "common/volume_mounts/extra_settings_files.yaml.j2")  | indent(width=12) | trim }}
 {% if development_mode | bool %}
             - name: awx-devel
               mountPath: "/awx_devel"
@@ -295,22 +280,7 @@ spec:
               mountPath: /etc/tower/settings.py
               subPath: settings.py
               readOnly: true
-{% if extra_settings_files.configmaps is defined and extra_settings_files.configmaps | length %}
-{% for configmap in extra_settings_files.configmaps %}
-            - name: {{ ansible_operator_meta.name }}-{{ configmap.key | replace('_', '-') | replace('.', '-') | lower }}-configmap
-              mountPath: "/etc/tower/conf.d/{{ configmap.key }}"
-              subPath: {{ configmap.key }}
-              readOnly: true
-{% endfor %}
-{% endif %}
-{% if extra_settings_files.secrets is defined and extra_settings_files.secrets | length %}
-{% for secret in extra_settings_files.secrets %}
-            - name: {{ ansible_operator_meta.name }}-{{ secret.key | replace('_', '-') | replace('.', '-') | lower }}-secret
-              mountPath: "/etc/tower/conf.d/{{ secret.key }}"
-              subPath: {{ secret.key }}
-              readOnly: true
-{% endfor %}
-{% endif %}
+            {{ lookup("template", "common/volume_mounts/extra_settings_files.yaml.j2")  | indent(width=12) | trim }}
             - name: {{ ansible_operator_meta.name }}-redis-socket
               mountPath: "/var/run/redis"
             - name: rsyslog-socket
@@ -460,22 +430,7 @@ spec:
               mountPath: "/etc/tower/settings.py"
               subPath: settings.py
               readOnly: true
-{% if extra_settings_files.configmaps is defined and extra_settings_files.configmaps | length %}
-{% for configmap in extra_settings_files.configmaps %}
-            - name: {{ ansible_operator_meta.name }}-{{ configmap.key | replace('_', '-') | replace('.', '-') | lower }}-configmap
-              mountPath: "/etc/tower/conf.d/{{ configmap.key }}"
-              subPath: {{ configmap.key }}
-              readOnly: true
-{% endfor %}
-{% endif %}
-{% if extra_settings_files.secrets is defined and extra_settings_files.secrets | length %}
-{% for secret in extra_settings_files.secrets %}
-            - name: {{ ansible_operator_meta.name }}-{{ secret.key | replace('_', '-') | replace('.', '-') | lower }}-secret
-              mountPath: "/etc/tower/conf.d/{{ secret.key }}"
-              subPath: {{ secret.key }}
-              readOnly: true
-{% endfor %}
-{% endif %}
+            {{ lookup("template", "common/volume_mounts/extra_settings_files.yaml.j2")  | indent(width=12) | trim }}
             - name: {{ ansible_operator_meta.name }}-redis-socket
               mountPath: "/var/run/redis"
             - name: rsyslog-socket
@@ -636,26 +591,7 @@ spec:
             items:
               - key: redis_conf
                 path: redis.conf
-{% if extra_settings_files.configmaps is defined and extra_settings_files.configmaps | length %}
-{% for configmap in extra_settings_files.configmaps %}
-        - name: {{ ansible_operator_meta.name }}-{{ configmap.key | replace('_', '-') | replace('.', '-') | lower }}-configmap
-          configMap:
-            name: {{ configmap.name }}
-            items:
-              - key: {{ configmap.key }}
-                path: {{ configmap.key }}
-{% endfor %}
-{% endif %}
-{% if extra_settings_files.secrets is defined and extra_settings_files.secrets | length %}
-{% for secret in extra_settings_files.secrets %}
-        - name: {{ ansible_operator_meta.name }}-{{ secret.key | replace('_', '-') | replace('.', '-') | lower }}-secret
-          secret:
-            secretName: {{ secret.name }}
-            items:
-              - key: {{ secret.key }}
-                path: {{ secret.key }}
-{% endfor %}
-{% endif %}
+        {{ lookup("template", "common/volumes/extra_settings_files.yaml.j2")  | indent(width=8) | trim }}
         - name: {{ ansible_operator_meta.name }}-redis-socket
           emptyDir: {}
         - name: {{ ansible_operator_meta.name }}-redis-data

--- a/roles/installer/templates/deployments/task.yaml.j2
+++ b/roles/installer/templates/deployments/task.yaml.j2
@@ -95,6 +95,22 @@ spec:
               mountPath: "/etc/tower/settings.py"
               subPath: settings.py
               readOnly: true
+{% if extra_settings_files.configmaps is defined and extra_settings_files.configmaps | length %}
+{% for configmap in extra_settings_files.configmaps %}
+            - name: {{ ansible_operator_meta.name }}-{{ configmap.key | replace('_', '-') | replace('.', '-') | lower }}-configmap
+              mountPath: "/etc/tower/conf.d/{{ configmap.key }}"
+              subPath: {{ configmap.key }}
+              readOnly: true
+{% endfor %}
+{% endif %}
+{% if extra_settings_files.secrets is defined and extra_settings_files.secrets | length %}
+{% for secret in extra_settings_files.secrets %}
+            - name: {{ ansible_operator_meta.name }}-{{ secret.key | replace('_', '-') | replace('.', '-') | lower }}-secret
+              mountPath: "/etc/tower/conf.d/{{ secret.key }}"
+              subPath: {{ secret.key }}
+              readOnly: true
+{% endfor %}
+{% endif %}
 {% if development_mode | bool %}
             - name: awx-devel
               mountPath: "/awx_devel"
@@ -279,6 +295,22 @@ spec:
               mountPath: /etc/tower/settings.py
               subPath: settings.py
               readOnly: true
+{% if extra_settings_files.configmaps is defined and extra_settings_files.configmaps | length %}
+{% for configmap in extra_settings_files.configmaps %}
+            - name: {{ ansible_operator_meta.name }}-{{ configmap.key | replace('_', '-') | replace('.', '-') | lower }}-configmap
+              mountPath: "/etc/tower/conf.d/{{ configmap.key }}"
+              subPath: {{ configmap.key }}
+              readOnly: true
+{% endfor %}
+{% endif %}
+{% if extra_settings_files.secrets is defined and extra_settings_files.secrets | length %}
+{% for secret in extra_settings_files.secrets %}
+            - name: {{ ansible_operator_meta.name }}-{{ secret.key | replace('_', '-') | replace('.', '-') | lower }}-secret
+              mountPath: "/etc/tower/conf.d/{{ secret.key }}"
+              subPath: {{ secret.key }}
+              readOnly: true
+{% endfor %}
+{% endif %}
             - name: {{ ansible_operator_meta.name }}-redis-socket
               mountPath: "/var/run/redis"
             - name: rsyslog-socket
@@ -428,6 +460,22 @@ spec:
               mountPath: "/etc/tower/settings.py"
               subPath: settings.py
               readOnly: true
+{% if extra_settings_files.configmaps is defined and extra_settings_files.configmaps | length %}
+{% for configmap in extra_settings_files.configmaps %}
+            - name: {{ ansible_operator_meta.name }}-{{ configmap.key | replace('_', '-') | replace('.', '-') | lower }}-configmap
+              mountPath: "/etc/tower/conf.d/{{ configmap.key }}"
+              subPath: {{ configmap.key }}
+              readOnly: true
+{% endfor %}
+{% endif %}
+{% if extra_settings_files.secrets is defined and extra_settings_files.secrets | length %}
+{% for secret in extra_settings_files.secrets %}
+            - name: {{ ansible_operator_meta.name }}-{{ secret.key | replace('_', '-') | replace('.', '-') | lower }}-secret
+              mountPath: "/etc/tower/conf.d/{{ secret.key }}"
+              subPath: {{ secret.key }}
+              readOnly: true
+{% endfor %}
+{% endif %}
             - name: {{ ansible_operator_meta.name }}-redis-socket
               mountPath: "/var/run/redis"
             - name: rsyslog-socket
@@ -588,6 +636,26 @@ spec:
             items:
               - key: redis_conf
                 path: redis.conf
+{% if extra_settings_files.configmaps is defined and extra_settings_files.configmaps | length %}
+{% for configmap in extra_settings_files.configmaps %}
+        - name: {{ ansible_operator_meta.name }}-{{ configmap.key | replace('_', '-') | replace('.', '-') | lower }}-configmap
+          configMap:
+            name: {{ configmap.name }}
+            items:
+              - key: {{ configmap.key }}
+                path: {{ configmap.key }}
+{% endfor %}
+{% endif %}
+{% if extra_settings_files.secrets is defined and extra_settings_files.secrets | length %}
+{% for secret in extra_settings_files.secrets %}
+        - name: {{ ansible_operator_meta.name }}-{{ secret.key | replace('_', '-') | replace('.', '-') | lower }}-secret
+          secret:
+            secretName: {{ secret.name }}
+            items:
+              - key: {{ secret.key }}
+                path: {{ secret.key }}
+{% endfor %}
+{% endif %}
         - name: {{ ansible_operator_meta.name }}-redis-socket
           emptyDir: {}
         - name: {{ ansible_operator_meta.name }}-redis-data

--- a/roles/installer/templates/deployments/web.yaml.j2
+++ b/roles/installer/templates/deployments/web.yaml.j2
@@ -231,6 +231,22 @@ spec:
               mountPath: /etc/tower/settings.py
               subPath: settings.py
               readOnly: true
+{% if extra_settings_files.configmaps is defined and extra_settings_files.configmaps | length %}
+{% for configmap in extra_settings_files.configmaps %}
+            - name: {{ ansible_operator_meta.name }}-{{ configmap.key | replace('_', '-') | replace('.', '-') | lower }}-configmap
+              mountPath: "/etc/tower/conf.d/{{ configmap.key }}"
+              subPath: {{ configmap.key }}
+              readOnly: true
+{% endfor %}
+{% endif %}
+{% if extra_settings_files.secrets is defined and extra_settings_files.secrets | length %}
+{% for secret in extra_settings_files.secrets %}
+            - name: {{ ansible_operator_meta.name }}-{{ secret.key | replace('_', '-') | replace('.', '-') | lower }}-secret
+              mountPath: "/etc/tower/conf.d/{{ secret.key }}"
+              subPath: {{ secret.key }}
+              readOnly: true
+{% endfor %}
+{% endif %}
             - name: {{ ansible_operator_meta.name }}-nginx-conf
               mountPath: /etc/nginx/nginx.conf
               subPath: nginx.conf
@@ -307,6 +323,22 @@ spec:
               mountPath: "/etc/tower/settings.py"
               subPath: settings.py
               readOnly: true
+{% if extra_settings_files.configmaps is defined and extra_settings_files.configmaps | length %}
+{% for configmap in extra_settings_files.configmaps %}
+            - name: {{ ansible_operator_meta.name }}-{{ configmap.key | replace('_', '-') | replace('.', '-') | lower }}-configmap
+              mountPath: "/etc/tower/conf.d/{{ configmap.key }}"
+              subPath: {{ configmap.key }}
+              readOnly: true
+{% endfor %}
+{% endif %}
+{% if extra_settings_files.secrets is defined and extra_settings_files.secrets | length %}
+{% for secret in extra_settings_files.secrets %}
+            - name: {{ ansible_operator_meta.name }}-{{ secret.key | replace('_', '-') | replace('.', '-') | lower }}-secret
+              mountPath: "/etc/tower/conf.d/{{ secret.key }}"
+              subPath: {{ secret.key }}
+              readOnly: true
+{% endfor %}
+{% endif %}
             - name: {{ ansible_operator_meta.name }}-redis-socket
               mountPath: "/var/run/redis"
             - name: rsyslog-socket
@@ -438,6 +470,26 @@ spec:
             items:
               - key: redis_conf
                 path: redis.conf
+{% if extra_settings_files.configmaps is defined and extra_settings_files.configmaps | length %}
+{% for configmap in extra_settings_files.configmaps %}
+        - name: {{ ansible_operator_meta.name }}-{{ configmap.key | replace('_', '-') | replace('.', '-') | lower }}-configmap
+          configMap:
+            name: {{ configmap.name }}
+            items:
+              - key: {{ configmap.key }}
+                path: {{ configmap.key }}
+{% endfor %}
+{% endif %}
+{% if extra_settings_files.secrets is defined and extra_settings_files.secrets | length %}
+{% for secret in extra_settings_files.secrets %}
+        - name: {{ ansible_operator_meta.name }}-{{ secret.key | replace('_', '-') | replace('.', '-') | lower }}-secret
+          secret:
+            secretName: {{ secret.name }}
+            items:
+              - key: {{ secret.key }}
+                path: {{ secret.key }}
+{% endfor %}
+{% endif %}
         - name: {{ ansible_operator_meta.name }}-uwsgi-config
           configMap:
             name: {{ ansible_operator_meta.name }}-{{ deployment_type }}-configmap

--- a/roles/installer/templates/deployments/web.yaml.j2
+++ b/roles/installer/templates/deployments/web.yaml.j2
@@ -231,22 +231,7 @@ spec:
               mountPath: /etc/tower/settings.py
               subPath: settings.py
               readOnly: true
-{% if extra_settings_files.configmaps is defined and extra_settings_files.configmaps | length %}
-{% for configmap in extra_settings_files.configmaps %}
-            - name: {{ ansible_operator_meta.name }}-{{ configmap.key | replace('_', '-') | replace('.', '-') | lower }}-configmap
-              mountPath: "/etc/tower/conf.d/{{ configmap.key }}"
-              subPath: {{ configmap.key }}
-              readOnly: true
-{% endfor %}
-{% endif %}
-{% if extra_settings_files.secrets is defined and extra_settings_files.secrets | length %}
-{% for secret in extra_settings_files.secrets %}
-            - name: {{ ansible_operator_meta.name }}-{{ secret.key | replace('_', '-') | replace('.', '-') | lower }}-secret
-              mountPath: "/etc/tower/conf.d/{{ secret.key }}"
-              subPath: {{ secret.key }}
-              readOnly: true
-{% endfor %}
-{% endif %}
+            {{ lookup("template", "common/volume_mounts/extra_settings_files.yaml.j2")  | indent(width=12) | trim }}
             - name: {{ ansible_operator_meta.name }}-nginx-conf
               mountPath: /etc/nginx/nginx.conf
               subPath: nginx.conf
@@ -323,22 +308,7 @@ spec:
               mountPath: "/etc/tower/settings.py"
               subPath: settings.py
               readOnly: true
-{% if extra_settings_files.configmaps is defined and extra_settings_files.configmaps | length %}
-{% for configmap in extra_settings_files.configmaps %}
-            - name: {{ ansible_operator_meta.name }}-{{ configmap.key | replace('_', '-') | replace('.', '-') | lower }}-configmap
-              mountPath: "/etc/tower/conf.d/{{ configmap.key }}"
-              subPath: {{ configmap.key }}
-              readOnly: true
-{% endfor %}
-{% endif %}
-{% if extra_settings_files.secrets is defined and extra_settings_files.secrets | length %}
-{% for secret in extra_settings_files.secrets %}
-            - name: {{ ansible_operator_meta.name }}-{{ secret.key | replace('_', '-') | replace('.', '-') | lower }}-secret
-              mountPath: "/etc/tower/conf.d/{{ secret.key }}"
-              subPath: {{ secret.key }}
-              readOnly: true
-{% endfor %}
-{% endif %}
+            {{ lookup("template", "common/volume_mounts/extra_settings_files.yaml.j2")  | indent(width=12) | trim }}
             - name: {{ ansible_operator_meta.name }}-redis-socket
               mountPath: "/var/run/redis"
             - name: rsyslog-socket
@@ -470,26 +440,7 @@ spec:
             items:
               - key: redis_conf
                 path: redis.conf
-{% if extra_settings_files.configmaps is defined and extra_settings_files.configmaps | length %}
-{% for configmap in extra_settings_files.configmaps %}
-        - name: {{ ansible_operator_meta.name }}-{{ configmap.key | replace('_', '-') | replace('.', '-') | lower }}-configmap
-          configMap:
-            name: {{ configmap.name }}
-            items:
-              - key: {{ configmap.key }}
-                path: {{ configmap.key }}
-{% endfor %}
-{% endif %}
-{% if extra_settings_files.secrets is defined and extra_settings_files.secrets | length %}
-{% for secret in extra_settings_files.secrets %}
-        - name: {{ ansible_operator_meta.name }}-{{ secret.key | replace('_', '-') | replace('.', '-') | lower }}-secret
-          secret:
-            secretName: {{ secret.name }}
-            items:
-              - key: {{ secret.key }}
-                path: {{ secret.key }}
-{% endfor %}
-{% endif %}
+        {{ lookup("template", "common/volumes/extra_settings_files.yaml.j2")  | indent(width=8) | trim }}
         - name: {{ ansible_operator_meta.name }}-uwsgi-config
           configMap:
             name: {{ ansible_operator_meta.name }}-{{ deployment_type }}-configmap

--- a/roles/installer/templates/jobs/migration.yaml.j2
+++ b/roles/installer/templates/jobs/migration.yaml.j2
@@ -29,22 +29,7 @@ spec:
               mountPath: "/etc/tower/settings.py"
               subPath: settings.py
               readOnly: true
-{% if extra_settings_files.configmaps is defined and extra_settings_files.configmaps | length %}
-{% for configmap in extra_settings_files.configmaps %}
-            - name: {{ ansible_operator_meta.name }}-{{ configmap.key | replace('_', '-') | replace('.', '-') | lower }}-configmap
-              mountPath: "/etc/tower/conf.d/{{ configmap.key }}"
-              subPath: {{ configmap.key }}
-              readOnly: true
-{% endfor %}
-{% endif %}
-{% if extra_settings_files.secrets is defined and extra_settings_files.secrets | length %}
-{% for secret in extra_settings_files.secrets %}
-            - name: {{ ansible_operator_meta.name }}-{{ secret.key | replace('_', '-') | replace('.', '-') | lower }}-secret
-              mountPath: "/etc/tower/conf.d/{{ secret.key }}"
-              subPath: {{ secret.key }}
-              readOnly: true
-{% endfor %}
-{% endif %}
+            {{ lookup("template", "common/volume_mounts/extra_settings_files.yaml.j2")  | indent(width=12) | trim }}
 {% if development_mode | bool %}
             - name: awx-devel
               mountPath: "/awx_devel"
@@ -110,26 +95,7 @@ spec:
             items:
               - key: settings
                 path: settings.py
-{% if extra_settings_files.configmaps is defined and extra_settings_files.configmaps | length %}
-{% for configmap in extra_settings_files.configmaps %}
-        - name: {{ ansible_operator_meta.name }}-{{ configmap.key | replace('_', '-') | replace('.', '-') | lower }}-configmap
-          configMap:
-            name: {{ configmap.name }}
-            items:
-              - key: {{ configmap.key }}
-                path: {{ configmap.key }}
-{% endfor %}
-{% endif %}
-{% if extra_settings_files.secrets is defined and extra_settings_files.secrets | length %}
-{% for secret in extra_settings_files.secrets %}
-        - name: {{ ansible_operator_meta.name }}-{{ secret.key | replace('_', '-') | replace('.', '-') | lower }}-secret
-          secret:
-            secretName: {{ secret.name }}
-            items:
-              - key: {{ secret.key }}
-                path: {{ secret.key }}
-{% endfor %}
-{% endif %}
+        {{ lookup("template", "common/volumes/extra_settings_files.yaml.j2")  | indent(width=8) | trim }}
 {% if development_mode | bool %}
         - name: awx-devel
           hostPath:

--- a/roles/installer/templates/jobs/migration.yaml.j2
+++ b/roles/installer/templates/jobs/migration.yaml.j2
@@ -29,6 +29,22 @@ spec:
               mountPath: "/etc/tower/settings.py"
               subPath: settings.py
               readOnly: true
+{% if extra_settings_files.configmaps is defined and extra_settings_files.configmaps | length %}
+{% for configmap in extra_settings_files.configmaps %}
+            - name: {{ ansible_operator_meta.name }}-{{ configmap.key | replace('_', '-') | replace('.', '-') | lower }}-configmap
+              mountPath: "/etc/tower/conf.d/{{ configmap.key }}"
+              subPath: {{ configmap.key }}
+              readOnly: true
+{% endfor %}
+{% endif %}
+{% if extra_settings_files.secrets is defined and extra_settings_files.secrets | length %}
+{% for secret in extra_settings_files.secrets %}
+            - name: {{ ansible_operator_meta.name }}-{{ secret.key | replace('_', '-') | replace('.', '-') | lower }}-secret
+              mountPath: "/etc/tower/conf.d/{{ secret.key }}"
+              subPath: {{ secret.key }}
+              readOnly: true
+{% endfor %}
+{% endif %}
 {% if development_mode | bool %}
             - name: awx-devel
               mountPath: "/awx_devel"
@@ -94,6 +110,26 @@ spec:
             items:
               - key: settings
                 path: settings.py
+{% if extra_settings_files.configmaps is defined and extra_settings_files.configmaps | length %}
+{% for configmap in extra_settings_files.configmaps %}
+        - name: {{ ansible_operator_meta.name }}-{{ configmap.key | replace('_', '-') | replace('.', '-') | lower }}-configmap
+          configMap:
+            name: {{ configmap.name }}
+            items:
+              - key: {{ configmap.key }}
+                path: {{ configmap.key }}
+{% endfor %}
+{% endif %}
+{% if extra_settings_files.secrets is defined and extra_settings_files.secrets | length %}
+{% for secret in extra_settings_files.secrets %}
+        - name: {{ ansible_operator_meta.name }}-{{ secret.key | replace('_', '-') | replace('.', '-') | lower }}-secret
+          secret:
+            secretName: {{ secret.name }}
+            items:
+              - key: {{ secret.key }}
+                path: {{ secret.key }}
+{% endfor %}
+{% endif %}
 {% if development_mode | bool %}
         - name: awx-devel
           hostPath:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

Closes #1834 

This PR add a new paramerter `extra_settings_files`  for AWX CR that allows users to add extra settings through python (`*.py`) files from ConfigMaps or Secrets.

This is helpful when users are in following situations that are difficult to solve by existing `extra_settings`:

- The `extra_settings` is very long and hard to manage
- Want to pass dictionaries or lists which written in readable multiline codes
- Doesn't want to consider quoted-quotes in `extra_settings`
- Want to manage `extra_settings` as sepalated multiple files
- Want to pass values from Secrets

**Design:**

- Users can add extra settings by mounting `*.py` files from ConfigMaps or Secrets
- This feature mounts specified `*.py` files under `/etc/tower/conf.d` in following pods/jobs/cronjobs which already have `settngs.py`
  - The task and web pods
  - The migration job
  - The metrics-utility-gather cronjobs and metrics-utility-report cronjobs
- Users can specify multiple ConfigMaps and Secrets
- Users can include multiple files in a single ConfigMap or Secret

**Restrictions:**

- The keys in ConfigMaps or Secrets MUST be the name of python files and MUST end with `,py`
- The keys in ConfigMaps or Secrets MUST consists of alphanumeric characters, `-`, `_` or `.`
  - https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/config-map-v1/
  - https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/secret-v1/
- The keys in ConfigMaps or Secrets are converted to the following strings, which MUST not exceed 63 characters
  - Keys in ConfigMaps: `<instance name>-<KEY>-configmap`
  - Keys in Secrets: `<instance name>-<KEY>-secret`
  - This is used as the name of the volume
    - The name of the volume can contain only lowercase alphanumeric characters or `-`, so any `_` and `.` in keys are replacetd with `-` then the keys are converted to lowercase
    - https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/volume/
    - https://kubernetes.io/docs/concepts/overview/working-with-objects/names/

<!---
If you are fixing an existing issue, please include "fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New or Enhanced Feature

##### ADDITIONAL INFORMATION

**Tested by deploying custom Operator:**

```bash
IMG=registry.example.com/ansible/awx:extra_settings_files \
DEFAULT_AWX_VERSION=24.2.0 \
NAMESPACE=awx \
make docker-build docker-push deploy
```

**Example demo ConfigMaps and Secrets**:

Since this is just for demonstration purposes, included settings and its value have no meaning.

```yaml
---
apiVersion: v1
kind: ConfigMap
metadata:
  namespace: awx
  name: demo-configmap-01
data:
  democonfigmap01_01.py: |
    UI_NEXT = False
    AUTOMATION_ANALYTICS_GATHER_INTERVAL = 1800
  democonfigmap01_02.py: |
    REMOTE_HOST_HEADERS = [
      "HTTP_X_FORWARDED_FOR",
      "REMOTE_ADDR",
      "REMOTE_HOST",
    ]
---
apiVersion: v1
kind: ConfigMap
metadata:
  namespace: awx
  name: demo-configmap-02
data:
  democonfigmap02_01.py: |
    AUTOMATION_ANALYTICS_URL = "https://awesome.demo.example.com"
    GALAXY_TASK_ENV = {
      "ANSIBLE_FORCE_COLOR": "false",
      "GIT_SSH_COMMAND": "ssh -o StrictHostKeyChecking=no",
      "EXTRA_SETTINGS_FROM_CONFIGMAP": "hello awx community",
    }
---
apiVersion: v1
kind: Secret
metadata:
  namespace: awx
  name: demo-secret-01
stringData:
  demosecret01_01.py: |
    TOWER_URL_BASE = "https://extra.settings.from.secret.example.com"
    ACTIVITY_STREAM_ENABLED = False
  demosecret01_02.py: |
    AWX_ISOLATION_SHOW_PATHS = [
      "/etc/pki/ca-trust:/etc/pki/ca-trust:O",
      "/usr/share/pki:/usr/share/pki:O",
      "/tmp/awx/demo:/tmp/awx/demo:0",
    ]
---
apiVersion: v1
kind: Secret
metadata:
  namespace: awx
  name: demo-secret-02
stringData:
  demosecret02_01.py: |
    SUBSCRIPTIONS_PASSWORD = "my-subscription-password123!"
    REDHAT_PASSWORD = "my-redhat-password123!"
```

**Example CR:**

```yaml
---
apiVersion: awx.ansible.com/v1beta1
kind: AWX
metadata:
  namespace: awx
  name: awx
spec:
  service_type: nodeport
  nodeport_port: 30080

  extra_settings_files:
    configmaps:
      - name: demo-configmap-01
        key: democonfigmap01_01.py
      - name: demo-configmap-01
        key: democonfigmap01_02.py
      - name: demo-configmap-02
        key: democonfigmap02_01.py
    secrets:
      - name: demo-secret-01
        key: demosecret01_01.py
      - name: demo-secret-01
        key: demosecret01_02.py
      - name: demo-secret-02
        key: demosecret02_01.py
```

**Results**

```bash
$ kubectl -n awx get deployment/awx-task -o json | jq -r  '.spec.template.spec.volumes[].name' | grep demo
awx-democonfigmap01-01-py-configmap
awx-democonfigmap01-02-py-configmap
awx-democonfigmap02-01-py-configmap
awx-demosecret01-01-py-secret
awx-demosecret01-02-py-secret
awx-demosecret02-01-py-secret

$ kubectl -n awx exec deployment/awx-task -- ls -l /etc/tower/conf.d
total 36
-rw-r--r--. 1 root root 613 Apr 22 06:20 credentials.py
-rw-r--r--. 1 root root  60 Apr 22 06:20 democonfigmap01_01.py
-rw-r--r--. 1 root root  86 Apr 22 06:20 democonfigmap01_02.py
-rw-r--r--. 1 root root 232 Apr 22 06:20 democonfigmap02_01.py
-rw-r--r--. 1 root root  98 Apr 22 06:20 demosecret01_01.py
-rw-r--r--. 1 root root 146 Apr 22 06:20 demosecret01_02.py
-rw-r--r--. 1 root root  99 Apr 22 06:20 demosecret02_01.py
-rw-r--r--. 1 root root 262 Apr 22 06:20 execution_environments.py
-rw-r--r--. 1 root root  91 Apr 22 06:20 ldap.py

$ kubectl -n awx exec deployment/awx-task -- bash -c 'find /etc/tower/conf.d -name 'demo*.py' | xargs grep -H .'
/etc/tower/conf.d/democonfigmap01_02.py:REMOTE_HOST_HEADERS = [
/etc/tower/conf.d/democonfigmap01_02.py:  "HTTP_X_FORWARDED_FOR",
/etc/tower/conf.d/democonfigmap01_02.py:  "REMOTE_ADDR",
/etc/tower/conf.d/democonfigmap01_02.py:  "REMOTE_HOST",
/etc/tower/conf.d/democonfigmap01_02.py:]
/etc/tower/conf.d/democonfigmap02_01.py:AUTOMATION_ANALYTICS_URL = "https://awesome.demo.example.com"
/etc/tower/conf.d/democonfigmap02_01.py:GALAXY_TASK_ENV = {
/etc/tower/conf.d/democonfigmap02_01.py:  "ANSIBLE_FORCE_COLOR": "false",
/etc/tower/conf.d/democonfigmap02_01.py:  "GIT_SSH_COMMAND": "ssh -o StrictHostKeyChecking=no",
/etc/tower/conf.d/democonfigmap02_01.py:  "EXTRA_SETTINGS_FROM_CONFIGMAP": "hello awx community",
/etc/tower/conf.d/democonfigmap02_01.py:}
/etc/tower/conf.d/democonfigmap01_01.py:UI_NEXT = False
/etc/tower/conf.d/democonfigmap01_01.py:AUTOMATION_ANALYTICS_GATHER_INTERVAL = 1800
/etc/tower/conf.d/demosecret02_01.py:SUBSCRIPTIONS_PASSWORD = "my-subscription-password123!"
/etc/tower/conf.d/demosecret02_01.py:REDHAT_PASSWORD = "my-redhat-password123!"
/etc/tower/conf.d/demosecret01_02.py:AWX_ISOLATION_SHOW_PATHS = [
/etc/tower/conf.d/demosecret01_02.py:  "/etc/pki/ca-trust:/etc/pki/ca-trust:O",
/etc/tower/conf.d/demosecret01_02.py:  "/usr/share/pki:/usr/share/pki:O",
/etc/tower/conf.d/demosecret01_02.py:  "/tmp/awx/demo:/tmp/awx/demo:0",
/etc/tower/conf.d/demosecret01_02.py:]
/etc/tower/conf.d/demosecret01_01.py:TOWER_URL_BASE = "https://extra.settings.from.secret.example.com"
/etc/tower/conf.d/demosecret01_01.py:ACTIVITY_STREAM_ENABLED = False
```

We can see from the UI that the settings have been changed. This is an excerpt:

![image](https://github.com/ansible/awx-operator/assets/2920259/17f47ec4-b7bf-4773-b8cf-4ecbfc081bc0)

To ensure there is no side-effect, I have also confirmed the minimal AWX CR _without_ `extra_settings_files` can be deployed:

```yaml
---
apiVersion: awx.ansible.com/v1beta1
kind: AWX
metadata:
  namespace: awx
  name: awx-demo
spec:
  service_type: nodeport
  nodeport_port: 30081
```

##### TODO

- [x] Documentation