### PR TITLE
Update the default crd example for the up.sh

### DIFF
--- a/dev/awx-cr/awx-openshift-cr.yml
+++ b/dev/awx-cr/awx-openshift-cr.yml
@@ -7,7 +7,7 @@ spec:
   service_type: clusterip
   ingress_type: Route
 
-  # Secrets
-  admin_password_secret: custom-admin-password
-  postgres_configuration_secret: custom-pg-configuration
-  secret_key_secret: custom-secret-key
+  # # Secrets
+  # admin_password_secret: custom-admin-password
+  # postgres_configuration_secret: custom-pg-configuration
+  # secret_key_secret: custom-secret-key


### PR DESCRIPTION
##### SUMMARY
Change on the default dev/awx-cr/awx-openshift-cr.yml to prevent errors with the up.sh.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION
The current configuration targets custom configuration files that should be optional.