### PR TITLE
Fail early if postgres_configuration_secret is specified by does not exist

### DIFF
--- a/roles/installer/tasks/database_configuration.yml
+++ b/roles/installer/tasks/database_configuration.yml
@@ -51,6 +51,14 @@
   set_fact:
     _default_postgres_image: "{{ _postgres_image }}:{{_postgres_image_version }}"
 
+- name: Fail if PostgreSQL secret is specified, but not found
+  fail:
+    msg: "PostgreSQL configuration {{ postgres_configuration_secret }} not found in namespace {{ ansible_operator_meta.namespace }}"
+  when:
+    - postgres_configuration_secret | length
+    - _custom_pg_config_resources is defined
+    - _custom_pg_config_resources['resources'] | length == 0
+
 - name: Set PostgreSQL configuration
   set_fact:
     _pg_config: '{{ _custom_pg_config_resources["resources"] | default([]) | length | ternary(_custom_pg_config_resources, _default_pg_config_resources) }}'


### PR DESCRIPTION
##### SUMMARY

Current, the operator checks if the secret exists, sees that it does not, then generates a secret and sets that on on the status.

```
status:
    postgresConfigurationSecret: awx-postgres-configuration
```

So you end up with the generated secret on the status, but still have an invalid postgres_configuration_secret on the AWX spec.

```
spec:
    postgres_configuration_secret: custom-pg-configuration
```
That could cause some serious issues for backup and restores...


This PR fails early if the specified secret does not exist and leaves an error on the AWX CR for the user to find, and fix.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New or Enhanced Feature
