### PR TITLE
Add ability to exclude postgres data during migration to Openshift AAP operator

### DIFF
--- a/config/crd/bases/awx.ansible.com_awxs.yaml
+++ b/config/crd/bases/awx.ansible.com_awxs.yaml
@@ -73,6 +73,9 @@ spec:
                 type: string
                 maxLength: 255
                 pattern: '^[a-zA-Z0-9][-a-zA-Z0-9]{0,253}[a-zA-Z0-9]$'
+              pg_dump_suffix:
+                description: Additional parameters for the pg_dump command during a migration
+                type: string
               postgres_label_selector:
                 description: Label selector used to identify postgres pod for data migration
                 type: string

--- a/config/manifests/bases/awx-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/awx-operator.clusterserviceversion.yaml
@@ -319,6 +319,11 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:io.kubernetes:Secret
+      - description: PostgreSQL dump additional parameters to exclude tables during migration to openshift
+        displayname: PostgreSQL backup extra arguments
+        path: pg_dump_suffix
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
       - description: Name of the k8s secret the symmetric encryption key is stored
           in.
         displayName: Secret Key

--- a/config/manifests/bases/awx-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/awx-operator.clusterserviceversion.yaml
@@ -320,7 +320,7 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:io.kubernetes:Secret
       - description: PostgreSQL dump additional parameters to exclude tables during migration to openshift
-        displayname: PostgreSQL backup extra arguments
+        displayname: PostgreSQL Extra Arguments for Migration to Openshift
         path: pg_dump_suffix
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:hidden

--- a/docs/migration/migration.md
+++ b/docs/migration/migration.md
@@ -65,6 +65,13 @@ spec:
   secret_key_secret: <resourcename>-secret-key
   ...
 ```
+### Exclude postgreSQL tables during migration (optional)
+
+Use the `pg_dump_suffix` parameter under `AWX.spec` to customize the pg_dump command that will execute during migration. This variable will append your provided pg_dump parameters to the end of the 'standard' command. For example, to exclude the data from 'main_jobevent' and 'main_job' to decrease the size of the backup use:
+
+```
+pg_dump_suffix: "--exclude-table-data 'main_jobevent*' --exclude-table-data 'main_job'"
+```
 
 ## Important Note
 

--- a/roles/installer/README.md
+++ b/roles/installer/README.md
@@ -15,6 +15,12 @@ See `defaults/main.yml` for all the role variables that you can override.
 
 TODO: add variable description table.
 
+To customize the pg_dump command that will be executed during migration use the `pg_dump_suffix` variable. This variable will append your provided pg_dump parameters to the end of the 'standard' command. For example to exclude the data from 'main_jobevent' and 'main_job' to decrease the size of the backup use:
+
+```
+pg_dump_suffix: "--exclude-table-data 'main_jobevent*' --exclude-table-data 'main_job'"
+```
+
 Dependencies
 ------------
 

--- a/roles/installer/README.md
+++ b/roles/installer/README.md
@@ -15,12 +15,6 @@ See `defaults/main.yml` for all the role variables that you can override.
 
 TODO: add variable description table.
 
-To customize the pg_dump command that will be executed during migration use the `pg_dump_suffix` variable. This variable will append your provided pg_dump parameters to the end of the 'standard' command. For example to exclude the data from 'main_jobevent' and 'main_job' to decrease the size of the backup use:
-
-```
-pg_dump_suffix: "--exclude-table-data 'main_jobevent*' --exclude-table-data 'main_job'"
-```
-
 Dependencies
 ------------
 

--- a/roles/installer/defaults/main.yml
+++ b/roles/installer/defaults/main.yml
@@ -241,6 +241,9 @@ postgres_configuration_secret: ''
 
 old_postgres_configuration_secret: ''
 
+# Allow additional parameters to be added to the pg_dump backup command during AAP VMs to OCP migration
+pg_dump_suffix: ''
+
 # Secret to lookup that provides default execution environment pull credentials
 #
 ee_pull_credentials_secret: ''

--- a/roles/installer/tasks/migrate_data.yml
+++ b/roles/installer/tasks/migrate_data.yml
@@ -44,6 +44,7 @@
       -d {{ awx_old_postgres_database }}
       -p {{ awx_old_postgres_port }}
       -F custom
+      {{ pg_dump_suffix }}
   no_log: "{{ no_log }}"
 
 - name: Set pg_restore command


### PR DESCRIPTION
##### SUMMARY

This allows the users to exclude certain tables during AAP migration to OCP as per https://access.redhat.com/solutions/6967353

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New or Enhanced Feature

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
