### PR TITLE
add ENGINE var as the value of CONTAINER_CMD var for docker-build and…

### DIFF
--- a/up.sh
+++ b/up.sh
@@ -115,12 +115,12 @@ fi
 # -- Build & Push Operator Image
 echo "Preparing to build $IMG:$TAG ($IMG:$DEV_TAG) with $ENGINE..."
 sleep 3
-make docker-build docker-push IMG=$IMG:$TAG
+make docker-build docker-push IMG=$IMG:$TAG CONTAINER_CMD=$ENGINE
 
 # Tag and Push DEV_TAG Image when DEV_TAG_PUSH is 'True'
 if $DEV_TAG_PUSH ; then
   $ENGINE tag $IMG:$TAG $IMG:$DEV_TAG
-  make docker-push IMG=$IMG:$DEV_TAG
+  make docker-push IMG=$IMG:$DEV_TAG CONTAINER_CMD=$ENGINE
 fi
 
 # -- Deploy Operator


### PR DESCRIPTION
… docker-push target of Makefile

##### SUMMARY
When using Podman as the container engine, the container build process fails with the error:

```bash
./up.sh: line 88: docker: command not found.
```
##### ISSUE TYPE

 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION
I added the ENGINE variable as the value of the CONTAINER_CMD variable that is passed to the docker-build and docker-push targets of the Makefile and now the image is built and pushed when using podman as container engine.

