### PR TITLE
Fix jquery version in redirect page

### DIFF
--- a/roles/installer/templates/configmaps/redirect-page.configmap.html.j2
+++ b/roles/installer/templates/configmaps/redirect-page.configmap.html.j2
@@ -70,7 +70,7 @@ data:
         </p>
 
         <!-- Include any additional scripts if needed -->
-        <script src="static/rest_framework/js/jquery-3.5.1.min.js"></script>
+        <script src="static/rest_framework/js/jquery-3.7.1.min.js"></script>
         <script src="static/rest_framework/js/bootstrap.min.js"></script>
     </body>
     </html>


### PR DESCRIPTION
##### SUMMARY

Fix jquery version in redirect page

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION

Other installer uses 3.7.1 and the file on disk is also using 3.7.1 from the rest framework directory.
