### PR TITLE
[AAP-64061] Add nginx log markers for direct API access detection

### DIFF
--- a/roles/installer/templates/configmaps/config.yaml.j2
+++ b/roles/installer/templates/configmaps/config.yaml.j2
@@ -111,11 +111,23 @@ data:
         server_tokens off;
         client_max_body_size {{ nginx_client_max_body_size }}M;
 
+        map $http_x_trusted_proxy $trusted_proxy_present {
+            default "trusted-proxy";
+            ""      "-";
+        }
+
+        map $http_x_dab_jw_token $dab_jwt_present {
+            default "dab-jwt";
+            ""      "-";
+        }
+
         log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
                           '$status $body_bytes_sent "$http_referer" '
-                          '"$http_user_agent" "$http_x_forwarded_for"';
+                          '"$http_user_agent" "$http_x_forwarded_for" '
+                          '$trusted_proxy_present $dab_jwt_present';
 
         access_log /dev/stdout main;
+        error_log /dev/stderr warn;
 
         map $http_upgrade $connection_upgrade {
             default upgrade;


### PR DESCRIPTION
## Summary

- Add `map` directives for `X-Trusted-Proxy` and `X-DAB-JW-TOKEN` headers
- Update `log_format` to append `$trusted_proxy_present` and `$dab_jwt_present` fields
- Add explicit `error_log /dev/stderr warn;`

These markers enable the CLI detection tool ([aap-detect-direct-component-access](https://github.com/ansible/aap-detect-direct-component-access)) to identify direct API access that bypasses AAP Gateway by scanning nginx logs from SOSReport or must-gather.

## Jira

- [AAP-64061](https://issues.redhat.com/browse/AAP-64061)
- [ANSTRAT-1840](https://issues.redhat.com/browse/ANSTRAT-1840)

##### ISSUE TYPE

 - New or Enhanced Feature

## Test plan

- [ ] Nginx logs contain `trusted-proxy`/`dab-jwt` or `-` fields appended to existing format
- [ ] Requests through Gateway show `trusted-proxy dab-jwt`
- [ ] Direct requests show `- -`
- [ ] Lightspeed traffic shows `- dab-jwt` (JWT without Trusted-Proxy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)