### PR TITLE
Make playbook compatible with new Ansible-core type system

### DIFF
--- a/ansible/instantiate-awx-deployment.yml
+++ b/ansible/instantiate-awx-deployment.yml
@@ -26,7 +26,7 @@
             image_version: "{{ image_version | default(omit) }}"
             development_mode: "{{ development_mode | default(omit) | bool }}"
             image_pull_policy: "{{ image_pull_policy | default(omit) }}"
-            nodeport_port: "{{ nodeport_port | default(omit) }}"
+            nodeport_port: "{{ nodeport_port | default(omit) | int }}"
             # ee_images:
             #   - name: test-ee
             #     image: quay.io/<user>/awx-ee


### PR DESCRIPTION
##### SUMMARY
In recent release, ansible-core got pickier about types. CLI arguments of `-e` are always string, which kind of causes this problem, so ports from CLI need to be converted to ints.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change
