### PR TITLE
fix: explicitly import ldap on config file

### DIFF
--- a/roles/installer/templates/settings/ldap.py.j2
+++ b/roles/installer/templates/settings/ldap.py.j2
@@ -1,11 +1,13 @@
+{% if ldap_cacert_ca_crt %}
 import ldap
 
 AUTH_LDAP_GLOBAL_OPTIONS = {
-{% if ldap_cacert_ca_crt %}
     ldap.OPT_X_TLS_REQUIRE_CERT: True,
     ldap.OPT_X_TLS_CACERTFILE: "/etc/openldap/certs/ldap-ca.crt"
-{% endif %}
 }
+{% else %}
+AUTH_LDAP_GLOBAL_OPTIONS = {}
+{% endif %}
 
 # Load LDAP BIND password from Kubernetes secret if define
 {% if ldap_password_secret -%}

--- a/roles/installer/templates/settings/ldap.py.j2
+++ b/roles/installer/templates/settings/ldap.py.j2
@@ -1,3 +1,5 @@
+import ldap
+
 AUTH_LDAP_GLOBAL_OPTIONS = {
 {% if ldap_cacert_ca_crt %}
     ldap.OPT_X_TLS_REQUIRE_CERT: True,


### PR DESCRIPTION
Bug, Docs Fix or other nominal change

```
File "/etc/tower/conf.d/ldap.py", line 2, in <module> ldap.OPT_X_TLS_REQUIRE_CERT: True,
^^^^
NameError: name 'ldap' is not defined
```
