### PR TITLE
node assignment configs are attached on all k8s workloads

### DIFF
--- a/roles/backup/templates/management-pod.yml.j2
+++ b/roles/backup/templates/management-pod.yml.j2
@@ -20,9 +20,33 @@ spec:
     resources:
       {{ backup_resource_requirements | to_nice_yaml(indent=2) | indent(width=6, first=False) }}
 {%- endif %}
-{% if db_management_pod_node_selector %}
+{% if task_node_selector %}
   nodeSelector:
-        {{ db_management_pod_node_selector | indent(width=8) }}
+    {{ task_node_selector | indent(width=4) }}
+{% elif node_selector %}
+  nodeSelector:
+    {{ node_selector | indent(width=4) }}
+{% endif %}
+{% if task_topology_spread_constraints %}
+  topologySpreadConstraints:
+    {{ task_topology_spread_constraints | indent(width=4) }}
+{% elif topology_spread_constraints %}
+  topologySpreadConstraints:
+    {{ topology_spread_constraints | indent(width=4) }}
+{% endif %}
+{% if task_tolerations %}
+  tolerations:
+    {{ task_tolerations | indent(width=4) }}
+{% elif tolerations %}
+  tolerations:
+    {{ tolerations | indent(width=4) }}
+{% endif %}
+{% if task_affinity %}
+  affinity:
+    {{ task_affinity | to_nice_yaml | indent(width=4) }}
+{% elif affinity %}
+  affinity:
+    {{ affinity | to_nice_yaml | indent(width=4) }}
 {% endif %}
   volumes:
     - name: {{ ansible_operator_meta.name }}-backup

--- a/roles/installer/templates/cronjobs/metrics-utility-gather.yaml.j2
+++ b/roles/installer/templates/cronjobs/metrics-utility-gather.yaml.j2
@@ -67,6 +67,34 @@ spec:
               mountPath: /etc/tower/settings.py
               subPath: settings.py
               readOnly: true
+{% if task_node_selector %}
+          nodeSelector:
+            {{ task_node_selector | indent(width=12) }}
+{% elif node_selector %}
+          nodeSelector:
+            {{ node_selector | indent(width=12) }}
+{% endif %}
+{% if task_topology_spread_constraints %}
+          topologySpreadConstraints:
+            {{ task_topology_spread_constraints | indent(width=12) }}
+{% elif topology_spread_constraints %}
+          topologySpreadConstraints:
+            {{ topology_spread_constraints | indent(width=12) }}
+{% endif %}
+{% if task_tolerations %}
+          tolerations:
+            {{ task_tolerations | indent(width=12) }}
+{% elif tolerations %}
+          tolerations:
+            {{ tolerations | indent(width=12) }}
+{% endif %}
+{% if task_affinity %}
+          affinity:
+            {{ task_affinity | to_nice_yaml | indent(width=12) }}
+{% elif affinity %}
+          affinity:
+            {{ affinity | to_nice_yaml | indent(width=12) }}
+{% endif %}
           volumes:
           - name: {{ ansible_operator_meta.name }}-metrics-utility
             persistentVolumeClaim:

--- a/roles/installer/templates/cronjobs/metrics-utility-report.yaml.j2
+++ b/roles/installer/templates/cronjobs/metrics-utility-report.yaml.j2
@@ -64,6 +64,34 @@ spec:
               mountPath: /etc/tower/settings.py
               subPath: settings.py
               readOnly: true
