### PR TITLE
Add use_db_compression option for backup database dumps

### DIFF
--- a/config/crd/bases/awx.ansible.com_awxbackups.yaml
+++ b/config/crd/bases/awx.ansible.com_awxbackups.yaml
@@ -88,6 +88,10 @@ spec:
               pg_dump_suffix:
                 description: Additional parameters for the pg_dump command
                 type: string
+              use_db_compression:
+                description: Enable compression for database dumps using pg_dump built-in compression.
+                type: boolean
+                default: true
               postgres_label_selector:
                 description: Label selector used to identify postgres pod for backing up data
                 type: string

--- a/config/manifests/bases/awx-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/awx-operator.clusterserviceversion.yaml
@@ -175,6 +175,12 @@ spec:
         path: additional_labels
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
+      - description: Enable compression for database dumps using pg_dump built-in compression
+        displayName: Use DB Compression
+        path: use_db_compression
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - displayName: Node Selector for backup management pod
         path: db_management_pod_node_selector
         x-descriptors:

--- a/roles/backup/defaults/main.yml
+++ b/roles/backup/defaults/main.yml
@@ -42,6 +42,9 @@ backup_resource_requirements:
 # Allow additional parameters to be added to the pg_dump backup command
 pg_dump_suffix: ''
 
+# Enable compression for database dumps (pg_dump -F custom built-in compression)
+use_db_compression: true
+
 # Labels defined on the resource, which should be propagated to child resources
 additional_labels: []
 

--- a/roles/backup/tasks/postgres.yml
+++ b/roles/backup/tasks/postgres.yml
@@ -121,6 +121,7 @@
       -d {{ awx_postgres_database }}
       -p {{ awx_postgres_port }}
       -F custom
+      {{ use_db_compression | bool | ternary('', '-Z 0') }}
       {{ pg_dump_suffix }}
   no_log: "{{ no_log }}"
 


### PR DESCRIPTION
## Summary
- Add `use_db_compression` boolean field (default: `true`) to AWXBackup CRD and backup role defaults
- When enabled (default), pg_dump uses its built-in compression within the custom format
- When disabled, passes `-Z 0` to pg_dump for uncompressed dumps
- `pg_restore` handles both compressed and uncompressed custom-format dumps transparently — no restore logic changes needed

Part of AAP-38759 (OCP Operator DB Compression).

## ISSUE TYPE
- New or Enhanced Feature

## Test plan
- [ ] Create AWXBackup with default `use_db_compression: true` — verify backup succeeds
- [ ] Create AWXBackup with `use_db_compression: false` — verify uncompressed backup succeeds
- [ ] Restore from a compressed backup — verify succeeds
- [ ] Restore from an uncompressed backup — verify succeeds
- [ ] Run molecule tests