### PR TITLE
ci: Update DOCKER_API_VERSION to 1.44

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
           - --skip-tags=replicas
           - -t replicas
     env:
-      DOCKER_API_VERSION: "1.41"
+      DOCKER_API_VERSION: "1.44"
       DEBUG_OUTPUT_DIR: /tmp/awx_operator_molecule_test
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Update `DOCKER_API_VERSION` from `1.41` to `1.44` in CI workflow
- The Docker daemon on `ubuntu-latest` runners now requires minimum API version 1.44, causing molecule kind tests (`-t replicas`) to fail during cluster teardown with: `client version 1.41 is too old. Minimum supported API version is 1.44`

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

## Test plan
- [x] Verify molecule CI passes for both matrix jobs (`--skip-tags=replicas` and `-t replicas`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)