### PR TITLE
Storing each containers log seperately and add init container log gathering

### DIFF
--- a/molecule/default/utils/output_all_container_logs_for_pod.yml
+++ b/molecule/default/utils/output_all_container_logs_for_pod.yml
@@ -1,15 +1,53 @@
 ---
-- name: Get all container log in pod
-  kubernetes.core.k8s_log:
-    namespace: '{{ namespace }}'
-    name: '{{ item.metadata.name }}'
-    all_containers: true
-  register: all_container_logs
+- name: Get all container name from pod
+  set_fact:
+    container_names: "{{ item.spec.containers | map(attribute='name') | list }}"
+  when: item.spec.containers is defined
 
-- name: Store logs in file
-  ansible.builtin.copy:
-    content: "{{ all_container_logs.log_lines | join('\n') }}"
-    dest: '{{ debug_output_dir }}/{{ item.metadata.name }}.log'
+- name: Get log from all container in pod
+  block:
+    - name: Get log from all container in pod
+      kubernetes.core.k8s_log:
+        namespace: '{{ namespace }}'
+        name: '{{ item.metadata.name }}'
+        container: '{{ container }}'
+      register: container_log
+      ignore_errors: true
+
+    - name: Store logs in file
+      ansible.builtin.copy:
+        content: "{{ container_log.log_lines | join('\n') }}"
+        dest: '{{ debug_output_dir }}/{{ item.metadata.name }}-{{ container }}.log'
+      ignore_errors: true
+  loop: "{{ container_names }}"
+  loop_control:
+    loop_var: container
+  when: container_names is defined
+
+- name: Get all init container name from pod if any
+  set_fact:
+    init_container_names: "{{ item.spec.initContainers | map(attribute='name') | list }}"
+  when: item.spec.initContainers is defined
+
+- name: Get log from all init container in pod
+  block:
+    - name: Get log from all init container in pod
+      kubernetes.core.k8s_log:
+        namespace: '{{ namespace }}'
+        name: '{{ item.metadata.name }}'
+        container: '{{ container }}'
+      register: container_log
+      ignore_errors: true
+
+    - name: Store logs in file
+      ansible.builtin.copy:
+        content: "{{ container_log.log_lines | join('\n') }}"
+        dest: '{{ debug_output_dir }}/{{ item.metadata.name }}-{{ container }}.log'
+      ignore_errors: true
+  loop: "{{ init_container_names }}"
+  loop_control:
+    loop_var: container
+  when: init_container_names is defined
 
 # TODO: all_containser option dump all of the output in a single output make it hard to read we probably should iterate through each of the container to get specific logs
 # also we should probably investigate toolings to do OpenShift style sosreport/must-gather for kind cluster or switch to microshift where sosreport is supported


### PR DESCRIPTION
##### SUMMARY
- store container log separately in github action molecule CI
- add init container log gathering in github action molecule CI

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
