### PR TITLE
deprecate LDAP auth

### DIFF
--- a/config/crd/bases/awx.ansible.com_awxs.yaml
+++ b/config/crd/bases/awx.ansible.com_awxs.yaml
@@ -1862,11 +1862,11 @@ spec:
               development_mode:
                 description: If the deployment should be done in development mode
                 type: boolean
-              ldap_cacert_secret:
-                description: Secret where can be found the LDAP trusted Certificate Authority Bundle
+              ldap_cacert_secret:  # deprecated
+                description: (Deprecated) Secret where can be found the LDAP trusted Certificate Authority Bundle
                 type: string
-              ldap_password_secret:
-                description: Secret where can be found the LDAP bind password
+              ldap_password_secret:  # deprecated
+                description: (Deprecated) Secret where can be found the LDAP bind password
                 type: string
               bundle_cacert_secret:
                 description: Secret where can be found the trusted Certificate Authority Bundle

--- a/config/manifests/bases/awx-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/awx-operator.clusterserviceversion.yaml
@@ -722,12 +722,12 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:hidden
-      - displayName: LDAP Certificate Authority Trust Bundle
+      - displayName: LDAP Certificate Authority Trust Bundle (Deprecated)
         path: ldap_cacert_secret
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:io.kubernetes:Secret
-      - displayName: LDAP Password Secret
+      - displayName: LDAP Password Secret (Deprecated)
         path: ldap_password_secret
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced

--- a/docs/user-guide/advanced-configuration/enabling-ldap-integration-at-awx-bootstrap.md
+++ b/docs/user-guide/advanced-configuration/enabling-ldap-integration-at-awx-bootstrap.md
@@ -1,4 +1,4 @@
-# Enabling LDAP Integration at AWX bootstrap
+# Enabling LDAP Integration at AWX bootstrap (Deprecated)
 
 A sample of extra settings can be found as below. All possible options can be found here: <https://django-auth-ldap.readthedocs.io/en/latest/reference.html#settings>
 

--- a/docs/user-guide/advanced-configuration/extra-settings.md
+++ b/docs/user-guide/advanced-configuration/extra-settings.md
@@ -28,6 +28,7 @@ spec:
     - setting: MAX_PAGE_SIZE
       value: "500"
 
+    # LDAP is deprecated
     - setting: AUTH_LDAP_BIND_DN
       value: "cn=admin,dc=example,dc=com"
 

--- a/docs/user-guide/advanced-configuration/trusting-a-custom-certificate-authority.md
+++ b/docs/user-guide/advanced-configuration/trusting-a-custom-certificate-authority.md
@@ -4,11 +4,11 @@ In cases which you need to trust a custom Certificate Authority, there are few v
 
 Trusting a custom Certificate Authority allows the AWX to access network services configured with SSL certificates issued locally, such as cloning a project from from an internal Git server via HTTPS. It is common for these scenarios, experiencing the error [unable to verify the first certificate](https://github.com/ansible/awx-operator/issues/376).
 
-| Name                             | Description                              | Default |
-| -------------------------------- | ---------------------------------------- | --------|
-| ldap_cacert_secret               | LDAP Certificate Authority secret name   |  ''     |
-| ldap_password_secret             | LDAP BIND DN Password secret name        |  ''     |
-| bundle_cacert_secret             | Certificate Authority secret name        |  ''     |
+| Name                                | Description                              | Default |
+|-------------------------------------| ---------------------------------------- |---------|
+| ldap_cacert_secret _(deprecated)_   | LDAP Certificate Authority secret name   | ''      |
+| ldap_password_secret _(deprecated)_ | LDAP BIND DN Password secret name        | ''      |
+| bundle_cacert_secret                | Certificate Authority secret name        | ''      |
 
 Please note the `awx-operator` will look for the data field `ldap-ca.crt` in the specified secret when using the `ldap_cacert_secret`, whereas the data field `bundle-ca.crt` is required for `bundle_cacert_secret` parameter.
 

--- a/roles/backup/tasks/secrets.yml
+++ b/roles/backup/tasks/secrets.yml
@@ -14,6 +14,7 @@
     - route_tls_secret
     # ingress_tls_secret is deprecated in favor of ingress_hosts.tls_secret
     - ingress_tls_secret
+    # LDAP is deprecated
     - ldap_cacert_secret
     - bundle_cacert_secret
     - ee_pull_credentials_secret

--- a/roles/installer/defaults/main.yml
+++ b/roles/installer/defaults/main.yml
@@ -442,11 +442,11 @@ projects_storage_access_mode: ReadWriteMany
 
 ca_trust_bundle: "/etc/pki/tls/certs/ca-bundle.crt"
 
-# Secret to lookup that provides the LDAP CACert trusted bundle
+# Secret to lookup that provides the LDAP CACert trusted bundle (Deprecated)
 #
 ldap_cacert_secret: ''
 
-# Secret to lookup that provides the LDAP bind password
+# Secret to lookup that provides the LDAP bind password (Deprecated)
 ldap_password_secret: ''
 
 # Secret to lookup that provides the custom CA trusted bundle

--- a/roles/installer/tasks/install.yml
+++ b/roles/installer/tasks/install.yml
@@ -44,12 +44,12 @@
 - name: Include secret key configuration tasks
   include_tasks: secret_key_configuration.yml
 
-- name: Load LDAP CAcert certificate
+- name: Load LDAP CAcert certificate (Deprecated)
   include_tasks: load_ldap_cacert_secret.yml
   when:
   - ldap_cacert_secret != ''
 
-- name: Load ldap bind password
+- name: Load ldap bind password (Deprecated)
   include_tasks: load_ldap_password_secret.yml
   when:
   - ldap_password_secret != ''

--- a/roles/installer/tasks/load_ldap_cacert_secret.yml
+++ b/roles/installer/tasks/load_ldap_cacert_secret.yml
@@ -1,4 +1,11 @@
 ---
+- name: Log LDAP deprecated message if applicable
+  debug:
+    msg: |
+      [DEPRECATION WARNING] LDAP is deprecated, but ldap_cacert_secret configuration is set.
+  when:
+    - ldap_cacert_secret != ''
+
 - name: Retrieve LDAP CA Certificate Secret
   k8s_info:
     kind: Secret

--- a/roles/installer/tasks/load_ldap_password_secret.yml
+++ b/roles/installer/tasks/load_ldap_password_secret.yml
@@ -1,4 +1,11 @@
 ---
+- name: Log LDAP deprecated message if applicable
+  debug:
+    msg: |
+        [DEPRECATION WARNING] LDAP is deprecated, but ldap_password_secret configuration is set.
+  when:
+    - ldap_password_secret != ''
+
 - name: Retrieve LDAP bind password Secret
   k8s_info:
     kind: Secret

--- a/roles/installer/vars/main.yml
+++ b/roles/installer/vars/main.yml
@@ -1,6 +1,7 @@
 ---
 postgres_initdb_args: '--auth-host=scram-sha-256'
 postgres_host_auth_method: 'scram-sha-256'
+# LDAP is deprecated
 ldap_cacert_ca_crt: ''
 bundle_ca_crt: ''
 projects_existing_claim: ''


### PR DESCRIPTION
##### SUMMARY
Deprecate LDAP auth


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION
this work is part of the efforts described here as part of the effort described here 
https://forum.ansible.com/t/transitioning-authentication-and-authorization-rbac-to-the-new-awx-architecture 