### PR TITLE
Update README.md for AWXBackup pg_dump_suffix

### DIFF
--- a/roles/backup/README.md
+++ b/roles/backup/README.md
@@ -102,7 +102,7 @@ backup_resource_requirements:
 To customize the pg_dump command that will be executed on a backup use the `pg_dump_suffix` variable. This variable will append your provided pg_dump parameters to the end of the 'standard' command. For example to exclude the data from 'main_jobevent' and 'main_job' to decrease the size of the backup use:
 
 ```
-pg_dump_suffix: "--exclude-table-data 'main_jobevent*' --exclude-table-data 'main_job'"
+pg_dump_suffix: "--exclude-table-data 'main_jobevent*' --exclude-table-data '*main_systemjobevent*' --exclude-table-data '*main_activitystream_*'"
 ```
 
 Testing


### PR DESCRIPTION
##### SUMMARY
The original command in this README.md does not seem to yield a usable AWXBackup object for me. I receive the following error when using it:
`[\"pg_restore: error: could not execute query: ERROR:  insert or update on table \\\"main_activitystream_job\\\" violates foreign key constraint \\\"main_activitystream__job_id_aa6811b5_fk_main_job_\\\"\", \"DETAIL:  Key (job_id)=(56322) is not present in table \\\"main_job\\\".\", \"Command was: ALTER TABLE ONLY public.main_activitystream_job\", \"    ADD CONSTRAINT main_activitystream__job_id_aa6811b5_fk_main_job_ FOREIGN KEY (job_id) REFERENCES public.main_job(unifiedjob_ptr_id) DEFERRABLE INITIALLY DEFERRED;\", \"\", \"\", \"pg_restore: error: could not execute query: ERROR:  insert or update on table \\\"main_host\\\" violates foreign key constraint \\\"main_host_last_job_id_d247075b_fk_main_job_unifiedjob_ptr_id\\\"\", \"DETAIL:  Key (last_job_id)=(57349) is not present in table \\\"main_job\\\".\", \"Command was: ALTER TABLE ONLY public.main_host\", \"    ADD CONSTRAINT main_host_last_job_id_d247075b_fk_main_job_unifiedjob_ptr_id FOREIGN KEY (last_job_id) REFERENCES public.main_job(unifiedjob_ptr_id) DEFERRABLE INITIALLY DEFERRED;\", \"\", \"\", \"pg_restore: error: could not execute query: ERROR:  insert or update on table \\\"main_jobhostsummary\\\" violates foreign key constraint \\\"main_jobhostsummary_job_id_8d60afa0_fk_main_job_\\\"\", \"DETAIL:  Key (job_id)=(57072) is not present in table \\\"main_job\\\".\", \"Command was: ALTER TABLE ONLY public.main_jobhostsummary\", \"    ADD CONSTRAINT main_jobhostsummary_job_id_8d60afa0_fk_main_job_ FOREIGN KEY (job_id) REFERENCES public.main_job(unifiedjob_ptr_id) DEFERRABLE INITIALLY DEFERRED;\", \"\", \"\", \"pg_restore: warning: errors ignored on restore: 3\", \"Terminated\"], \"stdout\": \"keepalive_pid: 56\\nMigrating data from old database...\\n\", \"stdout_lines\": [\"keepalive_pid: 56\", \"Migrating data from old database...\"]}`

The updated command for pg_dump_suffix, `"--exclude-table-data 'main_jobevent*' --exclude-table-data '*main_systemjobevent*' --exclude-table-data '*main_activitystream_*'"` seems to yield a usable AWXBackup object that is approximately 97% smaller than a full backup without the command. I'm hoping this might help others who run in to the issue.

If there's anything I'm missing, please let me know.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

