### PR TITLE
feat: add proxy env var support for AWX containers

### DIFF
--- a/config/crd/bases/awx.ansible.com_awxs.yaml
+++ b/config/crd/bases/awx.ansible.com_awxs.yaml
@@ -1901,6 +1901,15 @@ spec:
               bundle_cacert_secret:
                 description: Secret where can be found the trusted Certificate Authority Bundle
                 type: string
+              http_proxy:
+                description: HTTP proxy URL to configure on AWX containers
+                type: string
+              https_proxy:
+                description: HTTPS proxy URL to configure on AWX containers
+                type: string
+              no_proxy:
+                description: Comma-separated list of hosts that bypass the proxy on AWX containers
+                type: string
               projects_persistence:
                 description: Whether or not the /var/lib/projects directory will be persistent
                 default: false

--- a/config/manifests/bases/awx-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/awx-operator.clusterserviceversion.yaml
@@ -1074,6 +1074,24 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:io.kubernetes:Secret
+      - description: HTTP proxy URL to configure on AWX containers
+        displayName: HTTP Proxy
+        path: http_proxy
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: HTTPS proxy URL to configure on AWX containers
+        displayName: HTTPS Proxy
+        path: https_proxy
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Comma-separated list of hosts that bypass the proxy on AWX containers
+        displayName: No Proxy
+        path: no_proxy
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:text
       - displayName: Nodeport Port
         path: nodeport_port
         x-descriptors:

--- a/config/samples/awx_v1beta1_awx.yaml
+++ b/config/samples/awx_v1beta1_awx.yaml
@@ -16,3 +16,7 @@ spec:
     requests:
       cpu: 50m
       memory: 64M
+  # HTTP proxy settings (optional)
+  # http_proxy: "http://proxy.example.com:3128"
+  # https_proxy: "http://proxy.example.com:3128"
+  # no_proxy: "localhost,127.0.0.1,.cluster.local"

--- a/roles/installer/defaults/main.yml
+++ b/roles/installer/defaults/main.yml
@@ -459,6 +459,14 @@ ldap_password_secret: ''
 # Secret to lookup that provides the custom CA trusted bundle
 bundle_cacert_secret: ''
 
+# Proxy environment variables for AWX containers.
+# Defaults inherit from the operator pod environment (e.g. set by the OCP cluster
+# proxy object). Set these fields in the CR spec to override the inherited values
+# per instance.
+http_proxy: "{{ lookup('env', 'http_proxy') or lookup('env', 'HTTP_PROXY') or '' }}"
+https_proxy: "{{ lookup('env', 'https_proxy') or lookup('env', 'HTTPS_PROXY') or '' }}"
+no_proxy: "{{ lookup('env', 'no_proxy') or lookup('env', 'NO_PROXY') or '' }}"
+
 # Set false for basic install without operator
 update_status: true
 

--- a/roles/installer/tasks/install.yml
+++ b/roles/installer/tasks/install.yml
@@ -50,6 +50,12 @@
     definition: "{{ lookup('template', 'configmaps/redirect-page.configmap.html.j2') }}"
   when: public_base_url is defined
 
+- name: Apply proxy environment ConfigMap
+  k8s:
+    apply: true
+    definition: "{{ lookup('template', 'configmaps/proxy-env.configmap.yaml.j2') }}"
+    state: "{{ 'present' if (http_proxy or https_proxy or no_proxy) else 'absent' }}"
+
 - name: Load LDAP CAcert certificate (Deprecated)
   include_tasks: load_ldap_cacert_secret.yml
   when:

--- a/roles/installer/templates/configmaps/proxy-env.configmap.yaml.j2
+++ b/roles/installer/templates/configmaps/proxy-env.configmap.yaml.j2
@@ -1,0 +1,19 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: '{{ ansible_operator_meta.name }}-proxy-env'
+  namespace: '{{ ansible_operator_meta.namespace }}'
+data:
+{% if http_proxy %}
+  HTTP_PROXY: '{{ http_proxy }}'
+  http_proxy: '{{ http_proxy }}'
+{% endif %}
+{% if https_proxy %}
+  HTTPS_PROXY: '{{ https_proxy }}'
+  https_proxy: '{{ https_proxy }}'
+{% endif %}
+{% if no_proxy %}
+  NO_PROXY: '{{ no_proxy }}'
+  no_proxy: '{{ no_proxy }}'
+{% endif %}

