### PR TITLE
Enable seccompProfile for controller-manager

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -27,13 +27,8 @@ spec:
     spec:
       securityContext:
         runAsNonRoot: true
-        # For common cases that do not require escalating privileges
-        # it is recommended to ensure that all your Pods/Containers are restrictive.
-        # More info: https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted
-        # Please uncomment the following code if your project does NOT have to work on old Kubernetes
-        # versions < 1.19 or on vendors versions which do NOT support this field by default (i.e. Openshift < 4.11 ).
-        # seccompProfile:
-        #   type: RuntimeDefault
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - args:
         - --leader-elect


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

`controller-manager`'s `seccompProfile` should be set as `type: RuntimeDefault`. This has previously been avoided because of compatibility issues with platforms that have now long reached EOL.

<!---
If you are fixing an existing issue, please include "fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
-->

See also https://github.com/ansible/awx-operator/pull/1933.
