### PR TITLE
backup: Remove default parameter from jinja map

### DIFF
--- a/roles/backup/tasks/secrets.yml
+++ b/roles/backup/tasks/secrets.yml
@@ -20,9 +20,7 @@
 
 - name: Dump ingress tls secret names from awx spec and data into file
   include_tasks: dump_ingress_tls_secrets.yml
-  with_items:
-    - "{{ awx_spec.spec['ingress_hosts'] | default('') | map(attribute='tls_secret', default='') | select() | list }}"
-  when: awx_spec.spec['ingress_hosts'] | default('') | map(attribute='tls_secret', default='') | select() | list | length
+  with_items: "{{ awx_spec.spec['ingress_hosts'] | default([]) | selectattr('tls_secret', 'defined') | map(attribute='tls_secret') | list }}"
 
 - name: Dump receptor secret names and data into file
   include_tasks: dump_receptor_secrets.yml


### PR DESCRIPTION
##### SUMMARY
The default paramater from the jinja map filter has been added in the 2.11.0 release.
However, the downstream ansible operator is still using ansible 2.9 with jinja 2.10.x so using the default parameter leads to the following error:

```console
TASK [Dump ingress tls secret names from awx spec and data into file] ********************************
The error was: jinja2.exceptions.FilterArgumentError: Unexpected keyword argument 'default'
fatal: [localhost]: FAILED! => {
  "msg": "Unexpected failure during module execution.",
  "stdout": ""
}
```

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION

Rather than using the default parameter with the map filter then add the selectattr filter to get only the items with tls_secret defined and then get the tls_secret attribute with the map filter.

This also gets rid of the when statement since we always get an empty list when no tls_secret are present in ingress_hosts so the loop statement will be skipped on the empty list.

Finally this changes the default value from the ingress_hosts field because it's a list rather than a string.

https://jinja.palletsprojects.com/en/latest/templates/#jinja-filters.map
