### PR TITLE
add missing imagePullPolicy

### DIFF
--- a/roles/installer/templates/jobs/migration.yaml.j2
+++ b/roles/installer/templates/jobs/migration.yaml.j2
@@ -36,6 +36,7 @@ spec:
       containers:
         - name: "migration-job"
           image: '{{ _image }}'
+          imagePullPolicy: '{{ image_pull_policy }}'
           resources: {{ task_resource_requirements }}
           command:
             - awx-manage


### PR DESCRIPTION
##### SUMMARY
In the template for migration jobs, the attribute imagePullPolicy was missing.
##### ISSUE TYPE
 - Bug

##### ADDITIONAL INFORMATION
In a high secure, complete 'air-gapped' environment (also w/o registry access), where required images are pre installed in  all nodes, the migration job could'nt run because the usage of the default imagePullPolicy 'Always'. 