### PR TITLE
Fix innocuous but confusing typo in db management pod task

### DIFF
--- a/roles/backup/tasks/init.yml
+++ b/roles/backup/tasks/init.yml
@@ -77,10 +77,10 @@
   set_fact:
     _postgres_image: "{{ _custom_postgres_image | default(lookup('env', 'RELATED_IMAGE_AWX_POSTGRES')) | default(_default_postgres_image, true) }}"
 
-- name: Create management pod from templated deployment config
+- name: Create management pod from the template
   k8s:
     name: "{{ ansible_operator_meta.name }}-db-management"
-    kind: Deployment
+    kind: Pod
     state: present
     definition: "{{ lookup('template', 'management-pod.yml.j2') }}"
     wait: true

--- a/roles/restore/tasks/init.yml
+++ b/roles/restore/tasks/init.yml
@@ -86,10 +86,10 @@
   set_fact:
     _postgres_image: "{{ _custom_postgres_image | default(lookup('env', 'RELATED_IMAGE_AWX_POSTGRES'))  | default(_default_postgres_image, true) }}"
 
-- name: Create management pod from templated deployment config
+- name: Create management pod from the template
   k8s:
     name: "{{ ansible_operator_meta.name }}-db-management"
-    kind: Deployment
+    kind: Pod
     state: present
     definition: "{{ lookup('template', 'management-pod.yml.j2') }}"
     wait: true


### PR DESCRIPTION
##### SUMMARY

It is a Pod resource that is created, not a Deployment resource.  The task metadata should reflect that or else it is confusing.  This was still working regardless of this typo. 

##### ISSUE TYPE

 - Bug, Docs Fix or other nominal change

