### PR TITLE
Ability to add custom labels to the DB migration pods

### DIFF
--- a/roles/installer/templates/jobs/migration.yaml.j2
+++ b/roles/installer/templates/jobs/migration.yaml.j2
@@ -8,6 +8,10 @@ metadata:
     {{ lookup("template", "../common/templates/labels/version.yaml.j2") | indent(width=4) | trim }}
 spec:
   template:
+    metadata:
+      labels:
+        {{ lookup("template", "../common/templates/labels/common.yaml.j2")  | indent(width=8) | trim }}
+        {{ lookup("template", "../common/templates/labels/version.yaml.j2") | indent(width=8) | trim }}
     spec:
 {% if bundle_ca_crt %}
       initContainers:


### PR DESCRIPTION
##### SUMMARY
This PR allows to add the labels defined in the `additional_labels` parameter to the DB migration pods.

Useful when labels are used to control pod creation based on label rules.

##### ISSUE TYPE
 - New or Enhanced Feature

##### ADDITIONAL INFORMATION
Currently, labels are added at the DB migration job level, but not in the migration pod associated with that job.
The creation of this pod may be blocked if, for example, there is a control system based on labels.

This change simply reproduces what exists in the definition of task and web pods.