### PR TITLE
Fix unquoted timestamps in backup/restore event templates

### DIFF
--- a/roles/backup/templates/event.yml.j2
+++ b/roles/backup/templates/event.yml.j2
@@ -12,6 +12,6 @@ involvedObject:
 message: {{ error_msg }}
 reason: BackupFailed
 type: Warning
-firstTimestamp: {{ now }}
-lastTimestamp: {{ now }}
+firstTimestamp: "{{ now }}"
+lastTimestamp: "{{ now }}"
 count: 1

--- a/roles/restore/templates/event.yml.j2
+++ b/roles/restore/templates/event.yml.j2
@@ -12,6 +12,6 @@ involvedObject:
 message: {{ error_msg }}
 reason: RestoreFailed
 type: Warning
-firstTimestamp: {{ now }}
-lastTimestamp: {{ now }}
+firstTimestamp: "{{ now }}"
+lastTimestamp: "{{ now }}"
 count: 1


### PR DESCRIPTION
##### SUMMARY

Quote `{{ now }}` in `firstTimestamp` and `lastTimestamp` fields in event templates
to prevent PyYAML from converting the value to a datetime object, which can cause
Event creation to fail and mask the real error message.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change