### PR TITLE
Fix CI failure

### DIFF
--- a/molecule/requirements.yml
+++ b/molecule/requirements.yml
@@ -2,8 +2,6 @@
 collections:
   - name: community.general
   - name: kubernetes.core
-    version: 2.3.2
   - name: operator_sdk.util
   - name: community.docker
-    version: 3.4.5
   - name: awx.awx


### PR DESCRIPTION
##### SUMMARY
Test AWX-operator related failure in AWX CI failure https://github.com/ansible/awx/actions/runs/9163315974/job/25192130715?pr=15191

```
"msg": "Error searching for image testing-operator - Not supported URL scheme http+docker"
```

while building AWX operator image in molecule 

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
