### PR TITLE
fix: Make basic install without operator works

### DIFF
--- a/docs/troubleshooting/debugging.md
+++ b/docs/troubleshooting/debugging.md
@@ -96,6 +96,8 @@ Create a vars file:
 ansible_operator_meta:
   name: awx
   namespace: awx
+set_self_labels: false
+update_status: false
 service_type: nodeport
 ```
 The vars file will replace the awx resource so any value that you wish to over ride using the awx resource, put in the vars file. For example, if you wish to use your own image, version and pull policy, you can specify it like below:
@@ -106,6 +108,8 @@ The vars file will replace the awx resource so any value that you wish to over r
 ansible_operator_meta:
   name: awx
   namespace: awx
+set_self_labels: false
+update_status: false
 service_type: nodeport
 image: $DEV_DOCKER_TAG_BASE/awx_kube_devel
 image_pull_policy: Always

--- a/roles/installer/README.md
+++ b/roles/installer/README.md
@@ -26,7 +26,7 @@ Example Playbook
     - hosts: localhost
       connection: local
       roles:
-         - awx
+         - installer
 
 License
 -------

--- a/roles/installer/defaults/main.yml
+++ b/roles/installer/defaults/main.yml
@@ -443,6 +443,9 @@ ldap_password_secret: ''
 # Secret to lookup that provides the custom CA trusted bundle
 bundle_cacert_secret: ''
 
+# Set false for basic install without operator
+update_status: true
+
 # Whether secrets should be garbage collected
 # on teardown
 #

--- a/roles/installer/tasks/database_configuration.yml
+++ b/roles/installer/tasks/database_configuration.yml
@@ -153,6 +153,7 @@
   set_fact:
     _previous_upgraded_pg_version: "{{ this_awx['resources'][0]['status']['upgradedPostgresVersion'] | default(false) }}"
   when:
+    - this_awx['resources'][0] is defined
     - "'upgradedPostgresVersion' in this_awx['resources'][0]['status']"
 
 - name: Check if postgres pod is running an older version

--- a/roles/installer/tasks/install.yml
+++ b/roles/installer/tasks/install.yml
@@ -104,10 +104,11 @@
 
 - name: Enable optional metrics-utility
   include_tasks: enable_metrics_utility.yml
-  when: metrics_utility_enabled | bool
+  when: metrics_utility_enabled | default(false) | bool
 
 - name: Update status variables
   include_tasks: update_status.yml
+  when: update_status | bool
 
 - name: Cleanup & Set garbage collection refs
   include_tasks: cleanup.yml


### PR DESCRIPTION
##### SUMMARY

Following the roles/installer/README.md, AWX installation without operator not working.
Operator using the same role, we should fixed it to make it works without operator.
Most errors are undefined variables, or tasks related to the AWX component updates.

##### ISSUE TYPE

 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION

  - Update role name for README.md
  - Avoid the this_awx['resources'][0] is undefined in database_configuration.yml
  - Add update_status variable to include or not the update_status.yml
  - metrics_utility_enabled exists in CRD but not as variable

With the fix, I can deploy AWX in k8s with ansible-playbook command.