### PR TITLE
Fix: Enable the creation of a helm chart with a name other than awx-operator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -341,7 +341,7 @@ helm-chart-generate: kustomize helm kubectl-slice yq charts
 	rm -rf charts/$(CHART_NAME)
 	# create new chart metadata in Chart.yaml
 	cd charts && \
-		$(HELM) create awx-operator --starter $(shell pwd)/.helm/starter ;\
+		$(HELM) create $(CHART_NAME) --starter $(shell pwd)/.helm/starter ;\
 		$(YQ) -i '.version = "$(VERSION)"' $(CHART_NAME)/Chart.yaml ;\
 		$(YQ) -i '.appVersion = "$(VERSION)" | .appVersion style="double"' $(CHART_NAME)/Chart.yaml ;\
 		$(YQ) -i '.description = "$(CHART_DESCRIPTION)"' $(CHART_NAME)/Chart.yaml ;\
@@ -399,7 +399,7 @@ helm-package: helm-chart
 	@echo "== Package Current Chart Version =="
 	mkdir -p .cr-release-packages
 	# package the chart and put it in .cr-release-packages dir
-	$(HELM) package ./charts/awx-operator -d .cr-release-packages/$(VERSION)
+	$(HELM) package ./charts/$(CHART_NAME) -d .cr-release-packages/$(VERSION)
 
 # List all tags oldest to newest.
 TAGS := $(shell git ls-remote --tags --sort=version:refname --refs -q | cut -d/ -f3)


### PR DESCRIPTION
##### SUMMARY
This PR fixes issues that occur when trying to create a Helm chart package using a `CHART_NAME` that is different from the `awx-operator`. These errors occur because not all helm commands in the Makefile use `CHART_NAME`.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION

Two issues occur when you executes `make helm-package` command with the `CHART_NAME` variable.
Replacing the static `awx-operator` value with the CHART_NAME variable easily solves this problem.

Before: 
```shell
[vagrant@centos8-vagrant awx-operator]$ CHART_NAME=icdc-awx-operator VERSION=2.17.0 make helm-package
== KUSTOMIZE: Set image and chart label ==
cd config/manager && /home/vagrant/awx-operator/bin/kustomize edit set image controller=quay.io/ansible/awx-operator:2.17.0
cd config/manager && /home/vagrant/awx-operator/bin/kustomize edit set label helm.sh/chart:icdc-awx-operator
cd config/default && /home/vagrant/awx-operator/bin/kustomize edit set label helm.sh/chart:icdc-awx-operator
== Gather Helm Chart Metadata ==
# remove the existing chart if it exists
rm -rf charts/icdc-awx-operator
# create new chart metadata in Chart.yaml
cd charts && \
        /usr/local/bin/helm create awx-operator --starter /home/vagrant/awx-operator/.helm/starter ;\
        /home/vagrant/awx-operator/bin/yq -i '.version = "2.17.0"' icdc-awx-operator/Chart.yaml ;\
        /home/vagrant/awx-operator/bin/yq -i '.appVersion = "2.17.0" | .appVersion style="double"' icdc-awx-operator/Chart.yaml ;\
        /home/vagrant/awx-operator/bin/yq -i '.description = "A Helm chart for the AWX Operator"' icdc-awx-operator/Chart.yaml ;\

Creating awx-operator
Error: stat icdc-awx-operator/Chart.yaml: no such file or directory
Error: stat icdc-awx-operator/Chart.yaml: no such file or directory
Error: stat icdc-awx-operator/Chart.yaml: no such file or directory
make: *** [Makefile:342: helm-chart-generate] Error 1
```
After fixing the `$(HELM) create` command under the `helm-chart-generate` target, you can see that the package name does not match the helm chart name (`awx-operator-0.1.0.tgz`):

```shell
[vagrant@centos8-vagrant awx-operator]$ CHART_NAME=icdc-awx-operator VERSION=2.17.0 make helm-package
...
Helm chart successfully configured for icdc-awx-operator version 2.17.0
== Package Current Chart Version ==
mkdir -p .cr-release-packages
# package the chart and put it in .cr-release-packages dir
/usr/local/bin/helm package ./charts/awx-operator -d .cr-release-packages/2.17.0
Successfully packaged chart and saved it to: .cr-release-packages/2.17.0/awx-operator-0.1.0.tgz
```

After fixing the `$(HELM) package` command under the `helm-package` target, the package name will match the helm chart name.

```shell
[vagrant@centos8-vagrant awx-operator]$ CHART_NAME=icdc-awx-operator VERSION=2.17.0 make helm-package
...
Helm chart successfully configured for icdc-awx-operator version 2.17.0
== Package Current Chart Version ==
mkdir -p .cr-release-packages
# package the chart and put it in .cr-release-packages dir
/usr/local/bin/helm package ./charts/icdc-awx-operator -d .cr-release-packages/2.17.0
Successfully packaged chart and saved it to: .cr-release-packages/2.17.0/icdc-awx-operator-2.17.0.tgz
```
