### PR TITLE
set client_request_timeout from annotation in the CR

### DIFF
--- a/roles/installer/tasks/main.yml
+++ b/roles/installer/tasks/main.yml
@@ -3,6 +3,31 @@
   include_tasks: idle_deployment.yml
   when: idle_deployment | bool
 
+- name: Look up details for this deployment
+  k8s_info:
+    api_version: "{{ api_version }}"
+    kind: "{{ kind }}"
+    name: "{{ ansible_operator_meta.name }}"
+    namespace: "{{ ansible_operator_meta.namespace }}"
+  register: this_awx
+
+- name: set annotations based on this_awx
+  set_fact:
+    this_annotations: "{{ this_awx['resources'][0]['metadata']['annotations'] | default({}) }}"
+
+- name: set client_request_timeout based on annotation
+  set_fact:
+    client_request_timeout: "{{ (this_annotations['aap.ansible.io/client-request-timeout'][:-1]) | int }}"
+    client_request_timeout_overidden: true
+  when:
+    - "'aap.ansible.io/client-request-timeout' in this_annotations"
+    - this_annotations['aap.ansible.io/client-request-timeout'] is match('^\\d+s$')
+
+- name: client_request_timeout has been changed
+  debug:
+    msg: "client_request_timeout's default 30s value has been overriden by the annotation 'aap.ansible.io/client-request-timeout' to {{ client_request_timeout }}s"
+  when: client_request_timeout_overidden | default(false)
+
 - name: Check for presence of old awx Deployment
   k8s_info:
     api_version: apps/v1


### PR DESCRIPTION
rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
add the functionality to accept an annotation in the awx-cr to be able to override the default client_request_timeout value.
These new tasks will:
- check for annotation for client_request_timeout
- if annotation is present, override default value (currently set to 30s)
- log message noting the change
followup PR to #2056 

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

##### ADDITIONAL INFORMATION

matching PRS for other operators:
- https://github.com/ansible/galaxy-operator/pull/213
- https://github.com/ansible/eda-server-operator/pull/301

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New or Enhanced Feature
