### PR TITLE
Grant postgres to awx user on migrate_data

### DIFF
--- a/roles/installer/tasks/migrate_data.yml
+++ b/roles/installer/tasks/migrate_data.yml
@@ -77,7 +77,9 @@
       trap 'end_keepalive \"$keepalive_file\" \"$keepalive_pid\"' EXIT SIGINT SIGTERM
       echo keepalive_pid: $keepalive_pid
       set -e -o pipefail
+      psql -c 'GRANT postgres TO {{ awx_postgres_user }}'
       PGPASSWORD=\"$PGPASSWORD_OLD\" {{ pgdump }} | PGPASSWORD=\"$POSTGRES_PASSWORD\" {{ pg_restore }}
+      psql -c 'REVOKE postgres FROM {{ awx_postgres_user }}'
       set +e +o pipefail
       echo 'Successful'
       "


### PR DESCRIPTION


##### SUMMARY

This is needed in case customers move to
operator platform.

Fixes https://issues.redhat.com/browse/AAP-41592

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
TASK [Stream backup from pg_dump to the new postgresql container] ********************************943fatal: [localhost]: FAILED! => {"changed": true, "rc": 1, "return_code": 1, "stderr": "pg_restore: error: could not execute query: ERROR: must be member of role \"postgres\"\nCommand was: ALTER SCHEMA public OWNER TO postgres;\n\npg_restore: warning: errors ignored on restore: 1\nbash: line 12: 77 Terminated sleep 60\n", "stderr_lines": ["pg_restore: error: could not execute query: ERROR: must be member of role \"postgres\"", "Command was: ALTER SCHEMA public OWNER TO postgres;", "", "pg_restore: warning: errors ignored on restore: 1", "bash: line 12: 77 Terminated sleep 60"], "stdout": "keepalive_pid: 74\nMigrating data from old database...\n", "stdout_lines": ["keepalive_pid: 74", "Migrating data from old database..."]}
```
