### PR TITLE
Collect logs with greater determination

### DIFF
--- a/molecule/default/utils/output_all_container_logs_for_pod.yml
+++ b/molecule/default/utils/output_all_container_logs_for_pod.yml
@@ -5,10 +5,21 @@
     name: '{{ item.metadata.name }}'
     all_containers: true
   register: all_container_logs
+  ignore_errors: yes
 
 - name: Store logs in file
   ansible.builtin.copy:
-    content: "{{ all_container_logs.log_lines | join('\n') }}"
+    content: |-
+      {% if all_container_logs is failed %}
+      Failed to retrieve logs for pod {{ item.metadata.name }}:
+      {{ all_container_logs.msg | default(all_container_logs.stderr | default('No additional details provided.')) }}
+      {% elif all_container_logs.log_lines is defined %}
+      {{ all_container_logs.log_lines | join('\n') }}
+      {% elif all_container_logs.log is defined %}
+      {{ all_container_logs.log }}
+      {% else %}
+      No log content returned by kubernetes.core.k8s_log.
+      {% endif %}
     dest: '{{ debug_output_dir }}/{{ item.metadata.name }}.log'
 
 # TODO: all_containser option dump all of the output in a single output make it hard to read we probably should iterate through each of the container to get specific logs


### PR DESCRIPTION
##### SUMMARY
we saw a 500 error from web but didn't get traceback which should be in stdout.

This presumably fixes that, as current code seems to give up when it doesn't see a container

```
2025-11-04T13:16:08.9157852Z TASK [Get all container log in pod] ********************************************
2025-11-04T13:16:09.7736840Z [ERROR]: Task failed: Module failed: Unable to retrieve log from Pod due to: container "example-awx-ee" in pod "example-awx-task-6dbd9bc5dd-pk49f" is waiting to start: PodInitializing
2025-11-04T13:16:09.7738474Z Origin: /home/runner/work/awx/awx/awx-operator/molecule/default/utils/output_all_container_logs_for_pod.yml:2:3
2025-11-04T13:16:09.7739173Z 
2025-11-04T13:16:09.7740601Z 1 ---
2025-11-04T13:16:09.7742062Z 2 - name: Get all container log in pod
2025-11-04T13:16:09.7743497Z     ^ column 3
2025-11-04T13:16:09.7744804Z 
2025-11-04T13:16:09.7748606Z fatal: [localhost]: FAILED! => {"changed": false, "msg": "Unable to retrieve log from Pod due to: container \"example-awx-ee\" in pod \"example-awx-task-6dbd9bc5dd-pk49f\" is waiting to start: PodInitializing"}
2025-11-04T13:16:09.7749379Z 
```

You can kind of see here how it panics when a single container doesn't exist, and playbook ends. This is all fine when all tests pass, but almost certainly wrong in error cases.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

