### PR TITLE
remove default old PG config

### DIFF
--- a/roles/installer/tasks/database_configuration.yml
+++ b/roles/installer/tasks/database_configuration.yml
@@ -25,18 +25,10 @@
   when: old_postgres_configuration_secret | length
   no_log: "{{ no_log }}"
 
-- name: Check for default old PostgreSQL configuration
-  k8s_info:
-    kind: Secret
-    namespace: '{{ ansible_operator_meta.namespace }}'
-    name: '{{ ansible_operator_meta.name }}-old-postgres-configuration'
-  register: _default_old_pg_config_resources
-  no_log: "{{ no_log }}"
-
 - name: Set old PostgreSQL configuration
   set_fact:
-    # yamllint disable-line rule:line-length
-    old_pg_config: '{{ _custom_old_pg_config_resources["resources"] | default([]) | length | ternary(_custom_old_pg_config_resources, _default_old_pg_config_resources) }}'  # noqa 204
+    old_pg_config: '{{ _custom_old_pg_config_resources["resources"] }}'  # noqa 204
+  when: old_postgres_configuration_secret | length
 
 - name: Set proper database name when migrating from old deployment
   set_fact:


### PR DESCRIPTION
##### SUMMARY

Removes the use of a default secret name for DB migration.

The existance of a secret named `{{ ansible_operator_meta.name }}-old-postgres-configuration` causes the operator to force DB migration even if the user did not request a migration.

With this fix, a migration only occurs if the user specifically request a migration by setting the attribute `old_postgres_configuration_secret` to a non empty value

##### ISSUE TYPE
- Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION
```

```
