### PR TITLE
web: Add volume to handle debug logs

### DIFF
--- a/roles/installer/templates/deployments/web.yaml.j2
+++ b/roles/installer/templates/deployments/web.yaml.j2
@@ -261,6 +261,8 @@ spec:
               mountPath: "/etc/receptor/work_public_key.pem"
               subPath: "work-public-key.pem"
               readOnly: true
+            - name: {{ ansible_operator_meta.name }}-web-log
+              mountPath: /var/log/tower
 {% if development_mode | bool %}
             - name: awx-devel
               mountPath: "/awx_devel"
@@ -455,6 +457,8 @@ spec:
         - name: rsyslog-socket
           emptyDir: {}
         - name: receptor-socket
+          emptyDir: {}
+        - name: {{ ansible_operator_meta.name }}-web-log
           emptyDir: {}
         - name: {{ ansible_operator_meta.name }}-receptor-config
           configMap:


### PR DESCRIPTION
##### SUMMARY

When enabling debug web requests, the /var/log/tower directory needs to exist.
Rather than just creating that directory in the container image then create an emptyDir volume.


##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION

Closes: #1485
