### PR TITLE
Fix installer update-ca-trust command

### DIFF
--- a/roles/installer/templates/deployments/task.yaml.j2
+++ b/roles/installer/templates/deployments/task.yaml.j2
@@ -84,7 +84,7 @@ spec:
             - -c
             - |
               mkdir -p /etc/pki/ca-trust/extracted/{java,pem,openssl,edk2}
-              update-ca-trust extract
+              update-ca-trust extract --output /etc/pki/ca-trust/extracted
           volumeMounts:
             - name: "ca-trust-extracted"
               mountPath: "/etc/pki/ca-trust/extracted"

--- a/roles/installer/templates/deployments/web.yaml.j2
+++ b/roles/installer/templates/deployments/web.yaml.j2
@@ -93,7 +93,7 @@ spec:
             - -c
             - |
               mkdir -p /etc/pki/ca-trust/extracted/{java,pem,openssl,edk2}
-              update-ca-trust extract
+              update-ca-trust extract --output /etc/pki/ca-trust/extracted
           volumeMounts:
             - name: "ca-trust-extracted"
               mountPath: "/etc/pki/ca-trust/extracted"

--- a/roles/installer/templates/jobs/migration.yaml.j2
+++ b/roles/installer/templates/jobs/migration.yaml.j2
@@ -24,7 +24,7 @@ spec:
             - -c
             - |
               mkdir -p /etc/pki/ca-trust/extracted/{java,pem,openssl,edk2}
-              update-ca-trust extract
+              update-ca-trust extract --output /etc/pki/ca-trust/extracted
           volumeMounts:
             - name: "ca-trust-extracted"
               mountPath: "/etc/pki/ca-trust/extracted"


### PR DESCRIPTION
##### SUMMARY

The awx-task, awx-web and awx-migration run an init container `init-bundle-ca-trust` if you want to add your own CA certificate to the truststore. Therefore the `update-ca-trust` command is used.

The latest release of the `update-ca-trust` requires the --output param if you run as non-root user.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION
See: https://gitlab.com/redhat/centos-stream/rpms/ca-certificates/-/commit/81a090f89a413487bb8a8677eff9bb4fb8bfbf71
And: https://github.com/ansible/awx-ee/issues/258#issuecomment-2439742296

Fixes: https://github.com/ansible/awx-ee/issues/258

Before the init pod `init-bundle-ca-trust` failed with the following error message:
```
ln: failed to create symbolic link '/etc/pki/ca-trust/extracted/pem/directory-hash/ca-certificates.crt': Permission denied
```
