### PR TITLE
Fix LDAP secret retrieval

### DIFF
--- a/roles/installer/tasks/load_ldap_password_secret.yml
+++ b/roles/installer/tasks/load_ldap_password_secret.yml
@@ -9,6 +9,6 @@
 
 - name: Load LDAP bind password Secret content
   set_fact:
-    ldap_bind_password: '{{ ldap_password["resources"][0]["data"]["ldap-password"] | b64decode }}'
+    ldap_bind_password: '{{ ldap_password["resources"]["data"]["ldap-password"] | b64decode }}'
   no_log: "{{ no_log }}"
-  when: '"ldap-password" in ldap_password["resources"][0]["data"]'
+  when: '"ldap-password" in ldap_password["resources"]["data"]'


### PR DESCRIPTION
Update load_ldap_password_secret.yml to fix LDAP secret retrieval

##### SUMMARY
When deploying a Tower via Operator and configuring LDAP binding on deployment, LDAP secret cannot be retrieved by the playbook despite following the instructions in the documentation

Fixed file `/roles/installer/tasks/load_ldap_password_secret.yml` to allow correct retrieval of LDAP secret by removing `[0]` in lines 12 and 14

##### ISSUE TYPE
Bug fix

##### ADDITIONAL INFORMATION
Reproduction steps:

1. Clone repo and configure a deployment with LDAP binding on deployment
2. Create the ldap secret with the instructions available [here](https://ansible.readthedocs.io/projects/awx-operator/en/latest/user-guide/advanced-configuration/trusting-a-custom-certificate-authority.html) 
3. Confirm password is correctly set in the secret
4. Start deployment and watch logs of `awx-operator-controller-manager`
5. Deployment will fail with the following error
`task path: /opt/ansible/roles/installer/tasks/load_ldap_password_secret.yml:10\nfatal: [localhost]: FAILED! => {\"msg\": \"The conditional check '\\\"ldap-password\\\" in ldap_password[\\\"resources\\\"][0][\\\"data\\\"]' failed. The error was: error while evaluating conditional (\\\"ldap-password\\\" in ldap_password[\\\"resources\\\"][0][\\\"data\\\"]): list object has no element 0. list object has no element 0\\n\\nThe error appears to be in '/opt/ansible/roles/installer/tasks/load_ldap_password_secret.yml': line 10, column 3, but may\\nbe elsewhere in the file depending on the exact syntax problem.\\n\\nThe offending line appears to be:\\n\\n\\n- name: Load LDAP bind password Secret content\\n  ^ here\\n\"} `

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
