### PR TITLE
Wait for instance ready in molecule test

### DIFF
--- a/molecule/default/tasks/awx_test.yml
+++ b/molecule/default/tasks/awx_test.yml
@@ -127,6 +127,17 @@
     name: example-awx-admin-password
   register: admin_pw_secret
 
+- name: Wait for instance to be ready
+  uri:
+    url: "http://localhost/awx/api/v2/instances/?node_type=control&node_state=ready"
+    user: admin
+    password: "{{ admin_pw_secret.resources[0].data.password | b64decode }}"
+    force_basic_auth: yes
+  register: instances
+  until: instances['json']['count'] | int > 0
+  retries: 20
+  delay: 2
+
 - name: Validate demo job launch
   block:
     - name: Launch Demo Job Template


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Sometimes a job is launched through the web api before the instance is in a ready state. This throws a 500 internal server error, causing CI to fail.

Adds a task to query the instances endpoint and check that at least one control node is in a ready state.

There might be a better way to handle this, but this will get us past the constant CI failures and is easy to revert.

For example, paired with task_readiness_period, we can use k8s_info module to wait on Ready state of task pod, which might be a more k8s native way to achieve this.
<!---
If you are fixing an existing issue, please include "fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change
