### PR TITLE
Point at awx devel collection

### DIFF
--- a/molecule/requirements.yml
+++ b/molecule/requirements.yml
@@ -4,4 +4,6 @@ collections:
   - name: kubernetes.core
   - name: operator_sdk.util
   - name: community.docker
-  - name: awx.awx
+  - name: https://github.com/ansible/awx.git#/awx_collection/
+    type: git
+    version: devel


### PR DESCRIPTION

##### SUMMARY
awx.awx collection on galaxy is ooooold at this point. Releases are paused, so point at awx collection in devel to get that new bleeding edge hotness.

AAP-34010

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
