### PR TITLE
web: Update python path for rediect page

### DIFF
--- a/roles/installer/templates/deployments/web.yaml.j2
+++ b/roles/installer/templates/deployments/web.yaml.j2
@@ -202,7 +202,7 @@ spec:
           volumeMounts:
 {% if public_base_url is defined %}
             - name: redirect-page
-              mountPath: '/var/lib/awx/venv/awx/lib/python3.11/site-packages/awx/ui/build/index.html'
+              mountPath: '/var/lib/awx/venv/awx/lib/python3.12/site-packages/awx/ui/build/index.html'
               subPath: redirect-page.html
 {% endif %}
 {% if bundle_ca_crt %}


### PR DESCRIPTION
##### SUMMARY
The application container image is now using python3.12 so we need to update the associated volume mount for the redirect page.

##### ISSUE TYPE
 - Breaking Change 