### PR TITLE
Update Dockerfile ansible-operator to v1.34.2, operator-sdk to v1.34.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/operator-framework/ansible-operator:v1.34.0
+FROM quay.io/operator-framework/ansible-operator:v1.34.2
 
 USER root
 RUN dnf update --security --bugfix -y && \

--- a/Makefile
+++ b/Makefile
@@ -177,7 +177,7 @@ ifeq (,$(shell which operator-sdk 2>/dev/null))
 	@{ \
 	set -e ;\
 	mkdir -p $(dir $(OPERATOR_SDK)) ;\
-	curl -sSLo $(OPERATOR_SDK) https://github.com/operator-framework/operator-sdk/releases/download/v1.33.0/operator-sdk_$(OS)_$(ARCHA) ;\
+	curl -sSLo $(OPERATOR_SDK) https://github.com/operator-framework/operator-sdk/releases/download/v1.34.2/operator-sdk_$(OS)_$(ARCHA) ;\
 	chmod +x $(OPERATOR_SDK) ;\
 	}
 else


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Bumps version tag for operator-framework/ansible-operator from `v1.34.0` to `v1.34.2`
Bumps version tag for operator-framework/operator-sdk from `v1.33.0` to `v1.34.2`

<!---
If you are fixing an existing issue, please include "fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
-->

Heads up, looking at the last version bump PR https://github.com/ansible/awx-operator/pull/1714
The SDK was [noted](https://github.com/ansible/awx-operator/pull/1714#issuecomment-1957744406) that it was not showing v1.34.x, which still appears to be the case





