### PR TITLE
Fix nox test failure

### DIFF
--- a/.github/workflows/reusable-nox.yml
+++ b/.github/workflows/reusable-nox.yml
@@ -18,7 +18,7 @@ jobs:
         - name: Check out repo
           uses: actions/checkout@v4
         - name: Setup nox
-          uses: wntrblm/nox@2024.03.02
+          uses: wntrblm/nox@2024.04.15
           with:
               python-versions: "${{ matrix.python-versions }}"
         - name: "Run nox -s ${{ matrix.session }}"


### PR DESCRIPTION
##### SUMMARY
We are seeing nox test failures across PR's...

```
nox > Running session build
nox > Creating virtual environment (virtualenv) using python in .nox/build
nox > Command /opt/pipx/venvs/nox/bin/python -m virtualenv /home/runner/work/awx-operator/awx-operator/.nox/build failed with exit code 1:
TypeError: object.__init__() takes exactly one argument (the instance to initialize)
Exception ignored in: <function BaseFileLock.__del__ at 0x7f8ac7275f80>
Traceback (most recent call last):
  File "/opt/pipx/venvs/nox/lib/python3.11/site-packages/filelock/_api.py", line 365, in __del__
    self.release(force=True)
  File "/opt/pipx/venvs/nox/lib/python3.11/site-packages/virtualenv/util/lock.py", line 34, in release
    with self.thread_safe:
         ^^^^^^^^^^^^^^^^
AttributeError: '_CountedFileLock' object has no attribute 'thread_safe'
```

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION

