### PR TITLE
Add up.sh and down.sh development scripts for consistency with other ansible operators

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,7 @@ Have questions about this document or anything not covered here? Please file a n
   - [Table of contents](#table-of-contents)
   - [Things to know prior to submitting code](#things-to-know-prior-to-submitting-code)
   - [Submmiting your work](#submmiting-your-work)
+  - [Development](#development)
   - [Testing](#testing)
       - [Testing in Kind](#testing-in-kind)
       - [Testing in Minikube](#testing-in-minikube)
@@ -42,7 +43,8 @@ Have questions about this document or anything not covered here? Please file a n
 
 **Note**: If you have multiple commits, make sure to `squash` your commits into a single commit which will facilitate our release process.
 
-
+## Development
+The development environment consists of running an [`up.sh`](./up.sh) and a [`down.sh`](./down.sh) script, which applies or deletes yaml on the Openshift or K8s cluster you are connected to. See the [development.md](docs/development.md) for information on how to deploy and test changes from your branch.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ Please visit [our contributing guidelines](https://github.com/ansible/awx-operat
 
 For docs changes, create PRs on the appropriate files in the `/docs` folder.
 
+The development environment consists of running an [`up.sh`](https://github.com/ansible/awx-operator/blob/devel/up.sh) and a [`down.sh`](https://github.com/ansible/awx-operator/blob/devel/down.sh) script, which applies or deletes yaml on the Openshift or K8s cluster you are connected to. See the [development.md](https://github.com/ansible/awx-operator/blob/devel/docs/development.md) for information on how to deploy and test changes from your branch.
+
 ## Author
 
 This operator was originally built in 2019 by [Jeff Geerling](https://www.jeffgeerling.com) and is now maintained by the Ansible Team

--- a/dev/awx-cr/awx-cr-settings.yml
+++ b/dev/awx-cr/awx-cr-settings.yml
@@ -1,0 +1,24 @@
+---
+apiVersion: awx.ansible.com/v1beta1
+kind: AWX
+metadata:
+  name: awx
+spec:
+  service_type: clusterip
+  ingress_type: route
+  no_log: false
+
+  # Secrets
+  admin_password_secret: custom-admin-password
+  postgres_configuration_secret: custom-pg-configuration
+  secret_key_secret: custom-secret-key
+
+  # Resource Requirements
+  postgres_storage_requirements:
+    requests:
+      storage: 10Gi
+
+  # Extra Settings
+  extra_settings:
+    - setting: MAX_PAGE_SIZE
+      value: "500"

--- a/dev/awx-cr/awx-k8s-ingress.yml
+++ b/dev/awx-cr/awx-k8s-ingress.yml
@@ -1,0 +1,13 @@
+---
+apiVersion: awx.ansible.com/v1beta1
+kind: AWX
+metadata:
+  name: awx
+spec:
+  service_type: nodeport
+  ingress_type: ingress
+
+  # Secrets
+  admin_password_secret: custom-admin-password
+  postgres_configuration_secret: custom-pg-configuration
+  secret_key_secret: custom-secret-key

--- a/dev/awx-cr/awx-openshift-cr.yml
+++ b/dev/awx-cr/awx-openshift-cr.yml
@@ -1,0 +1,13 @@
+---
+apiVersion: awx.ansible.com/v1beta1
+kind: AWX
+metadata:
+  name: awx
+spec:
+  service_type: clusterip
+  ingress_type: Route
+
+  # Secrets
+  admin_password_secret: custom-admin-password
+  postgres_configuration_secret: custom-pg-configuration
+  secret_key_secret: custom-secret-key

--- a/dev/secrets/admin-password-secret.yml
+++ b/dev/secrets/admin-password-secret.yml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: custom-admin-password
+stringData:
+  password: 'password'

--- a/dev/secrets/custom-secret-key.yml
+++ b/dev/secrets/custom-secret-key.yml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: custom-secret-key
+stringData:
+  secret_key: 'awxsecret'

--- a/dev/secrets/external-pg-secret.yml
+++ b/dev/secrets/external-pg-secret.yml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: external-pg-secret
+stringData:
+  database: 'awx'
+  host: 'awx-postgres'
+  password: 'test'
+  port: '5432'
+  type: 'managed'
+  username: 'awx'

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,58 @@
+# Development Guide
+
+There are development scripts and yaml exaples in the [`dev/`](../dev) directory that, along with the up.sh and down.sh scripts in the root of the repo, can be used to build, deploy and test changes made to the awx-operator.
+
+
+## Build and Deploy
+
+
+If you clone the repo, and make sure you are logged in at the CLI with oc and your cluster, you can run:
+
+```
+export QUAY_USER=username
+export NAMESPACE=awx
+export TAG=test
+./up.sh
+```
+
+You can add those variables to your .bashrc file so that you can just run `./up.sh` in the future.
+
+> Note: the first time you run this, it will create quay.io repos on your fork. You will need to either make those public, or create a global pull secret on your Openshift cluster.
+
+To get the URL, if on **Openshift**, run:
+
+```
+$ oc get route
+```
+
+On **k8s with ingress**, run:
+
+```
+$ kubectl get ing
+```
+
+On **k8s with nodeport**, run:
+
+```
+$ kubectl get svc
+```
+
+The URL is then `http://<Node-IP>:<NodePort>`
+
+> Note: NodePort will only work if you expose that port on your underlying k8s node, or are accessing it from localhost.
+
+By default, the usename and password will be admin and password if using the `up.sh` script because it pre-creates a custom admin password k8s secret and specifies it on the AWX custom resource spec. Without that, a password would have been generated and stored in a k8s secret named <deployment-name>-admin-password.
+
+## Clean up
+
+
+Same thing for cleanup, just run ./down.sh and it will clean up your namespace on that cluster
+
+
+```
+./down.sh
+```
+
+## Running CI tests locally
+
+More tests coming soon...

--- a/down.sh
+++ b/down.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# AWX Operator down.sh
+# Purpose:
+#   Cleanup and delete the namespace you deployed in
+
+# -- Usage
+#   NAMESPACE=awx ./down.sh
+
+# -- Variables
+TAG=${TAG:-dev}
+AWX_CR=${AWX_CR:-awx}
+CLEAN_DB=${CLEAN_DB:-false}
+
+
+# -- Check for required variables
+# Set the following environment variables
+# export NAMESPACE=awx
+
+if [ -z "$NAMESPACE" ]; then
+  echo "Error: NAMESPACE env variable is not set. Run the following with your namespace:"
+  echo "  export NAMESPACE=developer"
+  exit 1
+fi
+
+# -- Delete Backups
+kubectl delete awxbackup --all
+
+# -- Delete Restores
+kubectl delete awxrestore --all
+
+# Deploy Operator
+make undeploy NAMESPACE=$NAMESPACE
+
+# Remove PVCs
+kubectl delete pvc postgres-15-$AWX_CR-postgres-15-0
+

--- a/up.sh
+++ b/up.sh
@@ -1,0 +1,134 @@
+#!/bin/bash
+# AWX Operator up.sh
+# Purpose:
+#   Build operator image from your local checkout, push to quay.io/youruser/awx-operator:dev, and deploy operator
+
+# -- Usage
+#   NAMESPACE=awx TAG=dev QUAY_USER=developer ./up.sh
+
+# -- User Variables
+NAMESPACE=${NAMESPACE:-awx}
+QUAY_USER=${QUAY_USER:-developer}
+TAG=${TAG:-$(git rev-parse --short HEAD)}
+DEV_TAG=${DEV_TAG:-dev}
+DEV_TAG_PUSH=${DEV_TAG_PUSH:-true}
+
+# -- Check for required variables
+# Set the following environment variables
+# export NAMESPACE=awx
+# export QUAY_USER=developer
+
+if [ -z "$QUAY_USER" ]; then
+  echo "Error: QUAY_USER env variable is not set."
+  echo "  export QUAY_USER=developer"
+  exit 1
+fi
+if [ -z "$NAMESPACE" ]; then
+  echo "Error: NAMESPACE env variable is not set. Run the following with your namespace:"
+  echo "  export NAMESPACE=developer"
+  exit 1
+fi
+
+# -- Container Build Engine (podman or docker)
+ENGINE=${ENGINE:-podman}
+
+# -- Variables
+IMG=quay.io/$QUAY_USER/awx-operator
+KUBE_APPLY="kubectl apply -n $NAMESPACE -f"
+
+# -- Wait for existing project to be deleted
+# Function to check if the namespace is in terminating state
+is_namespace_terminating() {
+    kubectl get namespace $NAMESPACE 2>/dev/null | grep -q 'Terminating'
+    return $?
+}
+
+# Check if the namespace exists and is in terminating state
+if kubectl get namespace $NAMESPACE 2>/dev/null; then
+    echo "Namespace $NAMESPACE exists."
+
+    if is_namespace_terminating; then
+        echo "Namespace $NAMESPACE is in terminating state. Waiting for it to be fully terminated..."
+        while is_namespace_terminating; do
+            sleep 5
+        done
+        echo "Namespace $NAMESPACE has been terminated."
+    fi
+fi
+
+# -- Create namespace
+kubectl create namespace $NAMESPACE
+
+
+# -- Prepare
+
+# Set imagePullPolicy to Always
+files=(
+    config/manager/manager.yaml
+)
+for file in "${files[@]}"; do
+  if grep -qF 'imagePullPolicy: IfNotPresent' ${file}; then
+    sed -i -e "s|imagePullPolicy: IfNotPresent|imagePullPolicy: Always|g" ${file};
+  fi
+done
+
+
+# Delete old operator deployment
+kubectl delete deployment awx-operator-controller-manager
+
+# Create secrets
+$KUBE_APPLY dev/secrets/custom-secret-key.yml
+$KUBE_APPLY dev/secrets/admin-password-secret.yml
+
+# (Optional) Create external-pg-secret
+# $KUBE_APPLY dev/secrets/external-pg-secret.yml
+
+
+# -- Login to Quay.io
+$ENGINE login quay.io
+
+if [ $ENGINE = 'podman' ]; then
+  if [ -f "$XDG_RUNTIME_DIR/containers/auth.json" ] ; then
+    REGISTRY_AUTH_CONFIG=$XDG_RUNTIME_DIR/containers/auth.json
+    echo "Found registry auth config: $REGISTRY_AUTH_CONFIG"
+  elif [ -f $HOME/.config/containers/auth.json ] ; then
+    REGISTRY_AUTH_CONFIG=$HOME/.config/containers/auth.json
+    echo "Found registry auth config: $REGISTRY_AUTH_CONFIG"
+  elif [ -f "/home/$USER/.docker/config.json" ] ; then
+    REGISTRY_AUTH_CONFIG=/home/$USER/.docker/config.json
+    echo "Found registry auth config: $REGISTRY_AUTH_CONFIG"
+  else
+    echo "No Podman configuration files were found."
+  fi
+fi
+
+if [ $ENGINE = 'docker' ]; then
+  if [ -f "/home/$USER/.docker/config.json" ] ; then
+	  REGISTRY_AUTH_CONFIG=/home/$USER/.docker/config.json
+    echo "Found registry auth config: $REGISTRY_AUTH_CONFIG"
+  else
+    echo "No Docker configuration files were found."
+  fi
+fi
+
+
+# -- Build & Push Operator Image
+echo "Preparing to build $IMG:$TAG ($IMG:$DEV_TAG) with $ENGINE..."
+sleep 3
+make docker-build docker-push IMG=$IMG:$TAG
+
+# Tag and Push DEV_TAG Image when DEV_TAG_PUSH is 'True'
+if $DEV_TAG_PUSH ; then
+  $ENGINE tag $IMG:$TAG $IMG:$DEV_TAG
+  make docker-push IMG=$IMG:$DEV_TAG
+fi
+
+# -- Deploy Operator
+make deploy IMG=$IMG:$TAG NAMESPACE=$NAMESPACE
+
+# -- Create CR
+# uncomment the CR you want to use
+$KUBE_APPLY dev/awx-cr/awx-openshift-cr.yml
+# $KUBE_APPLY dev/awx-cr/awx-cr-settings.yml
+# $KUBE_APPLY dev/awx-cr/awx-k8s-ingress.yml
+


### PR DESCRIPTION

##### SUMMARY
Contributing my development scripts made generic.  These are consistent with the ones in the eda-server-operator repo as well, and largely the same as the galaxy-operator repo. 

##### ISSUE TYPE

 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION

Usage examples:

Build operator image from your local checkout, push to quay.io/youruser/awx-operator:dev, and deploy operator.

```bash
export NAMESPACE=awx
export QUAY_USER=developer
./up.sh
```

Cleanup and delete the namespace you deployed in.
```bash
export NAMESPACE=awx
./down.sh
```