### PR TITLE
Bump kubernetes core version to avoid failures with clusters with ovirt

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -1,6 +1,6 @@
 ---
 collections:
   - name: kubernetes.core
-    version: '>=2.3.2'
+    version: '>=4.0.0'
   - name: operator_sdk.util
     version: "0.5.0"


### PR DESCRIPTION
##### SUMMARY
Bump kubernetes core version to fix https://issues.redhat.com/browse/AAP-28609
<!---
If you are fixing an existing issue, please include "fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
-->
Resolves https://issues.redhat.com/browse/AAP-28609

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before:
```
 TASK [Write awx object to pvc] ********************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: ValueError: too many values to unpack (expected 2)
fatal: [localhost]: FAILED! => {"changed": false, "module_stderr": "Traceback (most recent call last):\n  File \"/opt/ansible/.ansible/tmp/ansible-tmp-1722473422.4050024-36367-62786152993036/AnsiballZ_k8s_cp.py\", line 102, in <module>\n    _ansiballz_main()\n  File \"/opt/ansible/.ansible/tmp/ansible-tmp-1722473422.4050024-36367-62786152993036/AnsiballZ_k8s_cp.py\", line 94, in _ansiballz_main\n    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)\n  File \"/opt/ansible/.ansible/tmp/ansible-tmp-1722473422.4050024-36367-62786152993036/AnsiballZ_k8s_cp.py\", line 40, in invoke_module\n    runpy.run_module(mod_name='ansible_collections.kubernetes.core.plugins.modules.k8s_cp', init_globals=None, run_name='__main__', alter_sys=True)\n  File \"/usr/lib64/python3.6/runpy.py\", line 205, in run_module\n    return _run_module_code(code, init_globals, run_name, mod_spec)\n  File \"/usr/lib64/python3.6/runpy.py\", line 96, in _run_module_code\n    mod_name, mod_spec, pkg_name, script_name)\n  File \"/usr/lib64/python3.6/runpy.py\", line 85, in _run_code\n    exec(code, run_globals)\n  File \"/tmp/ansible_kubernetes.core.k8s_cp_payload_dzla_9o5/ansible_kubernetes.core.k8s_cp_payload.zip/ansible_collections/kubernetes/core/plugins/modules/k8s_cp.py\", line 221, in <module>\n  File \"/tmp/ansible_kubernetes.core.k8s_cp_payload_dzla_9o5/ansible_kubernetes.core.k8s_cp_payload.zip/ansible_collections/kubernetes/core/plugins/modules/k8s_cp.py\", line 217, in main\n  File \"/tmp/ansible_kubernetes.core.k8s_cp_payload_dzla_9o5/ansible_kubernetes.core.k8s_cp_payload.zip/ansible_collections/kubernetes/core/plugins/modules/k8s_cp.py\", line 190, in execute_module\n  File \"/tmp/ansible_kubernetes.core.k8s_cp_payload_dzla_9o5/ansible_kubernetes.core.k8s_cp_payload.zip/ansible_collections/kubernetes/core/plugins/module_utils/copy.py\", line 380, in check_pod\n  File \"/tmp/ansible_kubernetes.core.k8s_cp_payload_dzla_9o5/ansible_kubernetes.core.k8s_cp_payload.zip/ansible_collections/kubernetes/core/plugins/module_utils/common.py\", line 388, in find_resource\n  File \"/tmp/ansible_kubernetes.core.k8s_cp_payload_dzla_9o5/ansible_kubernetes.core.k8s_cp_payload.zip/ansible_collections/kubernetes/core/plugins/module_utils/common.py\", line 361, in _find_resource_with_prefix\n  File \"/tmp/ansible_kubernetes.core.k8s_cp_payload_dzla_9o5/ansible_kubernetes.core.k8s_cp_payload.zip/ansible_collections/kubernetes/core/plugins/module_utils/client/discovery.py\", line 159, in get\n  File \"/usr/lib/python3.6/site-packages/kubernetes/dynamic/discovery.py\", line 242, in search\n    results = self.__search(self.__build_search(**kwargs), self.__resources, [])\n  File \"/usr/lib/python3.6/site-packages/kubernetes/dynamic/discovery.py\", line 290, in __search\n    matches.extend(self.__search([key] + parts[1:], resources, reqParams))\n  File \"/usr/lib/python3.6/site-packages/kubernetes/dynamic/discovery.py\", line 276, in __search\n    return self.__search(parts[1:], resourcePart, reqParams + [part] )\n  File \"/usr/lib/python3.6/site-packages/kubernetes/dynamic/discovery.py\", line 290, in __search\n    matches.extend(self.__search([key] + parts[1:], resources, reqParams))\n  File \"/usr/lib/python3.6/site-packages/kubernetes/dynamic/discovery.py\", line 276, in __search\n    return self.__search(parts[1:], resourcePart, reqParams + [part] )\n  File \"/usr/lib/python3.6/site-packages/kubernetes/dynamic/discovery.py\", line 290, in __search\n    matches.extend(self.__search([key] + parts[1:], resources, reqParams))\n  File \"/usr/lib/python3.6/site-packages/kubernetes/dynamic/discovery.py\", line 266, in __search\n    prefix, group, part, resourcePart.preferred)\n  File \"/tmp/ansible_kubernetes.core.k8s_cp_payload_dzla_9o5/ansible_kubernetes.core.k8s_cp_payload.zip/ansible_collections/kubernetes/core/plugins/module_utils/client/discovery.py\", line 117, in get_resources_for_api_version\nValueError: too many values to unpack (expected 2)\n", "module_stdout": "", "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", "rc": 1}
```
After:
```
--------------------------- Ansible Task StdOut -------------------------------
TASK [backup : Write awx object to pvc] ****************************************
task path: /opt/ansible/roles/backup/tasks/awx-cro.yml:30
-------------------------------------------------------------------------------
{"level":"info","ts":1722557699.1441417,"logger":"logging_event_handler","msg":"[playbook task start]","name":"test","namespace":"dluong-aap","gvk":"automationcontroller.ansible.com/v1beta1, Kind=AutomationControllerBackup","event_type":"playbook_on_task_start","job":"7595619176979714620","EventData.Name":"backup : Write awx object to pvc"}
{"level":"info","ts":1722557700.7198837,"logger":"proxy","msg":"Read object from cache","resource":{"IsResourceRequest":true,"Path":"/api/v1/namespaces/dluong-aap/pods/test-db-management","Verb":"get","APIPrefix":"api","APIGroup":"","APIVersion":"v1","Namespace":"dluong-aap","Resource":"pods","Subresource":"","Name":"test-db-management","Parts":["pods","test-db-management"]}}
--------------------------- Ansible Task StdOut -------------------------------
```