### PR TITLE
Add postgresql option target_session_attrs

### DIFF
--- a/.helm/starter/templates/postgres-config.yaml
+++ b/.helm/starter/templates/postgres-config.yaml
@@ -12,6 +12,7 @@ stringData:
   username: {{ .username }}
   password: {{ .password }}
   sslmode: {{ .sslmode }}
+  target_session_attrs: {{ .target_session_attrs | default "any" }}
   type: {{ .type }}
 type: Opaque
 {{- end }}

--- a/docs/user-guide/database-configuration.md
+++ b/docs/user-guide/database-configuration.md
@@ -27,6 +27,7 @@ stringData:
   username: <username to connect as>
   password: <password to connect with>
   sslmode: prefer
+  target_session_attrs: read-write
   type: unmanaged
 type: Opaque
 ```
@@ -36,6 +37,8 @@ type: Opaque
 > It is possible to set a specific username, password, port, or database, but still have the database managed by the operator. In this case, when creating the postgres-configuration secret, the `type: managed` field should be added.
 
 **Note**: The variable `sslmode` is valid for `external` databases only. The allowed values are: `prefer`, `disable`, `allow`, `require`, `verify-ca`, `verify-full`.
+
+**Note**: The variable `target_session_attrs` is only useful for `clustered external` databases. The allowed values are: `any` (default), `read-write`, `read-only`, `primary`, `standby` and `prefer-standby`, whereby only `read-write` and `primary` really make sense in AWX use, as you want to connect to a database node that offers write support.
 
 Once the secret is created, you can specify it on your spec:
 

--- a/roles/installer/tasks/database_configuration.yml
+++ b/roles/installer/tasks/database_configuration.yml
@@ -100,6 +100,7 @@
     awx_postgres_port: "{{ pg_config['resources'][0]['data']['port'] | b64decode }}"
     awx_postgres_host: "{{ pg_config['resources'][0]['data']['host'] | b64decode }}"
     awx_postgres_sslmode: "{{ pg_config['resources'][0]['data']['sslmode'] |  default('prefer'|b64encode) | b64decode }}"
+    awx_postgres_target_session_attrs: "{{ pg_config['resources'][0]['data']['target_session_attrs'] | default('') | b64decode }}"
   no_log: "{{ no_log }}"
 
 - name: Set database as managed

--- a/roles/installer/templates/settings/credentials.py.j2
+++ b/roles/installer/templates/settings/credentials.py.j2
@@ -11,6 +11,9 @@ DATABASES = {
 {% if awx_postgres_sslmode in ['verify-ca', 'verify-full'] %}
                      'sslrootcert': '{{ ca_trust_bundle }}',
 {% endif %}
+{% if awx_postgres_target_session_attrs %}
+                     'target_session_attrs': '{{ awx_postgres_target_session_attrs }}',
+{% endif %}
         },
     }
 }
@@ -25,6 +28,9 @@ LISTENER_DATABASES = {
             'keepalives_count': {{ postgres_keepalives_count }},
 {% else %}
             'keepalives': 0,
+{% endif %}
+{% if awx_postgres_target_session_attrs %}
+            'target_session_attrs': '{{ awx_postgres_target_session_attrs }}',
 {% endif %}
         },
     }


### PR DESCRIPTION
##### SUMMARY
Added support for the postgresql option 'target_session_attrs'. This is required if you have a postgreSQL database cluster and want to ensure that AWX only connects to the primary database node with write permissions.

This change is all the more necessary as this option cannot be passed in `custom.py` as the order in which the configuration files are loaded is not stable. It is therefor not possible to guarantee, that the `DATABASES` dictionary is already defined or will be overwritten later.

PR fixes #1792 

##### ISSUE TYPE
 - New or Enhanced Feature

##### ADDITIONAL INFORMATION
The following has been added:
* add `target_session_attrs` to the database credentials template in the ansible installer role
* add `target_session_attrs` to the postgresql config template in the helm chart

I've successfully tested that change with `molecule/kind` and in our own K8s Cluster with postgreSQL-Cluster database backend.