### PR TITLE
Add postgres pod securityContext setting.

### DIFF
--- a/config/crd/bases/awx.ansible.com_awxs.yaml
+++ b/config/crd/bases/awx.ansible.com_awxs.yaml
@@ -1905,6 +1905,10 @@ spec:
                 description: Set session cookie secure mode for web
                 type: string
               postgres_security_context_settings:
+                description: Key/values that will be set under the container-level securityContext field
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              postgres_pod_security_context_settings:
                 description: Key/values that will be set under the pod-level securityContext field
                 type: object
                 x-kubernetes-preserve-unknown-fields: true

--- a/config/manifests/bases/awx-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/awx-operator.clusterserviceversion.yaml
@@ -140,8 +140,13 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:hidden
-      - displayName: PostgreSQL Security Context Settings
+      - displayName: PostgreSQL Container-level Security Context Settings
         path: postgres_security_context_settings
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - displayName: PostgreSQL Pod-level Security Context Settings
+        path: postgres_pod_security_context_settings
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:hidden

--- a/docs/user-guide/advanced-configuration/security-context.md
+++ b/docs/user-guide/advanced-configuration/security-context.md
@@ -2,10 +2,11 @@
 
 It is possible to modify some `SecurityContext` proprieties of the various deployments and stateful sets if needed.
 
-| Name                               | Description                                  | Default |
-| ---------------------------------- | -------------------------------------------- | ------- |
-| security_context_settings          | SecurityContext for Task and Web deployments | {}      |
-| postgres_security_context_settings | SecurityContext for PostgreSQL container | {}      |
+| Name                                   | Description                                  | Default |
+| -------------------------------------- | -------------------------------------------- | ------- |
+| security_context_settings              | SecurityContext for Task and Web deployments | {}      |
+| postgres_security_context_settings     | SecurityContext for PostgreSQL container     | {}      |
+| postgres_pod_security_context_settings | SecurityContext for PostgreSQL pod           | {}      |
 
 Example configuration securityContext for the Task and Web deployments:
 
@@ -18,4 +19,6 @@ spec:
         - ALL
   postgres_security_context_settings:
     runAsNonRoot: true
+  postgres_pod_security_context_settings:
+    fsGroup: 26
 ```

--- a/roles/installer/defaults/main.yml
+++ b/roles/installer/defaults/main.yml
@@ -465,6 +465,7 @@ development_mode: false
 
 security_context_settings: {}
 postgres_security_context_settings: {}
+postgres_pod_security_context_settings: {}
 
 # Set no_log settings on certain tasks
 no_log: true

--- a/roles/installer/templates/statefulsets/postgres.yaml.j2
+++ b/roles/installer/templates/statefulsets/postgres.yaml.j2
@@ -145,6 +145,10 @@ spec:
       nodeSelector:
         {{ postgres_selector | indent(width=8) }}
 {% endif %}
+{% if postgres_pod_security_context_settings|length %}
+      securityContext:
+        {{ postgres_pod_security_context_settings | to_nice_yaml | indent(8) }}
+{% endif %}
 {% if postgres_tolerations %}
       tolerations:
         {{ postgres_tolerations | indent(width=8) }}


### PR DESCRIPTION
Previously, it was not possible to set the pod-level securityContext, which makes it impossible to solve a `persistent volume` permissions issue on a kubernetes cluster with enforced nonRoot containers.

Fixes #1770 and similar postgres "Permission denied" issues.

##### SUMMARY

By default, persistent volume is create with `root:root  0755` permissions.
In order to run postgres in the non-root container, the filesystem ownership must be changed.

The existing workaroud is to run a `chown` command in an init container.

Unfortunately, this is not possible to run a root init container on security-hardened kubernetes clusters, such as those which prohibit root containers with the help of a ValidatingAdmissionPolicy.

The kubernetes native solution to this problem is the `fsGroup` setting. When enabled, it [enforces recursive group-write permission before the container startup](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#configure-volume-permission-and-ownership-change-policy-for-pods).

> By default, Kubernetes recursively changes ownership and permissions for the contents of each volume to match the fsGroup specified in a Pod's securityContext

```yaml
kind: Pod
spec:
  securityContext:
    fsGroup: 26
    fsGroupChangePolicy: Always
```

The `awxs` CRD claims that the `postgres_security_context_settings` configures the pod-level securityContext, when in fact it configures the container-level one.

This PR introduces the pod spec securityContext setting and fixes the relevant documentation.


##### ISSUE TYPE

 - New or Enhanced Feature

##### ADDITIONAL INFORMATION

This PR can be tested with the following settings:

```yaml
apiVersion: awx.ansible.com/v1beta1
kind: AWX
metadata:
  name: awx
spec:
    postgres_pod_security_context_settings:
      fsGroup: 26
      fsGroupChangePolicy: Always
    postgres_security_context_settings:
      runAsUser: 26
      runAsGroup: 26
```