### PR TITLE
Use --no-acl flag when restoring to exclude GRANT and REVOKE commands

### DIFF
--- a/roles/restore/tasks/postgres.yml
+++ b/roles/restore/tasks/postgres.yml
@@ -83,7 +83,7 @@
 - name: Set pg_restore command
   set_fact:
     pg_restore: >-
-      pg_restore --clean --if-exists
+      pg_restore --clean --if-exists --no-owner --no-acl
       -U {{ awx_postgres_user }}
       -h {{ resolvable_db_host }}
       -d {{ awx_postgres_database }}


### PR DESCRIPTION
##### SUMMARY

Use --no-acl flag when restoring to exclude GRANT and REVOKE commands

  This avoids running in to the following error when pg_restore is run as
  the application db user from the db-management pod:

  pg_restore: error: could not execute query: ERROR: must be member of role postgres
  Command was: ALTER SCHEMA public OWNER TO postgres;


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change


