### PR TITLE
Use check_instance_ready for task pod readiness

### DIFF
--- a/roles/installer/templates/deployments/task.yaml.j2
+++ b/roles/installer/templates/deployments/task.yaml.j2
@@ -245,7 +245,7 @@ spec:
             exec:
               command:
                 - /usr/bin/awx-manage
-                - check
+                - check_instance_ready
             initialDelaySeconds: {{ task_readiness_initial_delay }}
             periodSeconds: {{ task_readiness_period }}
             failureThreshold: {{ task_readiness_failure_threshold }}


### PR DESCRIPTION
##### SUMMARY
we been running into flakiness in our CI where the we try to launch the demo job before task instance is truly ready (marked as ready in database)

this new readiness check will check if the instance is marked ready in database

depends on https://github.com/ansible/awx/pull/15238

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