--- a/roles/installer/templates/deployments/task.yaml.j2
+++ b/roles/installer/templates/deployments/task.yaml.j2
@@ -49,6 +49,9 @@ spec:
 {% elif annotations %}
         {{ annotations | indent(width=8) }}
 {% endif %}
+{% if http_proxy or https_proxy or no_proxy %}
+        checksum-configmaps-proxy-env: "{{ lookup('template', 'configmaps/proxy-env.configmap.yaml.j2') | sha1 }}"
+{% endif %}
     spec:
       serviceAccountName: '{{ ansible_operator_meta.name }}'
 {% if image_pull_secret is defined %}
@@ -351,6 +354,10 @@ spec:
 {% if task_extra_env -%}
             {{ task_extra_env | indent(width=12, first=True) }}
 {% endif %}
+          envFrom:
+            - configMapRef:
+                name: '{{ ansible_operator_meta.name }}-proxy-env'
+                optional: true
           resources: {{ task_resource_requirements }}
         - image: '{{ _control_plane_ee_image }}'
           name: '{{ ansible_operator_meta.name }}-ee'
@@ -414,6 +421,10 @@ spec:
 {% if ee_extra_env -%}
             {{ ee_extra_env | indent(width=12, first=True) }}
 {% endif %}
+          envFrom:
+            - configMapRef:
+                name: '{{ ansible_operator_meta.name }}-proxy-env'
+                optional: true
         - image: '{{ _image }}'
           name: '{{ ansible_operator_meta.name }}-rsyslog'
 {% if rsyslog_command %}
@@ -475,6 +486,10 @@ spec:
 {% if rsyslog_extra_env -%}
             {{ rsyslog_extra_env | indent(width=12, first=True) }}
 {% endif %}
+          envFrom:
+            - configMapRef:
+                name: '{{ ansible_operator_meta.name }}-proxy-env'
+                optional: true
 {% if task_node_selector %}
       nodeSelector:
         {{ task_node_selector | indent(width=8) }}

--- a/roles/installer/templates/deployments/web.yaml.j2
+++ b/roles/installer/templates/deployments/web.yaml.j2
@@ -52,6 +52,9 @@ spec:
 {% elif annotations %}
         {{ annotations | indent(width=8) }}
 {% endif %}
+{% if http_proxy or https_proxy or no_proxy %}
+        checksum-configmaps-proxy-env: "{{ lookup('template', 'configmaps/proxy-env.configmap.yaml.j2') | sha1 }}"
+{% endif %}
     spec:
 {% if uwsgi_listen_queue_size is defined and uwsgi_listen_queue_size|int > 128 %}
       securityContext:
@@ -300,6 +303,10 @@ spec:
 {% if web_extra_env -%}
             {{ web_extra_env | indent(width=12, first=True) }}
 {% endif %}
+          envFrom:
+            - configMapRef:
+                name: '{{ ansible_operator_meta.name }}-proxy-env'
+                optional: true
           resources: {{ web_resource_requirements }}
         - image: '{{ _image }}'
           name: '{{ ansible_operator_meta.name }}-rsyslog'
@@ -349,6 +356,10 @@ spec:
 {% if rsyslog_extra_env -%}
             {{ rsyslog_extra_env | indent(width=12, first=True) }}
 {% endif %}
+          envFrom:
+            - configMapRef:
+                name: '{{ ansible_operator_meta.name }}-proxy-env'
+                optional: true
           resources: {{ rsyslog_resource_requirements }}
 {% if web_node_selector %}
       nodeSelector:


### PR DESCRIPTION
##### SUMMARY
Add http_proxy, https_proxy, and no_proxy CRD fields to the AWX spec.

Add the proxy-aware OLM annotation to the CSV so that OLM injects cluster proxy configuration into the operator manager pod.

##### ISSUE TYPE
 - New or Enhanced Feature

##### ADDITIONAL INFORMATION
