### PR TITLE
Accepts new status conditions from the operator on the CR object

### DIFF
--- a/config/crd/bases/awx.ansible.com_awxs.yaml
+++ b/config/crd/bases/awx.ansible.com_awxs.yaml
@@ -2014,6 +2014,7 @@ spec:
                 type: string
             type: object
           status:
+            x-kubernetes-preserve-unknown-fields: true
             properties:
               URL:
                 description: URL to access the deployed instance
@@ -2062,5 +2063,6 @@ spec:
                       type: string
                   type: object
                 type: array
+                x-kubernetes-preserve-unknown-fields: true
             type: object
         type: object


### PR DESCRIPTION
##### SUMMARY
Thanks to the Ansible Operator SDK, status.conditions are automatically added to the AWX CR if a task fails, with the error as part of the status.  

Unfortunately, the CRD schema currently exclude all status conditions that are not explicitly accepted.  This PR changes that so that error messages can be seen on the AWX CR if a task fails.  For example:

```
  status:
    conditions:
    - ansibleResult:
        changed: 3
        completion: 2025-02-10T21:14:09.383551
        failures: 1
        ok: 42
        skipped: 17
      lastTransitionTime: "2025-02-10T21:14:09Z"
      message: |
        The task includes an option with an undefined variable. The error was: 'this_will_fail' is undefined. 'this_will_fail' is undefined

        The error appears to be in '/opt/ansible/roles/installer/tasks/database_configuration.yml': line 54, column 3, but may
        be elsewhere in the file depending on the exact syntax problem.

        The offending line appears to be:


        - name: this will fail
          ^ here
      reason: Failed
      status: "True"
      type: Failure
```

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New or Enhanced Feature