### PR TITLE
Add upgradedFrom status for check-version changes

### DIFF
--- a/config/crd/bases/awx.ansible.com_awxs.yaml
+++ b/config/crd/bases/awx.ansible.com_awxs.yaml
@@ -2042,6 +2042,9 @@ spec:
               image:
                 description: URL of the image used for the deployed instance
                 type: string
+              upgradedFrom:
+                description: Last gated version
+                type: string
               conditions:
                 description: The resulting conditions when a Service Telemetry is instantiated
                 items:


### PR DESCRIPTION
##### SUMMARY

Without this, `upgradeFrom` status was not getting set.  Follow-up work for:
* https://github.com/ansible/awx-operator/pull/1972 

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
