### PR TITLE
add graceful harakiri

### DIFF
--- a/roles/installer/templates/configmaps/config.yaml.j2
+++ b/roles/installer/templates/configmaps/config.yaml.j2
@@ -225,7 +225,7 @@ data:
             location {{ ingress_path }} {
                 # Add trailing / if missing
                 rewrite ^(.*)$http_host(.*[^/])$ $1$http_host$2/ permanent;
-                uwsgi_read_timeout 120s;
+                uwsgi_read_timeout 125s;
                 uwsgi_pass uwsgi;
                 include /etc/nginx/uwsgi_params;
                 include /etc/nginx/conf.d/*.conf;
@@ -299,6 +299,11 @@ data:
     master-fifo = /var/lib/awx/awxfifo
     max-requests = 1000
     buffer-size = 32768
+
+    harakiri = 120
+    harakiri-graceful-timeout = 115
+    harakiri-graceful-signal = 6
+    py-call-osafterfork = true
     
     if-env = UWSGI_MOUNT_PATH
     mount = %(_)=awx.wsgi:application


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Requests that exceed a certain timeout can be killed by uwsgi
But it begs the question -- what were they doing?!
pairs with https://github.com/ansible/awx/pull/15447/files

By configuring uwsgi harakiri to send a SIGSYS (signal 31) as a first "graceful" signal, we can catch it in middleware and log a message with the stack where code was executing (probably stuck) and more information about the request

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->


Sample traceback:
(this was contrived by putting "time.sleep(300)" in the root view)
```
tools_awx_1       | Fri Aug 16 15:30:15 2024 - *** HARAKIRI ON WORKER 1 (pid: 13747, try: 1, graceful: yes) ***                                                                                                                                                                                                             
tools_awx_1       | Fri Aug 16 15:30:15 2024 - HARAKIRI !!! worker 1 status !!!                                                                               
tools_awx_1       | Fri Aug 16 15:30:15 2024 - HARAKIRI [core 0] 172.23.0.1 - GET /api/ since 1723822210                                                      
tools_awx_1       | Fri Aug 16 15:30:15 2024 - HARAKIRI !!! end of worker 1 status !!!                                                                        
tools_awx_1       | Fri Aug 16 15:30:15 2024 - HARAKIRI: graceful termination attempt on worker 1 with signal 31. Next harakiri: 1723822217                                                                                                                                                                                 
tools_awx_1       | Fri Aug 16 15:30:15 2024 - HARAKIRI triggered by worker 1 core 0 !!!                                                                      
tools_awx_1       | 2024-08-16 15:30:15,942 ERROR    [60200fba] awx.main.middleware Catching harakiri graceful signal for b3762186-1014-4608-a1f5-225d9f1bcd4a with method: GET path: /api/                                                                                                                                 
tools_awx_1       | 2024-08-16 15:30:15,948 ERROR    [60200fba] awx.main.middleware Received harakiri graceful signal while in stack:   File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/rest_framework/views.py", line 506, in dispatch                                                                          
tools_awx_1       |     response = handler(request, *args, **kwargs)                                                                                          
tools_awx_1       |   File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/django/utils/decorators.py", line 46, in _wrapper                                                                                                                                                                                          
tools_awx_1       |     return bound_method(*args, **kwargs)                                                                                                  
tools_awx_1       |   File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/django/utils/decorators.py", line 134, in _wrapper_view                                                                                                                                                                                    
tools_awx_1       |     response = view_func(request, *args, **kwargs)                                                                                        
tools_awx_1       |   File "/awx_devel/awx/api/views/root.py", line 53, in get                                                                                
tools_awx_1       |     time.sleep(300)                                        
tools_awx_1       |   File "/awx_devel/awx/main/harakiri_middleware.py", line 15, in handle_signal                                                            
tools_awx_1       |     logger.error(f"Received harakiri graceful signal while in stack: {''.join(traceback.format_stack()[-5:])}")                 
```