### PR TITLE
Add explicit list filter after rejectattr

### DIFF
--- a/roles/installer/tasks/resources_configuration.yml
+++ b/roles/installer/tasks/resources_configuration.yml
@@ -267,8 +267,8 @@
           - status.phase=Running
       register: _new_pod
       until:
-        - "_new_pod['resources'] | length"
-        - "_new_pod['resources'] | rejectattr('metadata.deletionTimestamp', 'defined') | length"
+        - _new_pod['resources'] | length
+        - _new_pod['resources'] | rejectattr('metadata.deletionTimestamp', 'defined') | list | length
       retries: 60
       delay: 5
 


### PR DESCRIPTION
##### SUMMARY

With ansible 2.9.27 (operator-sdk v1.27.0) then the rejectattr filter returns a generator so we need to cast it to list. The behavior doesn't exist when using a more recent operator-sdk version like v1.34.0 (ansible-core 2.15.8) but using the list filter on that version works too (even if not needed)

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION

`"<generator object select_or_reject at 0x7fbbf0443728>"`

This is a similar issue as 80a9e8c.

```console
TASK [Get the new resource pod information after updating resource.] ********************************
FAILED! => {"msg": "The conditional check '_new_pod['resources'] | rejectattr('metadata.deletionTimestamp', 'defined') | length' failed. The error was: Unexpected templating type error occurred on ({% if _new_pod['resources'] | rejectattr('metadata.deletionTimestamp', 'defined') | length %} True {% else %} False {% endif %}): object of type 'generator' has no len()
```

This also removes the unneeded quotes on the when conditions.