### PR TITLE
django: Add --no-imports option

### DIFF
--- a/roles/installer/tasks/initialize_django.yml
+++ b/roles/installer/tasks/initialize_django.yml
@@ -8,7 +8,7 @@
       bash -c "echo 'from django.contrib.auth.models import User;
       nsu = User.objects.filter(is_superuser=True, username=\"{{ admin_user }}\").count();
       exit(0 if nsu > 0 else 1)'
-      | awx-manage shell"
+      | awx-manage shell --no-imports"
   ignore_errors: true
   register: users_result
   changed_when: users_result.return_code > 0


### PR DESCRIPTION
##### SUMMARY

With django updated to 5.2 then the django shell commands load imports at startup which flood stdout with logs and break workflows

##### ISSUE TYPE
 - Breaking Change 

##### ADDITIONAL INFORMATION
https://docs.djangoproject.com/en/dev/releases/5.2/#automatic-models-import-in-the-shell

Adding --no-imports to the cli call solves the issue.

https://docs.djangoproject.com/en/5.2/ref/django-admin/#cmdoption-shell-no-imports