### PR TITLE
add postgres securityContext at pod level

### DIFF
--- a/config/crd/bases/awx.ansible.com_awxs.yaml
+++ b/config/crd/bases/awx.ansible.com_awxs.yaml
@@ -1899,6 +1899,10 @@ spec:
                 description: Set session cookie secure mode for web
                 type: string
               postgres_security_context_settings:
+                description: Key/values that will be set under the container-level securityContext field
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              postgres_pod_security_context_settings:
                 description: Key/values that will be set under the pod-level securityContext field
                 type: object
                 x-kubernetes-preserve-unknown-fields: true

--- a/config/manifests/bases/awx-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/awx-operator.clusterserviceversion.yaml
@@ -134,8 +134,13 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:hidden
-      - displayName: PostgreSQL Security Context Settings
+      - displayName: PostgreSQL Container Security Context Settings
         path: postgres_security_context_settings
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - displayName: PostgreSQL Pod Security Context Settings
+        path: postgres_pod_security_context_settings
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:hidden

--- a/docs/user-guide/advanced-configuration/security-context.md
+++ b/docs/user-guide/advanced-configuration/security-context.md
@@ -2,10 +2,11 @@
 
 It is possible to modify some `SecurityContext` proprieties of the various deployments and stateful sets if needed.
 
-| Name                               | Description                                  | Default |
-| ---------------------------------- | -------------------------------------------- | ------- |
-| security_context_settings          | SecurityContext for Task and Web deployments | {}      |
-| postgres_security_context_settings | SecurityContext for PostgreSQL container | {}      |
+| Name                                   | Description                                  | Default |
+| -------------------------------------- | -------------------------------------------- | ------- |
+| security_context_settings              | SecurityContext for Task and Web deployments | {}      |
+| postgres_security_context_settings     | SecurityContext for PostgreSQL container     | {}      |
+| postgres_pod_security_context_settings | SecurityContext for PostgreSQL pod           | {}      |
 
 Example configuration securityContext for the Task and Web deployments:
 

--- a/roles/installer/defaults/main.yml
+++ b/roles/installer/defaults/main.yml
@@ -461,6 +461,7 @@ development_mode: false
 
 security_context_settings: {}
 postgres_security_context_settings: {}
+postgres_pod_security_context_settings: {}
 
 # Set no_log settings on certain tasks
 no_log: true

--- a/roles/installer/templates/statefulsets/postgres.yaml.j2
+++ b/roles/installer/templates/statefulsets/postgres.yaml.j2
@@ -149,6 +149,10 @@ spec:
       tolerations:
         {{ postgres_tolerations | indent(width=8) }}
 {% endif %}
+{% if postgres_pod_security_context_settings|length %}
+      securityContext:
+        {{ postgres_pod_security_context_settings | to_nice_yaml | indent(8) }}
+{% endif %}
 {% if postgres_extra_volumes %}
       volumes:
         {{ postgres_extra_volumes | indent(width=8, first=False) }}


### PR DESCRIPTION
##### SUMMARY
The description  for `postgres_security_context_settings`   '...will be set under the pod-level securityContext field' is wrong, this settings are injected in container-level securityContext.
For setting on pod-level the field `postgres_pod_security_context_settings` is added

##### ISSUE TYPE
 - Bug

##### ADDITIONAL INFORMATION
For some CSI-Drivers (e.g. Longhorn) it's required to modify the securityContext on pod-level.
(see  also https://longhorn.io/docs/1.7.0/nodes-and-volumes/volumes/pvc-ownership-and-permission).

The existing field `postgres_security_context_settings` is for container-level.
Maybe this field should renamed to postgres_container_security_context_settings.

```
    ...
        volumeMounts:
        - mountPath: /var/lib/pgsql/data
          name: postgres-15
          subPath: data
      dnsPolicy: ClusterFirst
      restartPolicy: Always
      schedulerName: default-scheduler
      securityContext:
        fsGroup: 26
        fsGroupChangePolicy: Always
      terminationGracePeriodSeconds: 30
    ...

```
