### PR TITLE
[1952] Move security context in statefulsets/postgres to pod-level spec

### DIFF
--- a/roles/installer/templates/statefulsets/postgres.yaml.j2
+++ b/roles/installer/templates/statefulsets/postgres.yaml.j2
@@ -38,6 +38,10 @@ spec:
         {{ postgres_annotations | indent(width=8) }}
 {% endif %}
     spec:
+{% if postgres_security_context_settings|length %}
+      securityContext:
+        {{ postgres_security_context_settings | to_nice_yaml | indent(8) }}
+{% endif %}
 {% if image_pull_secret is defined %}
       imagePullSecrets:
         - name: {{ image_pull_secret }}
@@ -75,10 +79,6 @@ spec:
         - image: '{{ _postgres_image }}'
           imagePullPolicy: '{{ image_pull_policy }}'
           name: postgres
-{% if postgres_security_context_settings|length %}
-          securityContext:
-            {{ postgres_security_context_settings | to_nice_yaml | indent(12) }}
-{% endif %}
 {% if postgres_extra_args %}
           command: ["run-postgresql"]
           args: {{ postgres_extra_args }}


### PR DESCRIPTION
https://github.com/ansible/awx-operator/issues/1952

##### SUMMARY
Please see issue 1952.

This collides with  PR https://github.com/ansible/awx-operator/pull/1947 so it's up to you whether to chose to expose both pod and container security context or stick to pod's only.

##### ISSUE TYPE
 - Bug

##### ADDITIONAL INFORMATION
Not much to say here, just enabling use of pod-level security context.