### PR TITLE
Guard against missing version status on existing CR

### DIFF
--- a/roles/installer/tasks/check_existing.yml
+++ b/roles/installer/tasks/check_existing.yml
@@ -25,7 +25,10 @@
     - name: Set previous_version version based on AWX CR version status
       ansible.builtin.set_fact:
         previous_version: "{{ existing_cr.resources[0].status.version }}"
-      when: existing_cr['resources'] | length
+      when:
+        - existing_cr.resources | length
+        - existing_cr.resources[0].status is defined
+        - existing_cr.resources[0].status.version is defined
 
     - name: If previous_version is less than or equal to gating_version, set upgraded_from to previous_version
       ansible.builtin.set_fact:


### PR DESCRIPTION
##### SUMMARY
Fixes bad conditional that was causing the reconciliation loop to fail if the version status is not set on the AWX CR, which can happen in some cases.


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bug, Docs Fix or other nominal change
