### PR TITLE
Fixes when awx is missing django_auth_ldap dependency

### DIFF
--- a/roles/installer/templates/configmaps/config.yaml.j2
+++ b/roles/installer/templates/configmaps/config.yaml.j2
@@ -15,7 +15,11 @@ data:
     import os
     import socket
     # Import all so that extra_settings works properly
-    from django_auth_ldap.config import *
+    try:
+        # Some AWX setups may have no django_auth_ldap dependency.
+        from django_auth_ldap.config import *
+    except:
+        pass
 
     def get_secret():
         if os.path.exists("/etc/tower/SECRET_KEY"):


### PR DESCRIPTION
##### SUMMARY
Some AWX setups maybe missing the django_auth_ldap dependency, what may cause the deployment to crash.  

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