+{% if task_node_selector %}
+          nodeSelector:
+            {{ task_node_selector | indent(width=12) }}
+{% elif node_selector %}
+          nodeSelector:
+            {{ node_selector | indent(width=12) }}
+{% endif %}
+{% if task_topology_spread_constraints %}
+          topologySpreadConstraints:
+            {{ task_topology_spread_constraints | indent(width=12) }}
+{% elif topology_spread_constraints %}
+          topologySpreadConstraints:
+            {{ topology_spread_constraints | indent(width=12) }}
+{% endif %}
+{% if task_tolerations %}
+          tolerations:
+            {{ task_tolerations | indent(width=12) }}
+{% elif tolerations %}
+          tolerations:
+            {{ tolerations | indent(width=12) }}
+{% endif %}
+{% if task_affinity %}
+          affinity:
+            {{ task_affinity | to_nice_yaml | indent(width=12) }}
+{% elif affinity %}
+          affinity:
+            {{ affinity | to_nice_yaml | indent(width=12) }}
+{% endif %}
           volumes:
           - name: {{ ansible_operator_meta.name }}-metrics-utility
             persistentVolumeClaim:

--- a/roles/mesh_ingress/templates/deployment.yml.j2
+++ b/roles/mesh_ingress/templates/deployment.yml.j2
@@ -71,6 +71,22 @@ spec:
       restartPolicy: Always
       schedulerName: default-scheduler
       serviceAccount: {{ ansible_operator_meta.name }}
+{% if node_selector %}
+      nodeSelector:
+        {{ node_selector | indent(width=8) }}
+{% endif %}
+{% if topology_spread_constraints %}
+      topologySpreadConstraints:
+        {{ topology_spread_constraints | indent(width=8) }}
+{% endif %}
+{% if tolerations %}
+      tolerations:
+        {{ tolerations | indent(width=8) }}
+{% endif %}
+{% if affinity %}
+      affinity:
+        {{ affinity | to_nice_yaml | indent(width=8) }}
+{% endif %}
       volumes:
       - name: {{ ansible_operator_meta.name }}-receptor-tls
       - name: {{ ansible_operator_meta.name }}-receptor-ca

--- a/roles/restore/templates/management-pod.yml.j2
+++ b/roles/restore/templates/management-pod.yml.j2
@@ -20,9 +20,33 @@ spec:
     resources:
       {{ restore_resource_requirements | to_nice_yaml(indent=2) | indent(width=6, first=False) }}
 {%- endif %}
-{% if db_management_pod_node_selector %}
-      nodeSelector:
-        {{ db_management_pod_node_selector | indent(width=8) }}
+{% if task_node_selector %}
+  nodeSelector:
+    {{ task_node_selector | indent(width=4) }}
+{% elif node_selector %}
+  nodeSelector:
+    {{ node_selector | indent(width=4) }}
+{% endif %}
+{% if task_topology_spread_constraints %}
+  topologySpreadConstraints:
+    {{ task_topology_spread_constraints | indent(width=4) }}
+{% elif topology_spread_constraints %}
+  topologySpreadConstraints:
+    {{ topology_spread_constraints | indent(width=4) }}
+{% endif %}
+{% if task_tolerations %}
+  tolerations:
+    {{ task_tolerations | indent(width=4) }}
+{% elif tolerations %}
+  tolerations:
+    {{ tolerations | indent(width=4) }}
+{% endif %}
+{% if task_affinity %}
+  affinity:
+    {{ task_affinity | to_nice_yaml | indent(width=4) }}
+{% elif affinity %}
+  affinity:
+    {{ affinity | to_nice_yaml | indent(width=4) }}
 {% endif %}
   volumes:
     - name: {{ ansible_operator_meta.name }}-backup


### PR DESCRIPTION
##### SUMMARY
The db migration pod and the backup process pod have failed to schedule on a k8s cluster where every node has a taint. So this PR adds the task_* related node-assignment params and the global node-assignment params as fallback to every k8s workload that didn't have node-assignment configuration available on them.

This fixes issues like #1774

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION
I PR'd a similar fix with https://github.com/ansible/awx-operator/pull/1804, only targeting the migration pod. Realised I need somethign similar on the backup pod.

The task_* params seem well suited for most of the k8s workloads except for the mesh-ingress deployment, so I had that only use the global params
