### PR TITLE
installer: db-migrate: add support for resource requirements

### DIFF
--- a/config/crd/bases/awx.ansible.com_awxs.yaml
+++ b/config/crd/bases/awx.ansible.com_awxs.yaml
@@ -1462,6 +1462,32 @@ spec:
                         type: string
                     type: object
                 type: object
+              migration_job_resource_requirements:
+                description: Resource requirements for the django migration job container
+                properties:
+                  requests:
+                    properties:
+                      cpu:
+                        type: string
+                      memory:
+                        type: string
+                      storage:
+                        type: string
+                      ephemeral-storage:
+                        type: string
+                    type: object
+                  limits:
+                    properties:
+                      cpu:
+                        type: string
+                      memory:
+                        type: string
+                      storage:
+                        type: string
+                      ephemeral-storage:
+                        type: string
+                    type: object
+                type: object
               postgres_init_container_resource_requirements:
                 description: (Deprecated, use postgres_resource_requirements parameter) Resource requirements for the postgres init container
                 properties:

--- a/config/manifests/bases/awx-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/awx-operator.clusterserviceversion.yaml
@@ -485,6 +485,11 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
+      - displayName: Django Migration Job Container Resource Requirements
+        path: migration_job_resource_requirements
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
       - description: Sets permissions on the /var/lib/pgsql/data for postgres container using an init container (not Openshift)
         displayName: PostgreSQL initialize data volume
         path: postgres_data_volume_init

--- a/config/samples/awx_v1beta1_awx_resource_limits.yaml
+++ b/config/samples/awx_v1beta1_awx_resource_limits.yaml
@@ -25,6 +25,13 @@ spec:
     limits:
       cpu: 1000m
       memory: 4Gi
+  migration_job_resource_requirements:
+    requests:
+      cpu: 250m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
   redis_resource_requirements:
     requests:
       cpu: 50m

--- a/docs/user-guide/advanced-configuration/containers-resource-requirements.md
+++ b/docs/user-guide/advanced-configuration/containers-resource-requirements.md
@@ -26,7 +26,8 @@ The resource requirements for both, the task and the web containers are configur
 | ------------------------------------ | ------------------------------------------------------------ | ------------------------------------ |
 | web_resource_requirements            | Web container resource requirements                          | requests: {cpu: 100m, memory: 128Mi} |
 | task_resource_requirements           | Task container resource requirements                         | requests: {cpu: 100m, memory: 128Mi} |
-| ee_resource_requirements             | EE control plane container resource requirements             | requests: {cpu: 50m, memory: 64Mi} |
+| ee_resource_requirements             | EE control plane container resource requirements             | requests: {cpu: 50m, memory: 64Mi}   |
+| migration_job_resource_requirements  | Django migration job resource requirements                   | requests: {cpu: 250m, memory: 128Mi} |
 | redis_resource_requirements          | Redis container resource requirements                        | requests: {cpu: 100m, memory: 128Mi} |
 | postgres_resource_requirements       | Postgres container (and initContainer) resource requirements | requests: {cpu: 10m, memory: 64Mi}   |
 | rsyslog_resource_requirements        | Rsyslog container resource requirements                      | requests: {cpu: 100m, memory: 128Mi} |
@@ -63,6 +64,13 @@ spec:
     limits:
       cpu: 1000m
       memory: 4Gi
+  migration_job_resource_requirements:
+    requests:
+      cpu: 250m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
   redis_resource_requirements:
     requests:
       cpu: 50m

--- a/roles/installer/defaults/main.yml
+++ b/roles/installer/defaults/main.yml
@@ -327,6 +327,11 @@ ee_resource_requirements:
     cpu: 100m
     memory: 64Mi
 
+migration_job_resource_requirements:
+  requests:
+    cpu: 250m
+    memory: 128Mi
+
 # TODO: validate default resource requirements
 
 # Customize CSRF options

--- a/roles/installer/templates/jobs/migration.yaml.j2
+++ b/roles/installer/templates/jobs/migration.yaml.j2
@@ -40,6 +40,7 @@ spec:
             - awx-manage
             - migrate
             - --noinput
+          resources: {{ migration_job_resource_requirements }}
           volumeMounts:
             - name: {{ ansible_operator_meta.name }}-application-credentials
               mountPath: "/etc/tower/conf.d/credentials.py"


### PR DESCRIPTION
##### SUMMARY

Namespaces with an active ResourceQuota can't spawn a migration job pod, because there's no option available to set a resource request.

##### ISSUE TYPE
 - New or Enhanced Feature

##### ADDITIONAL INFORMATION
