### PR TITLE
build: bump ansible-operator to v1.36.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/operator-framework/ansible-operator:v1.34.2
+FROM quay.io/operator-framework/ansible-operator:v1.36.0
 
 USER root
 RUN dnf update --security --bugfix -y && \

--- a/Makefile
+++ b/Makefile
@@ -177,7 +177,7 @@ ifeq (,$(shell which ansible-operator 2>/dev/null))
 	@{ \
 	set -e ;\
 	mkdir -p $(dir $(ANSIBLE_OPERATOR)) ;\
-	curl -sSLo $(ANSIBLE_OPERATOR) https://github.com/operator-framework/ansible-operator-plugins/releases/download/v1.34.0/ansible-operator_$(OS)_$(ARCHA) ;\
+	curl -sSLo $(ANSIBLE_OPERATOR) https://github.com/operator-framework/ansible-operator-plugins/releases/download/v1.36.0/ansible-operator_$(OS)_$(ARCHA) ;\
 	chmod +x $(ANSIBLE_OPERATOR) ;\
 	}
 else


### PR DESCRIPTION
bump ansible-operator version to v1.36.0 to mitigate vulnerabilites. reduces 336 vulns (143 fixable) to 188 vulns (1 fixable)

SUMMARY
Bumps version tag for operator-framework/ansible-operator from v1.34.0 to v1.34.2
Bumps version tag for operator-framework/operator-sdk from v1.33.0 to v1.34.2

ISSUE TYPE
Bug, Docs Fix or other nominal change
