### PR TITLE
Add configurable pull secret file support to up.sh

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -3,6 +3,52 @@
 There are development scripts and yaml exaples in the [`dev/`](../dev) directory that, along with the up.sh and down.sh scripts in the root of the repo, can be used to build, deploy and test changes made to the awx-operator.
 
 
+## Prerequisites
+
+You will need to have the following tools installed:
+
+* [git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
+* [podman](https://podman.io/docs/installation) or [docker](https://docs.docker.com/get-docker/)
+* [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
+* [oc](https://docs.openshift.com/container-platform/4.11/cli_reference/openshift_cli/getting-started-cli.html) (if using Openshift)
+
+You will also need to have a container registry account. This guide uses quay.io, but any container registry will work. You will need to create a robot account and login at the CLI with `podman login` or `docker login`.
+
+## Quay.io Setup for Development
+
+Before using the development scripts, you'll need to set up a Quay.io repository and pull secret:
+
+### 1. Create a Private Quay.io Repository
+- Go to [quay.io](https://quay.io) and create a private repository named `awx-operator` under your username
+- The repository URL should be `quay.io/username/awx-operator`
+
+### 2. Create a Bot Account
+- In your Quay.io repository, go to Settings → Robot Accounts
+- Create a new robot account with write permissions to your repository
+- Click on the robot account name to view its credentials
+
+### 3. Generate Kubernetes Pull Secret
+- In the robot account details, click "Kubernetes Secret"
+- Copy the generated YAML content from the pop-up
+
+### 4. Create Local Pull Secret File
+- Create a file at `hacking/pull-secret.yml` in your awx-operator checkout
+- Paste the Kubernetes secret YAML content into this file
+- **Important**: Change the `name` field in the secret from the default to `redhat-operators-pull-secret`
+- The `hacking/` directory is in `.gitignore`, so this file won't be committed to git
+
+Example `hacking/pull-secret.yml`:
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redhat-operators-pull-secret  # Change this name
+  namespace: awx
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: <base64-encoded-credentials>
+```
+
 ## Build and Deploy
 
 
@@ -17,7 +63,7 @@ export TAG=test
 
 You can add those variables to your .bashrc file so that you can just run `./up.sh` in the future.
 
-> Note: the first time you run this, it will create quay.io repos on your fork. You will need to either make those public, or create a global pull secret on your Openshift cluster.
+> Note: the first time you run this, it will create quay.io repos on your fork. If you followed the Quay.io setup steps above and created the `hacking/pull-secret.yml` file, the script will automatically handle the pull secret. Otherwise, you will need to either make those repos public, or create a global pull secret on your cluster.
 
 To get the URL, if on **Openshift**, run:
 

--- a/up.sh
+++ b/up.sh
@@ -5,6 +5,7 @@
 
 # -- Usage
 #   NAMESPACE=awx TAG=dev QUAY_USER=developer ./up.sh
+#   NAMESPACE=awx TAG=dev QUAY_USER=developer PULL_SECRET_FILE=my-secret.yml ./up.sh
 
 # -- User Variables
 NAMESPACE=${NAMESPACE:-awx}
@@ -12,6 +13,7 @@ QUAY_USER=${QUAY_USER:-developer}
 TAG=${TAG:-$(git rev-parse --short HEAD)}
 DEV_TAG=${DEV_TAG:-dev}
 DEV_TAG_PUSH=${DEV_TAG_PUSH:-true}
+PULL_SECRET_FILE=${PULL_SECRET_FILE:-hacking/pull-secret.yml}
 
 # -- Check for required variables
 # Set the following environment variables
@@ -72,6 +74,10 @@ for file in "${files[@]}"; do
   fi
 done
 
+# Create redhat-operators-pull-secret if pull credentials file exists
+if [ -f "$PULL_SECRET_FILE" ]; then
+  $KUBE_APPLY $PULL_SECRET_FILE
+fi
 
 # Delete old operator deployment
 kubectl delete deployment awx-operator-controller-manager


### PR DESCRIPTION
### SUMMARY
Add conditional Red Hat operators pull secret support to dev up.sh script

Adds automatic detection and application of hacking/pull-secret.yml during development setup. If the pull credentials file exists, the script will apply it to the namespace, enabling access to Red Hat operator images during local development and testing.


##### User flow
1. Create a private quay.io repo (quay.io/username/awx-operator)
2. Create a quay bot user for the repo, then get the k8s secret yaml from the quay.io bot helper pop-up
3. Create a file in your awx-operator checkout at `hacking/pull-secret.yml` with that k8s secret yaml.  In that file, change the name of the k8s secret to `redhat-operators-pull-secret` (the operator knows to look for this).  The `hacking/` directory is in the .gitignore, which will prevent git from adding this file to commits.
4. Set the env var QUAY_USER (`export QUAY_USER=username`)
5. Run the up.sh script and the secret will be created and used automatically.

##### Notes
- Applies a pull-secret yaml file if it exists at hacking/awx-cr.yml
- The operator will look for a pull secret called redhat-operators-pull-secret
- This makes it possible to use a private operator image on your quay.io registry out of the box with the up.sh

##### ISSUE TYPE

 - New or Enhanced Feature


