### PR TITLE
Fixes for passwords for FIPS compliance

### DIFF
--- a/roles/installer/defaults/main.yml
+++ b/roles/installer/defaults/main.yml
@@ -430,6 +430,9 @@ postgres_init_container_commands: |
   chown 26:0 /var/lib/pgsql/data
   chmod 700 /var/lib/pgsql/data
 
+# Enable PostgreSQL SCRAM-SHA-256 migration
+postgres_scram_migration_enabled: true
+
 # Configure postgres connection keepalive
 postgres_keepalives: true
 postgres_keepalives_idle: 5

--- a/roles/installer/tasks/database.yml
+++ b/roles/installer/tasks/database.yml
@@ -70,6 +70,22 @@
     - debug:
         msg: "--- Upgrading from {{ old_postgres_pod['metadata']['name'] | default('NONE')}} Pod ---"
 
+    - name: Migrate from md5 to scram-sha-256
+      k8s_exec:
+        namespace: "{{ ansible_operator_meta.namespace }}"
+        pod: "{{ old_postgres_pod['metadata']['name'] }}"
+        command: |
+          bash -c "
+          psql -U postgres -c \"ALTER SYSTEM SET password_encryption = 'scram-sha-256';\" &&
+          psql -U postgres -c \"SELECT pg_reload_conf();\" &&
+          psql -U postgres -c \"ALTER USER \\\"{{ awx_postgres_user }}\\\" WITH PASSWORD '{{ awx_postgres_pass }}';\"
+          "
+      register: _migration_output
+      no_log: "{{ no_log }}"
+      when:
+        - postgres_scram_migration_enabled
+        - (_old_pg_version.stdout | default(0) | int ) == 13
+
     - name: Upgrade data dir from old Postgres to {{ supported_pg_version }} if applicable
       include_tasks: upgrade_postgres.yml
       when:


### PR DESCRIPTION
##### SUMMARY
Set password_encryption to scram-sha-256 and re-encrypt the DB user passwords for FIPS compliance.

(cherry picked from commit 0e76404357a77a5f773aee6e2b3a5b85d1f514b7)

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION
Fix required for upgrades from PG-13 to PG-15 when FIPS is enabled