### PR TITLE
DRAFT: initial runasuser testing for istio support, fixes #1838

### DIFF
--- a/.helm/starter/README.md
+++ b/.helm/starter/README.md
@@ -345,6 +345,16 @@ Below the addition variables to customize the secret configuration.
 | `customVolumes.projects.accessModes` | Volume access mode | `ReadWriteOnce` |
 | `customVolumes.postgres.storageClassName` | PersistentVolume storage class name | `<resourcename>-projects-volume` |
 
+#### runAsUser for init containers
+Used to override the default init container UID, helpful if you are running istio, etc.
+
+Example:
+
+```yaml
+AWX:
+  initContainerRunAsUser: "1337"
+```
+
 # Contributing
 
 ## Adding abstracted sections

--- a/config/crd/bases/awx.ansible.com_awxs.yaml
+++ b/config/crd/bases/awx.ansible.com_awxs.yaml
@@ -1536,6 +1536,12 @@ spec:
                         type: string
                     type: object
                 type: object
+              init_container_run_as_user:
+                description: Override the runAsUser uid for init containers
+                properties:
+                  runAsUser:
+                    type: string
+                type: object
               init_container_resource_requirements:
                 description: Resource requirements for the init container
                 properties:

--- a/config/manifests/bases/awx-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/awx-operator.clusterserviceversion.yaml
@@ -507,6 +507,11 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
+      - description: Init Container runAsUser override
+        path: init_container_run_as_user
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:string
       - displayName: Replicas
         path: replicas
         x-descriptors:

--- a/roles/installer/defaults/main.yml
+++ b/roles/installer/defaults/main.yml
@@ -351,6 +351,9 @@ init_container_resource_requirements:
     cpu: 100m
     memory: 128Mi
 
+init_container_run_as_user:
+  runAsUser: "1337"
+
 # Add extra environment variables to the AWX task/web containers. Specify as
 # literal block. E.g.:
 # task_extra_env: |

--- a/roles/installer/templates/deployments/task.yaml.j2
+++ b/roles/installer/templates/deployments/task.yaml.j2
@@ -78,6 +78,9 @@ spec:
           image: '{{ _image }}'
           imagePullPolicy: '{{ image_pull_policy }}'
           resources: {{ init_container_resource_requirements }}
+          {% if init_container_run_as_user -%}
+            {{ init_container_run_as_user | indent(width=12, first=True) }}
+          {% endif %}
           command:
             - /bin/sh
             - -c


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

In order for the init-database container to launch successfully on a cluster running istio with sidecar injection, it must be run with the UID 1337. This tells istio to start up the envoy proxy sidecar first before starting up the init-database container, as networking is required for the init-database container to run.

fixes #1838

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug Fix

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
-->

I'm flagging this as DRAFT as this is my first stab at rolling anything in the awx-operator code and I am far more familiar with helm than I am with the intricacies of ansible jinja templates. Reviews and comments greatly appreciated.
