### PR TITLE
Add automatic backup PVC creation with create_backup_pvc option

### DIFF
--- a/config/crd/bases/awx.ansible.com_awxbackups.yaml
+++ b/config/crd/bases/awx.ansible.com_awxbackups.yaml
@@ -48,6 +48,10 @@ spec:
               backup_pvc:
                 description: Name of the backup PVC
                 type: string
+              create_backup_pvc:
+                description: If true (default), automatically create the backup PVC if it does not exist
+                type: boolean
+                default: true
               backup_pvc_namespace:
                 description: (Deprecated) Namespace the PVC is in
                 type: string

--- a/roles/backup/defaults/main.yml
+++ b/roles/backup/defaults/main.yml
@@ -8,6 +8,9 @@ api_version: '{{ deployment_type }}.ansible.com/v1beta1'
 backup_pvc: ''
 backup_pvc_namespace: "{{ ansible_operator_meta.namespace }}"
 
+# If true (default), automatically create the backup PVC if it does not exist
+create_backup_pvc: true
+
 # Size of backup PVC if created dynamically
 backup_storage_requirements: ''
 

--- a/roles/backup/tasks/init.yml
+++ b/roles/backup/tasks/init.yml
@@ -22,17 +22,18 @@
   block:
     - name: Set error message
       set_fact:
-        error_msg: "{{ backup_pvc }} does not exist, please create this pvc first."
+        error_msg: "{{ backup_pvc }} does not exist, please create this pvc first or ensure create_backup_pvc is set to true (default) for automatic backup_pvc creation."
 
     - name: Handle error
       import_tasks: error_handling.yml
 
     - name: Fail early if pvc is defined but does not exist
       fail:
-        msg: "{{ backup_pvc }} does not exist, please create this pvc first."
+        msg: "{{ backup_pvc }} does not exist, please create this pvc first or ensure create_backup_pvc is set to true (default) for automatic backup_pvc creation."
   when:
     - backup_pvc != ''
     - provided_pvc.resources | length == 0
+    - not create_backup_pvc | bool
 
 # If backup_pvc is defined, use in management-pod.yml.j2
 - name: Set default pvc name
@@ -60,7 +61,7 @@
             namespace: "{{ backup_pvc_namespace }}"
             ownerReferences: null
   when:
-    - backup_pvc == '' or backup_pvc is not defined
+    - (backup_pvc == '' or backup_pvc is not defined) or (create_backup_pvc | bool)
 
 - name: Set default postgres image
   set_fact:


### PR DESCRIPTION
##### SUMMARY

When users specify a custom backup_pvc name, the operator now automatically creates the PVC instead of failing with "does not exist, please create this pvc first."

Changes:
- Add create_backup_pvc variable (default: true) to backup defaults
- Update error condition to check create_backup_pvc before failing
- Update PVC creation condition to include create_backup_pvc
- Add create_backup_pvc field to AWXBackup CRD

Users who want the previous behavior can set create_backup_pvc: false.

##### ISSUE TYPE
 - New or Enhanced Feature