### PR TITLE
Assign ownership of backup pvc to postgres image's uid

### DIFF
--- a/roles/backup/templates/management-pod.yml.j2
+++ b/roles/backup/templates/management-pod.yml.j2
@@ -7,6 +7,15 @@ metadata:
   labels:
     {{ lookup("template", "../common/templates/labels/common.yaml.j2") | indent(width=4) | trim }}
 spec:
+  initContainers:
+    - name: init-pvc-chown
+      image: busybox
+      # _postgres_image runs as uid 26
+      command: ["sh", "-c", "chown -R :26 /backups && chmod -R 770 /backups"]
+      volumeMounts:
+        - name: {{ ansible_operator_meta.name }}-backup
+          mountPath: /backups
+          readOnly: false
   containers:
   - name: {{ ansible_operator_meta.name }}-db-management
     image: "{{ _postgres_image }}"


### PR DESCRIPTION
##### SUMMARY
Backups are failing because the postgres image runs as uid 26 that doesn't have perms to the backup PVC. This fixes #1830 

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION
The other option is to have the db-management pod run as root (uid 0), but I dont think thats the preferred solution.