### PR TITLE
Update k8s_exec and k8s_cp to include container name

### DIFF
--- a/roles/backup/tasks/awx-cro.yml
+++ b/roles/backup/tasks/awx-cro.yml
@@ -31,5 +31,6 @@
   k8s_cp:
     namespace: "{{ backup_pvc_namespace }}"
     pod: "{{ ansible_operator_meta.name }}-db-management"
+    container: "{{ ansible_operator_meta.name }}-db-management"
     remote_path: "{{ backup_dir  }}/awx_object"
     content: "{{ awx_spec | to_yaml }}"

--- a/roles/backup/tasks/delete_backup.yml
+++ b/roles/backup/tasks/delete_backup.yml
@@ -3,5 +3,6 @@
   k8s_exec:
     namespace: "{{ backup_pvc_namespace }}"
     pod: "{{ ansible_operator_meta.name }}-db-management"
+    container: "{{ ansible_operator_meta.name }}-db-management"
     command: >-
       bash -c 'rm -rf {{ backup_dir  }}'

--- a/roles/backup/tasks/postgres.yml
+++ b/roles/backup/tasks/postgres.yml
@@ -60,6 +60,7 @@
   k8s_exec:
     namespace: "{{ backup_pvc_namespace }}"
     pod: "{{ ansible_operator_meta.name }}-db-management"
+    container: "{{ ansible_operator_meta.name }}-db-management"
     command: >-
       mkdir -p {{ backup_dir }}
 
@@ -67,6 +68,7 @@
   k8s_exec:
     namespace: "{{ backup_pvc_namespace }}"
     pod: "{{ ansible_operator_meta.name }}-db-management"
+    container: "{{ ansible_operator_meta.name }}-db-management"
     command: >-
       touch {{ backup_dir }}/tower.db
 
@@ -126,6 +128,7 @@
   k8s_exec:
     namespace: "{{ backup_pvc_namespace }}"
     pod: "{{ ansible_operator_meta.name }}-db-management"
+    container: "{{ ansible_operator_meta.name }}-db-management"
     command: |
       bash -c "
       function end_keepalive {

--- a/roles/backup/tasks/secrets.yml
+++ b/roles/backup/tasks/secrets.yml
@@ -50,6 +50,7 @@
   k8s_cp:
     namespace: "{{ backup_pvc_namespace }}"
     pod: "{{ ansible_operator_meta.name }}-db-management"
+    container: "{{ ansible_operator_meta.name }}-db-management"
     remote_path: "{{ backup_dir }}/secrets.yml"
     content: "{{ secrets | to_yaml }}"
   no_log: "{{ no_log }}"

--- a/roles/restore/tasks/import_vars.yml
+++ b/roles/restore/tasks/import_vars.yml
@@ -12,6 +12,7 @@
     k8s_cp:
       namespace: "{{ backup_pvc_namespace }}"
       pod: "{{ ansible_operator_meta.name }}-db-management"
+      container: "{{ ansible_operator_meta.name }}-db-management"
       remote_path: "{{ backup_dir  }}/awx_object"
       local_path: "{{ tmp_spec.path }}"
       state: from_pod

--- a/roles/restore/tasks/init.yml
+++ b/roles/restore/tasks/init.yml
@@ -98,6 +98,7 @@
   k8s_exec:
     namespace: "{{ backup_pvc_namespace }}"
     pod: "{{ ansible_operator_meta.name }}-db-management"
+    container: "{{ ansible_operator_meta.name }}-db-management"
     command: >-
       bash -c "stat {{ backup_dir }}"
   register: stat_backup_dir

--- a/roles/restore/tasks/postgres.yml
+++ b/roles/restore/tasks/postgres.yml
@@ -115,6 +115,7 @@
   k8s_exec:
     namespace: "{{ backup_pvc_namespace }}"
     pod: "{{ ansible_operator_meta.name }}-db-management"
+    container: "{{ ansible_operator_meta.name }}-db-management"
     command: |
       bash -c "
       function end_keepalive {

--- a/roles/restore/tasks/secrets.yml
+++ b/roles/restore/tasks/secrets.yml
@@ -10,6 +10,7 @@
   k8s_cp:
     namespace: "{{ backup_pvc_namespace }}"
     pod: "{{ ansible_operator_meta.name }}-db-management"
+    container: "{{ ansible_operator_meta.name }}-db-management"
     remote_path: "{{ backup_dir  }}/secrets.yml"
     local_path: "{{ tmp_secrets.path }}"
     state: from_pod


### PR DESCRIPTION
##### SUMMARY
We need to specify a container in environments that use sidecar injection, like in the case of istio service mesh. If the container is not specified, and a side car is injected so there are multiple containers running in the pod, this task will fail because a container was not specified in a pod with multiple containers.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change
 Bug preventing backups in environments that use Istio service mesh or other automatic side-car injection

##### ADDITIONAL INFORMATION
Container that we create is the same name as the pod, so we just need to tell the backup to use the container we created, to differentiate it from any sidecars containers that might've been injected

