### PR TITLE
Create _metrics_utility_secret for metrics utility

### DIFF
--- a/roles/installer/defaults/main.yml
+++ b/roles/installer/defaults/main.yml
@@ -495,6 +495,7 @@ nginx_listen_queue_size: "{{ uwsgi_listen_queue_size }}"
 # metrics-utility (github.com/ansible/metrics-utility)
 _metrics_utility_enabled: "{{ metrics_utility_enabled | default(false) }}"
 _metrics_utility_configmap: "{{ metrics_utility_configmap | default(deployment_type + '-metrics-utility-configmap') }}"
+_metrics_utility_secret: "{{ metrics_utility_secret | default(deployment_type + '-metrics-utility-secret') }}"
 _metrics_utility_console_enabled: "{{ metrics_utility_console_enabled | default(false) }}"
 _metrics_utility_image: "{{ metrics_utility_image | default(_image) }}"
 _metrics_utility_image_version: "{{ metrics_utility_image_version | default(_image_version) }}"


### PR DESCRIPTION
##### SUMMARY
The template for the metrics utility cronjobs references  the variable _metrics_utility_secret.  This variable is missing from the list of variables constructed for the utility.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

