### PR TITLE
Enable readiness probe for task pod in CI

### DIFF
--- a/molecule/default/templates/awx_cr_molecule.yml.j2
+++ b/molecule/default/templates/awx_cr_molecule.yml.j2
@@ -45,6 +45,7 @@ spec:
   extra_settings:
   - setting: LOG_AGGREGATOR_LEVEL
     value: "'DEBUG'"
+  task_readiness_period: 15
 {% if additional_fields is defined %}
   {{ additional_fields | to_nice_yaml | indent(2) }}
 {% endif %}


### PR DESCRIPTION
##### SUMMARY
Avoid race condition where job launch before task container is ready


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
