### PR TITLE
Add tolerations for Postgres pods in backup and restore management

### DIFF
--- a/roles/backup/defaults/main.yml
+++ b/roles/backup/defaults/main.yml
@@ -28,6 +28,18 @@ clean_backup_on_delete: false
 #   kubernetes.io/os: linux
 db_management_pod_node_selector: ''
 
+# Add tolerations for the Postgres pods to backup.
+# Specify as a list of dicts. E.g.:
+# db_management_pod_tolerations:
+#   - key: "key1"
+#     operator: "Equal"
+#     value: "value1"
+#     effect: "NoSchedule"
+#   - key: "key2"
+#     operator: "Exists"
+#     effect: "NoExecute"
+db_management_pod_tolerations: []
+
 # Variable to signal that this role is being run as a finalizer
 finalizer_run: false
 

--- a/roles/backup/templates/management-pod.yml.j2
+++ b/roles/backup/templates/management-pod.yml.j2
@@ -24,6 +24,10 @@ spec:
   nodeSelector:
         {{ db_management_pod_node_selector | indent(width=8) }}
 {% endif %}
+{% if db_management_pod_tolerations %}
+  tolerations:
+        {{ db_management_pod_tolerations | indent(width=8) }}
+{% endif %}
   volumes:
     - name: {{ ansible_operator_meta.name }}-backup
       persistentVolumeClaim:

--- a/roles/restore/defaults/main.yml
+++ b/roles/restore/defaults/main.yml
@@ -24,6 +24,17 @@ no_log: true
 #   kubernetes.io/os: linux
 db_management_pod_node_selector: ''
 
+# Add tolerations for the Postgres pods to backup.
+# Specify as a list of dicts. E.g.:
+# db_management_pod_tolerations:
+#   - key: "key1"
+#     operator: "Equal"
+#     value: "value1"
+#     effect: "NoSchedule"
+#   - key: "key2"
+#     operator: "Exists"
+#     effect: "NoExecute"
+db_management_pod_tolerations: []
 
 # Default resource requirements
 restore_resource_requirements:

--- a/roles/restore/templates/management-pod.yml.j2
+++ b/roles/restore/templates/management-pod.yml.j2
@@ -24,6 +24,10 @@ spec:
       nodeSelector:
         {{ db_management_pod_node_selector | indent(width=8) }}
 {% endif %}
+{% if db_management_pod_tolerations %}
+      tolerations:
+        {{ db_management_pod_tolerations | indent(width=8) }}
+{% endif %}
   volumes:
     - name: {{ ansible_operator_meta.name }}-backup
       persistentVolumeClaim:


### PR DESCRIPTION
##### SUMMARY
This pull request adds support for specifying Kubernetes tolerations for the db-management pods in both backup and restore ansible roles. This allows the pods to be scheduled on nodes with specific taints, improving deployment flexibility.

Kubernetes tolerations support:

* Added a new variable `db_management_pod_tolerations` to `roles/backup/defaults/main.yml` for configuring tolerations as a list of dictionaries.
* Added a new variable `db_management_pod_tolerations` to `roles/restore/defaults/main.yml` for configuring tolerations as a list of dictionaries.
* Updated the `roles/backup/templates/management-pod.yml.j2` template to inject the `tolerations` field into the pod spec if `db_management_pod_tolerations` is set.
* Updated the `roles/restore/templates/management-pod.yml.j2` template to similarly inject the `tolerations` field for restore management pods.

##### ISSUE TYPE

 - New or Enhanced Feature

##### ADDITIONAL INFORMATION

This fixes issues like https://github.com/ansible/awx-operator/issues/1774 and it is similar to what was requested here https://github.com/ansible/awx-operator/pull/1853
