### PR TITLE
Add github-actions package manager

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,13 @@ updates:
     labels:
       - "component:docs"
       - "dependencies"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    groups:
+      dependencies:
+        patterns:
+          - "*"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"


### PR DESCRIPTION


##### SUMMARY
This change adds github-actions package manager to the dependabot config file to bump action versions.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION
N/A. Follows up on https://github.com/ansible/awx-operator/pull/1899
