### PR TITLE
Fix backup for non Openshift cluster

### DIFF
--- a/roles/backup/README.md
+++ b/roles/backup/README.md
@@ -105,6 +105,16 @@ To customize the pg_dump command that will be executed on a backup use the `pg_d
 pg_dump_suffix: "--exclude-table-data 'main_jobevent*' --exclude-table-data 'main_job'"
 ```
 
+When using a hostPath backed PVC and some other storage classes like longhorn storage, the postgres data directory needs to be accessible by the user in the postgres pod (UID 26).
+
+To initialize this directory with the correct permissions, configure the following setting, which will use an init container to set the permissions in the postgres volume.
+
+```
+init_container_commands: |
+  chown 26:0 /backups
+  chmod 700 /backups
+```
+
 Testing
 ----------------
 

--- a/roles/backup/templates/management-pod.yml.j2
+++ b/roles/backup/templates/management-pod.yml.j2
@@ -7,6 +7,20 @@ metadata:
   labels:
     {{ lookup("template", "../common/templates/labels/common.yaml.j2") | indent(width=4) | trim }}
 spec:
+{% if init_container_commands %}
+  initContainers:
+    - name: init
+      image: '{{ _postgres_image }}'
+      command:
+        - "/bin/sh"
+        - "-c"
+        - |
+          {{ init_container_commands | indent(width=14) }}
+      volumeMounts:
+        - name: {{ ansible_operator_meta.name }}-backup
+          mountPath: /backups
+          readOnly: false
+{% endif %}
   containers:
   - name: {{ ansible_operator_meta.name }}-db-management
     image: "{{ _postgres_image }}"


### PR DESCRIPTION
SUMMARY
Backups are failing because the postgres image runs as uid 26 that doesn't have perms to the backup PVC. This fixes https://github.com/ansible/awx-operator/issues/1830

ISSUE TYPE
Bug, Docs Fix or other nominal change

ADDITIONAL INFORMATION
Changes requested in #1854