### PR TITLE
Add create_superuser option to skip admin user creation

### DIFF
--- a/config/crd/bases/awx.ansible.com_awxs.yaml
+++ b/config/crd/bases/awx.ansible.com_awxs.yaml
@@ -1691,6 +1691,10 @@ spec:
                 description: Whether or not to preload data upon instance creation
                 default: true
                 type: boolean
+              create_superuser:
+                description: Whether to create the admin superuser during installation. Set to false when deploying as part of AAP where the gateway admin user is used instead.
+                default: true
+                type: boolean
               task_args:
                 type: array
                 items:

--- a/config/manifests/bases/awx-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/awx-operator.clusterserviceversion.yaml
@@ -610,6 +610,11 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - displayName: Create admin superuser during installation?
+        path: create_superuser
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - displayName: Deploy the instance in development mode?
         path: development_mode
         x-descriptors:

--- a/roles/installer/defaults/main.yml
+++ b/roles/installer/defaults/main.yml
@@ -524,3 +524,7 @@ extra_settings_files: {}
 
 # idle_deployment - Scale down deployments to put AWX into an idle state
 idle_deployment: false
+
+# create_superuser - Whether to create the admin superuser during installation.
+# Set to false when deploying as part of AAP where the gateway admin user is used instead.
+create_superuser: true

--- a/roles/installer/tasks/initialize_django.yml
+++ b/roles/installer/tasks/initialize_django.yml
@@ -1,40 +1,43 @@
 ---
-- name: Check if there are any super users defined.
-  k8s_exec:
-    namespace: "{{ ansible_operator_meta.namespace }}"
-    pod: "{{ awx_web_pod_name }}"
-    container: "{{ ansible_operator_meta.name }}-web"
-    command: >-
-      bash -c "echo 'from django.contrib.auth.models import User;
-      nsu = User.objects.filter(is_superuser=True, username=\"{{ admin_user }}\").count();
-      exit(0 if nsu > 0 else 1)'
-      | awx-manage shell --no-imports"
-  ignore_errors: true
-  register: users_result
-  changed_when: users_result.return_code > 0
+- name: Create/update super user
+  when: create_superuser | bool
+  block:
+    - name: Check if there are any super users defined.
+      k8s_exec:
+        namespace: "{{ ansible_operator_meta.namespace }}"
+        pod: "{{ awx_web_pod_name }}"
+        container: "{{ ansible_operator_meta.name }}-web"
+        command: >-
+          bash -c "echo 'from django.contrib.auth.models import User;
+          nsu = User.objects.filter(is_superuser=True, username=\"{{ admin_user }}\").count();
+          exit(0 if nsu > 0 else 1)'
+          | awx-manage shell --no-imports"
+      ignore_errors: true
+      register: users_result
+      changed_when: users_result.return_code > 0
 
-- name: Create super user via Django if it doesn't exist.
-  k8s_exec:
-    namespace: "{{ ansible_operator_meta.namespace }}"
-    pod: "{{ awx_web_pod_name }}"
-    container: "{{ ansible_operator_meta.name }}-web"
-    command: bash -c "ANSIBLE_REVERSE_RESOURCE_SYNC=false awx-manage createsuperuser --username={{ admin_user | quote }} --email={{ admin_email | quote }} --noinput"
-  register: result
-  changed_when: "'That username is already taken' not in result.stderr"
-  failed_when: "'That username is already taken' not in result.stderr and 'Superuser created successfully' not in result.stdout"
-  no_log: "{{ no_log }}"
-  when: users_result.return_code > 0
+    - name: Create super user via Django if it doesn't exist.
+      k8s_exec:
+        namespace: "{{ ansible_operator_meta.namespace }}"
+        pod: "{{ awx_web_pod_name }}"
+        container: "{{ ansible_operator_meta.name }}-web"
+        command: bash -c "ANSIBLE_REVERSE_RESOURCE_SYNC=false awx-manage createsuperuser --username={{ admin_user | quote }} --email={{ admin_email | quote }} --noinput"
+      register: result
+      changed_when: "'That username is already taken' not in result.stderr"
+      failed_when: "'That username is already taken' not in result.stderr and 'Superuser created successfully' not in result.stdout"
+      no_log: "{{ no_log }}"
+      when: users_result.return_code > 0
 
-- name: Update Django super user password
-  k8s_exec:
-    namespace: "{{ ansible_operator_meta.namespace }}"
-    pod: "{{ awx_web_pod_name }}"
-    container: "{{ ansible_operator_meta.name }}-web"
-    command: awx-manage update_password --username='{{ admin_user }}' --password='{{ admin_password }}'
-  register: result
-  changed_when: "'Password updated' in result.stdout"
-  no_log: "{{ no_log }}"
-  when: users_result.return_code > 0
+    - name: Update Django super user password
+      k8s_exec:
+        namespace: "{{ ansible_operator_meta.namespace }}"
+        pod: "{{ awx_web_pod_name }}"
+        container: "{{ ansible_operator_meta.name }}-web"
+        command: awx-manage update_password --username='{{ admin_user }}' --password='{{ admin_password }}'
+      register: result
+      changed_when: "'Password updated' in result.stdout"
+      no_log: "{{ no_log }}"
+      when: users_result.return_code > 0
 
 - name: Check if legacy queue is present
   k8s_exec:

--- a/roles/installer/tasks/install.yml
+++ b/roles/installer/tasks/install.yml
@@ -67,6 +67,7 @@
 
 - name: Include admin password configuration tasks
   include_tasks: admin_password_configuration.yml
+  when: create_superuser | bool
 
 - name: Include broadcast websocket configuration tasks
   include_tasks: broadcast_websocket_configuration.yml


### PR DESCRIPTION
## Summary

When deploying AWX as part of AAP where all authentication goes through the AAP Gateway, the component-level admin user is not needed. This PR adds a boolean `create_superuser` field (default: `true`) that allows operators to opt out of creating the admin superuser during installation.

## Changes

- `roles/installer/defaults/main.yml` — add `create_superuser: true` default
- `roles/installer/tasks/install.yml` — skip `admin_password_configuration` when `create_superuser=false`
- `roles/installer/tasks/initialize_django.yml` — wrap `createsuperuser` + `update_password` in a block gated by `create_superuser | bool`

## Behavior

When `create_superuser: false`:
- The `<name>-admin-password` K8s Secret is not created
- `awx-manage createsuperuser` is not run
- `awx-manage update_password` is not run

When `create_superuser: true` (default): no change to existing behavior.

## Context

In AAP 2.7, direct API access to platform components (Controller, Hub, EDA) is being removed. All authentication is centralized through the AAP Gateway. The component-level admin user was previously needed for installer post-install tasks (license upload, postinstall config), but those have since been updated to use gateway credentials. There is no remaining post-creation caller for the controller admin user in the installer or operator.

Relates-to: AAP-68980

🤖 Generated with [Claude Code](https://claude.com/claude-code)