### PR TITLE
Fix Label PR check by using python venv for requests library

### DIFF
--- a/.github/workflows/label_pr.yml
+++ b/.github/workflows/label_pr.yml
@@ -13,9 +13,17 @@ jobs:
     name: Label PR - Community
     steps:
       - uses: actions/checkout@v4
+
       - uses: actions/setup-python@v5
-      - name: Install python requests
-        run: pip install requests
+
+      - name: Create a virtual environment
+        run: python3 -m venv venv
+
+      - name: Activate virtual environment and install dependencies
+        run: |
+          source venv/bin/activate
+          pip3 install requests
+
       - name: Check if user is a member of Ansible org
         uses: jannekem/run-python-script-action@v1
         id: check_user
@@ -32,6 +40,7 @@ jobs:
                 print("User is member")
             else:
                 print("User is community")
+
       - name: Add community label if not a member
         if: contains(steps.check_user.outputs.stdout, 'community')
         uses: andymckay/labeler@e6c4322d0397f3240f0e7e30a33b5c5df2d39e90


### PR DESCRIPTION
##### SUMMARY
Fix Label PR check by using python venv for requests library

Failed CI workflow:
* https://github.com/ansible/awx-operator/actions/runs/11368911538/job/31625113327?pr=1972

Fixes the following error:

```
Run pip install requests
error: externally-managed-environment

× This environment is externally managed
╰─> To install Python packages system-wide, try apt install
    python3-xyz, where xyz is the package you are trying to
    install.
    
    If you wish to install a non-Debian-packaged Python package,
    create a virtual environment using python3 -m venv path/to/venv.
    Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
    sure you have python3-full installed.
    
    If you wish to install a non-Debian packaged Python application,
    it may be easiest to use pipx install xyz, which will manage a
    virtual environment for you. Make sure you have pipx installed.
    
    See /usr/share/doc/python3.12/README.venv for more information.

note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
hint: See PEP 668 for the detailed specification.
```
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
