### PR TITLE
Fix custom backup PVC name not used with create_backup_pvc

### DIFF
--- a/roles/backup/tasks/init.yml
+++ b/roles/backup/tasks/init.yml
@@ -43,7 +43,7 @@
 # by default, it will re-use the old pvc if already created (unless a pvc is provided)
 - name: Set PVC to use for backup
   set_fact:
-    backup_claim: "{{ backup_pvc | default(_default_backup_pvc, true) }}"
+    backup_pvc: "{{ backup_pvc | default(_default_backup_pvc, true) }}"
 
 - block:
     - name: Create PVC for backup
@@ -57,7 +57,7 @@
           apiVersion: v1
           kind: PersistentVolumeClaim
           metadata:
-            name: "{{ deployment_name }}-backup-claim"
+            name: "{{ backup_pvc }}"
             namespace: "{{ backup_pvc_namespace }}"
             ownerReferences: null
   when:

--- a/roles/backup/tasks/update_status.yml
+++ b/roles/backup/tasks/update_status.yml
@@ -9,5 +9,5 @@
     namespace: "{{ ansible_operator_meta.namespace }}"
     status:
       backupDirectory: "{{ backup_dir }}"
-      backupClaim: "{{ backup_claim }}"
+      backupClaim: "{{ backup_pvc }}"
   when: backup_complete

--- a/roles/backup/templates/backup_pvc.yml.j2
+++ b/roles/backup/templates/backup_pvc.yml.j2
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: {{ deployment_name }}-backup-claim
+  name: {{ backup_pvc }}
   namespace: "{{ backup_pvc_namespace }}"
   ownerReferences: null
   labels:

--- a/roles/backup/templates/management-pod.yml.j2
+++ b/roles/backup/templates/management-pod.yml.j2
@@ -27,6 +27,6 @@ spec:
   volumes:
     - name: {{ ansible_operator_meta.name }}-backup
       persistentVolumeClaim:
-        claimName: {{ backup_claim }}
+        claimName: {{ backup_pvc }}
         readOnly: false
   restartPolicy: Never


### PR DESCRIPTION
## ISSUE TYPE

New or Enhanced Feature

## Summary

Fix custom backup PVC name not being used when `create_backup_pvc: true` and `backup_pvc` is specified.

## Problem

When a user specifies `backup_pvc: my-custom-pvc` with `create_backup_pvc: true`, the operator creates a PVC named `{deployment_name}-backup-claim` (the hardcoded default) instead of `my-custom-pvc`. The management pod then tries to mount the custom-named PVC which doesn't exist, causing the backup to hang.

The `backup_claim` variable was correctly resolved from `backup_pvc`, but the PVC template and ownerReference removal used the hardcoded `{{ deployment_name }}-backup-claim` name instead.

## Solution

Replace the `backup_claim` variable with `backup_pvc` throughout the backup role. The `set_fact` now resolves `backup_pvc` directly (defaulting to `{deployment_name}-backup-claim` when not specified), and all templates reference `{{ backup_pvc }}`.

## Changes

- `roles/backup/tasks/init.yml`: `set_fact` resolves `backup_pvc` instead of `backup_claim`; ownerRef removal uses `{{ backup_pvc }}`
- `roles/backup/templates/backup_pvc.yml.j2`: PVC name uses `{{ backup_pvc }}`
- `roles/backup/templates/management-pod.yml.j2`: `claimName` uses `{{ backup_pvc }}`
- `roles/backup/tasks/update_status.yml`: `backupClaim` uses `{{ backup_pvc }}`

## Testing

Tested on MicroShift with custom backup PVC names and sizes per component. All PVCs created with correct custom names and backup completed successfully.