### PR TITLE
Fix disable reverse sync on mgmt command

### DIFF
--- a/roles/installer/tasks/initialize_django.yml
+++ b/roles/installer/tasks/initialize_django.yml
@@ -18,13 +18,11 @@
     namespace: "{{ ansible_operator_meta.namespace }}"
     pod: "{{ awx_web_pod_name }}"
     container: "{{ ansible_operator_meta.name }}-web"
-    command: awx-manage createsuperuser --username={{ admin_user | quote }} --email={{ admin_email | quote }} --noinput
+    command: bash -c "ANSIBLE_REVERSE_RESOURCE_SYNC=false awx-manage createsuperuser --username={{ admin_user | quote }} --email={{ admin_email | quote }} --noinput"
   register: result
   changed_when: "'That username is already taken' not in result.stderr"
   failed_when: "'That username is already taken' not in result.stderr and 'Superuser created successfully' not in result.stdout"
   no_log: "{{ no_log }}"
-  environment:
-    ANSIBLE_REVERSE_RESOURCE_SYNC: "false"
   when: users_result.return_code > 0
 
 - name: Update Django super user password
@@ -116,9 +114,7 @@
     pod: "{{ awx_web_pod_name }}"
     container: "{{ ansible_operator_meta.name }}-web"
     command: >-
-      bash -c "awx-manage create_preload_data"
+      bash -c "ANSIBLE_REVERSE_RESOURCE_SYNC=false awx-manage create_preload_data"
   register: cdo
   changed_when: "'added' in cdo.stdout"
-  environment:
-    ANSIBLE_REVERSE_RESOURCE_SYNC: "false"
   when: create_preload_data | bool


### PR DESCRIPTION
##### SUMMARY
environment does not get pass into command for k8s exec

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
