### PR TITLE
Add support for spec overrides when restoring AWX

### DIFF
--- a/config/crd/bases/awx.ansible.com_awxrestores.yaml
+++ b/config/crd/bases/awx.ansible.com_awxrestores.yaml
@@ -94,6 +94,11 @@ spec:
               postgres_image_version:
                 description: PostgreSQL container image version to use
                 type: string
+              spec_overrides:
+                description: Overrides for the AWX spec
+                # type: string
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
               image_pull_policy:
                 description: The image pull policy
                 type: string

--- a/config/manifests/bases/awx-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/awx-operator.clusterserviceversion.yaml
@@ -218,6 +218,10 @@ spec:
         path: postgres_image_version
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:hidden
+      - displayName: AWX Spec Overrides
+        path: spec_overrides
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
       - displayName: Image Pull Policy
         path: image_pull_policy
         x-descriptors:

--- a/roles/restore/defaults/main.yml
+++ b/roles/restore/defaults/main.yml
@@ -39,4 +39,6 @@ additional_labels: []
 
 # Maintain some of the recommended `app.kubernetes.io/*` labels on the resource (self)
 set_self_labels: true
+
+spec_overrides: {}
 ...

--- a/roles/restore/tasks/deploy_awx.yml
+++ b/roles/restore/tasks/deploy_awx.yml
@@ -1,5 +1,10 @@
 ---
 
+- name: Combine spec_overrides with spec
+  set_fact:
+    spec: "{{ spec | default({}) | combine(spec_overrides) }}"
+  no_log: "{{ no_log }}"
+
 - name: Deploy AWX
   k8s:
     state: "{{ state | default('present') }}"


### PR DESCRIPTION
##### SUMMARY

There are often times where you might want to override specific parameters on the AWX spec when restoring from a backup. One such case is when you want to extend the database PVC size.  

To extend the storage size of your postgres PVC, with this change, you can now:
1. Create an AWXBackup
2. Create an AWXRestore with a spec_overrides entry for `spec_overrides.postgres_storage_requirements.requests: 110Gi` on your AWXRestore object
3. The new deployment will have any spec_overrides preferentially included on the new AWX CR spec.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New or Enhanced Feature
