### PR TITLE
Update Skip replicas field when set to 0 for autoscaler(eg. KEDA) compatibility

### DIFF
--- a/molecule/default/tasks/awx_replicas_test.yml
+++ b/molecule/default/tasks/awx_replicas_test.yml
@@ -12,8 +12,8 @@
 
     - include_tasks: _test_case_replicas.yml
       vars:
-        expected_web_replicas: 0
-        expected_task_replicas: 0
+        expected_web_replicas: 1
+        expected_task_replicas: 1
 
 ####
 
@@ -43,8 +43,8 @@
 
     - include_tasks: _test_case_replicas.yml
       vars:
-        expected_web_replicas: 0
-        expected_task_replicas: 0
+        expected_web_replicas: 1
+        expected_task_replicas: 1
 
 ####
 

--- a/roles/installer/templates/deployments/task.yaml.j2
+++ b/roles/installer/templates/deployments/task.yaml.j2
@@ -8,9 +8,9 @@ metadata:
     {{ lookup("template", "../common/templates/labels/common.yaml.j2")  | indent(width=4) | trim }}
     {{ lookup("template", "../common/templates/labels/version.yaml.j2") | indent(width=4) | trim }}
 spec:
-{% if task_replicas != '' and task_manage_replicas | bool %}
+{% if task_replicas != '' and task_replicas|int != 0 and task_manage_replicas | bool %}
   replicas: {{ task_replicas }}
-{% elif replicas != '' and task_manage_replicas | bool %}
+{% elif replicas != '' and replicas|int != 0 and task_manage_replicas | bool %}
   replicas: {{ replicas }}
 {% endif %}
   selector:

--- a/roles/installer/templates/deployments/web.yaml.j2
+++ b/roles/installer/templates/deployments/web.yaml.j2
@@ -9,9 +9,9 @@ metadata:
     {{ lookup("template", "../common/templates/labels/common.yaml.j2")  | indent(width=4) | trim }}
     {{ lookup("template", "../common/templates/labels/version.yaml.j2") | indent(width=4) | trim }}
 spec:
-{% if web_replicas != '' and web_manage_replicas | bool %}
+{% if web_replicas != '' and web_replicas|int != 0 and web_manage_replicas | bool %}
   replicas: {{ web_replicas }}
-{% elif replicas != '' and web_manage_replicas | bool %}
+{% elif replicas != '' and replicas|int != 0 and web_manage_replicas | bool %}
   replicas: {{ replicas }}
 {% endif %}
   selector:


### PR DESCRIPTION
##### SUMMARY
Skip replicas field definition when set to 0 to improve compatibility with Kubernetes autoscalers.
When replicas is explicitly set to 0, omitting the field from the Deployment spec allows autoscalers to take full control of scaling decisions without conflicts.
This approach has the advantage of explicitly indicating that the workload is managed by external autoscaling solutions, making the scaling ownership clear in the deployment configuration.

##### ISSUE TYPE
 - New or Enhanced Feature

##### ADDITIONAL INFORMATION
Modified the replicas condition logic in both task.yaml.j2 and web.yaml.j2 templates to add `|int != 0` checks.
This ensures that when `task_replicas`, `web_replicas`, or `replicas` variables are set to 0,
the replicas field is completely omitted from the generated Deployment manifest.

**Before:**
```yaml
spec:
  replicas: 0  # Explicitly defined, can interfere with autoscalers

After:
spec:
  # replicas field omitted when set to 0, Kubernetes defaults to 1
```
This change enables seamless integration with various Kubernetes autoscaling solutions (HPA, VPA, KEDA, etc.) that require complete control over replica management.

Test Updates:
Updated molecule test expectations to reflect the new behavior where omitted replicas field defaults to 1 instead of 0.