### PR TITLE
Fix install awx-task > init-database container if it needs to be stopped by kubernetes

### DIFF
--- a/roles/installer/templates/deployments/task.yaml.j2
+++ b/roles/installer/templates/deployments/task.yaml.j2
@@ -97,7 +97,7 @@ spec:
           image: '{{ _image }}'
           imagePullPolicy: '{{ image_pull_policy }}'
           resources: {{ init_container_resource_requirements }}
-          command:
+          args:
             - /bin/sh
             - -c
             - wait-for-migrations


### PR DESCRIPTION
##### SUMMARY
If the database setup is in some way wrong, the `wait-for-migrations` command inside the `init-database` container runs infinitely and can't be stopped by kubernetes. The "PID 1" problem.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION
The `wait-for-migrations` command needs to be started by `dump-init` command. The `dump-init` command is the default ENTRYPOINT of the used container image. See: https://github.com/ansible/awx/blob/devel/tools/ansible/roles/dockerfile/templates/Dockerfile.j2#L321
`command:` overwrites the ENTRYPOINT, `args:` append to the ENTRYPOINT

Otherwise the `init-database` can't be stopped by kubernetes because the PID 1 ignores all SIGTERM / SIGKILL signals.