### PR TITLE
Fix AWXRestore multiple bugs

### DIFF
--- a/roles/restore/defaults/main.yml
+++ b/roles/restore/defaults/main.yml
@@ -40,5 +40,8 @@ additional_labels: []
 # Maintain some of the recommended `app.kubernetes.io/*` labels on the resource (self)
 set_self_labels: true
 
+# If set to true, the restore process will drop and recreate the database schema before restoring
+force_drop_db: false
+
 spec_overrides: {}
 ...

--- a/roles/restore/tasks/postgres.yml
+++ b/roles/restore/tasks/postgres.yml
@@ -83,12 +83,23 @@
 - name: Set pg_restore command
   set_fact:
     pg_restore: >-
-      pg_restore --clean --if-exists --no-owner --no-acl
+      pg_restore {{ force_drop_db | bool | ternary('', '--clean --if-exists') }} --no-owner --no-acl
       -U {{ awx_postgres_user }}
       -h {{ resolvable_db_host }}
       -d {{ awx_postgres_database }}
       -p {{ awx_postgres_port }}
   no_log: "{{ no_log }}"
+
+- name: Grant CREATEDB privilege to database user for force_drop_db
+  kubernetes.core.k8s_exec:
+    namespace: "{{ ansible_operator_meta.namespace }}"
+    pod: "{{ postgres_pod_name }}"
+    container: postgres
+    command: >-
+      psql -c "ALTER USER {{ awx_postgres_user }} CREATEDB;"
+  when:
+    - force_drop_db | bool
+    - awx_postgres_type == 'managed'
 
 - name: Force drop and create database if force_drop_db is true
   block:
@@ -155,3 +166,14 @@
       "
   register: data_migration
   no_log: "{{ no_log }}"
+
+- name: Revoke CREATEDB privilege from database user
+  kubernetes.core.k8s_exec:
+    namespace: "{{ ansible_operator_meta.namespace }}"
+    pod: "{{ postgres_pod_name }}"
+    container: postgres
+    command: >-
+      psql -c "ALTER USER {{ awx_postgres_user }} NOCREATEDB;"
+  when:
+    - force_drop_db | bool
+    - awx_postgres_type == 'managed'

--- a/roles/restore/vars/main.yml
+++ b/roles/restore/vars/main.yml
@@ -14,7 +14,4 @@ broadcast_websocket_secret: '{{ deployment_name }}-broadcast-websocket'
 postgres_configuration_secret: '{{ deployment_name }}-postgres-configuration'
 supported_pg_version: 15
 image_pull_policy: IfNotPresent
-
-# If set to true, the restore process will delete the existing database and create a new one
-force_drop_db: false
 pg_drop_create: ''


### PR DESCRIPTION
##### SUMMARY
- Move force_drop_db from vars/main.yml to defaults/main.yml so CR spec values are not overridden by Ansible variable precedence
- Grant CREATEDB priv to database user before DROP/CREATE and revoke it after restore, following the containerized-installer pattern
- Omit --clean --if-exists from pg_restore when force_drop_db is true since the database is freshly created and empty, avoiding partition index dependency errors

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION
Fixes: #2093 