```bash
devel *$ ❯ QUAY_USER=MYUSER ./up.sh 
namespace/awx created
Error from server (NotFound): deployments.apps "awx-operator-controller-manager" not found
secret/custom-secret-key created
secret/custom-admin-password created
Authenticating with existing credentials for quay.io
Existing credentials are valid. Already logged in to quay.io
Found registry auth config: /home/MYUSER/.config/containers/auth.json
Preparing to build quay.io/MYUSER/awx-operator:9864979 (quay.io/MYUSER/awx-operator:dev) with podman...
podman build  -t quay.io/MYUSER/awx-operator:9864979 .
WARN[0000] missing "DEFAULT_AWX_VERSION" build argument. Try adding "--build-arg DEFAULT_AWX_VERSION=<VALUE>" to the command line 
WARN[0000] missing "OPERATOR_VERSION" build argument. Try adding "--build-arg OPERATOR_VERSION=<VALUE>" to the command line 
STEP 1/14: FROM quay.io/operator-framework/ansible-operator:v1.34.2
STEP 2/14: USER root
--> Using cache aad8fd0be5f7e95ddac5b96244403f7bebd5dfa92e929185fdbb9ded9e255de2
--> aad8fd0be5f7
STEP 3/14: RUN dnf update --security --bugfix -y &&     dnf install -y openssl
--> Using cache cbb2d6662ef56d10af67d5da851829bbc7bf868e88da1de7c331a85f3aeaa14e
--> cbb2d6662ef5
STEP 4/14: USER 1001
--> Using cache 28e8e4bbd8a39cbe468a236aca44d026a023af786319ede817d812da47e9e65a
--> 28e8e4bbd8a3
STEP 5/14: ARG DEFAULT_AWX_VERSION
--> Using cache f094c33128ea83cff09e6fb0d938af8cca07b87eadfe68754126b9421b224b0a
--> f094c33128ea
STEP 6/14: ARG OPERATOR_VERSION
--> Using cache 62bff888d078e0184fb4b2e509e1619463538a4c480d032eabe222016aaf1316
--> 62bff888d078
STEP 7/14: ENV DEFAULT_AWX_VERSION=${DEFAULT_AWX_VERSION}
--> Using cache 3eaebd5729f439afdefe721daa9f0fa0be5cabea8dd08af542b8951d97a81871
--> 3eaebd5729f4
STEP 8/14: ENV OPERATOR_VERSION=${OPERATOR_VERSION}
--> Using cache 77d314a706ab32107ed90c229342465417dbe0cd8db1ec07bfaaef9cffa88243
--> 77d314a706ab
STEP 9/14: COPY requirements.yml ${HOME}/requirements.yml
--> Using cache f2336255ea237360321deef8b6173231b54524f635ce947d18f4fb7d8d9ee581
--> f2336255ea23
STEP 10/14: RUN ansible-galaxy collection install -r ${HOME}/requirements.yml  && chmod -R ug+rwx ${HOME}/.ansible
--> Using cache ca75e6f542126eba8c49f97fab2293d5b6f09189c3c1861b6786b7e733438d53
--> ca75e6f54212
STEP 11/14: COPY watches.yaml ${HOME}/watches.yaml
--> Using cache 13916f3ac26a06e7dd3c8ba3ad2e34b529aaa7ed77a74dcd8a870796fa5cec5e
--> 13916f3ac26a
STEP 12/14: COPY roles/ ${HOME}/roles/
--> Using cache 350534b72890ace6fbe1cb7dd34b7315d8197bda38edd0b47cfbe47b2d6d4ed6
--> 350534b72890
STEP 13/14: COPY playbooks/ ${HOME}/playbooks/
--> Using cache e34826834c33682aa09e294864a03a9f0441c7a05f57e893b686a81054a26fb5
--> e34826834c33
STEP 14/14: ENTRYPOINT ["/tini", "--", "/usr/local/bin/ansible-operator", "run",     "--watches-file=./watches.yaml",     "--reconcile-period=0s"     ]
--> Using cache 8b4673aa713a0b3535e2008c59676ea68e50a00531a7133b84b2b1b60debb6f6
COMMIT quay.io/MYUSER/awx-operator:9864979
--> 8b4673aa713a
Successfully tagged quay.io/MYUSER/awx-operator:9864979
Successfully tagged quay.io/MYUSER/awx-operator:dev
Successfully tagged quay.io/MYUSER/awx-operator:16b228d
Successfully tagged quay.io/MYUSER/awx-operator:039157d
8b4673aa713a0b3535e2008c59676ea68e50a00531a7133b84b2b1b60debb6f6
podman push quay.io/MYUSER/awx-operator:9864979
Getting image source signatures
Copying blob aa42ef82fc0a skipped: already exists  
Copying blob 7da382de64b9 skipped: already exists  
Copying blob d26cb58f0d75 skipped: already exists  
Copying blob e0d9d46c1906 skipped: already exists  
Copying blob 32a773a315f7 skipped: already exists  
Copying blob c81b95f103e3 skipped: already exists  
Copying blob 8e84025a95d5 skipped: already exists  
Copying blob 4f4fb700ef54 skipped: already exists  
Copying blob 6f85a1990c65 skipped: already exists  
Copying blob 764632c16092 skipped: already exists  
Copying blob 44137013e94b skipped: already exists  
Copying blob c8c9c23d905f skipped: already exists  
Copying blob 57e8b053631f skipped: already exists  
Copying blob d29416bfe090 skipped: already exists  
Copying blob 66c2f272c3c1 skipped: already exists  
Copying blob b6a2a34df7f7 skipped: already exists  
Copying config 8b4673aa71 done   | 
Writing manifest to image destination
podman push quay.io/MYUSER/awx-operator:dev
Getting image source signatures
Copying blob e0d9d46c1906 skipped: already exists  
Copying blob 7da382de64b9 skipped: already exists  
Copying blob d26cb58f0d75 skipped: already exists  
Copying blob 32a773a315f7 skipped: already exists  
Copying blob aa42ef82fc0a skipped: already exists  
Copying blob 6f85a1990c65 skipped: already exists  
Copying blob 4f4fb700ef54 skipped: already exists  
Copying blob c81b95f103e3 skipped: already exists  
Copying blob 764632c16092 skipped: already exists  
Copying blob 8e84025a95d5 skipped: already exists  
Copying blob 44137013e94b skipped: already exists  
Copying blob c8c9c23d905f skipped: already exists  
Copying blob 66c2f272c3c1 skipped: already exists  
Copying blob 57e8b053631f skipped: already exists  
Copying blob d29416bfe090 skipped: already exists  
Copying blob b6a2a34df7f7 skipped: already exists  
Copying config 8b4673aa71 done   | 
Writing manifest to image destination
Warning: resource namespaces/awx is missing the kubectl.kubernetes.io/last-applied-configuration annotation which is required by kubectl apply. kubectl apply should only be used on resources created declaratively by either kubectl create --save-config or kubectl apply. The missing annotation will be patched automatically.
namespace/awx configured
customresourcedefinition.apiextensions.k8s.io/awxbackups.awx.ansible.com created
customresourcedefinition.apiextensions.k8s.io/awxmeshingresses.awx.ansible.com created
customresourcedefinition.apiextensions.k8s.io/awxrestores.awx.ansible.com created
customresourcedefinition.apiextensions.k8s.io/awxs.awx.ansible.com created
serviceaccount/awx-operator-controller-manager created
role.rbac.authorization.k8s.io/awx-operator-awx-manager-role created
role.rbac.authorization.k8s.io/awx-operator-leader-election-role created
clusterrole.rbac.authorization.k8s.io/awx-operator-metrics-reader created
clusterrole.rbac.authorization.k8s.io/awx-operator-proxy-role created
rolebinding.rbac.authorization.k8s.io/awx-operator-awx-manager-rolebinding created
rolebinding.rbac.authorization.k8s.io/awx-operator-leader-election-rolebinding created
clusterrolebinding.rbac.authorization.k8s.io/awx-operator-proxy-rolebinding created
configmap/awx-operator-awx-manager-config created
service/awx-operator-controller-manager-metrics-service created
deployment.apps/awx-operator-controller-manager created
awx.awx.ansible.com/awx created
```
