### PR TITLE
refactor: remove proxy env var CRD fields and CSV specDescriptors

### DIFF
--- a/config/crd/bases/awx.ansible.com_awxs.yaml
+++ b/config/crd/bases/awx.ansible.com_awxs.yaml
@@ -1901,15 +1901,6 @@ spec:
               bundle_cacert_secret:
                 description: Secret where can be found the trusted Certificate Authority Bundle
                 type: string
-              http_proxy:
-                description: HTTP proxy URL to configure on AWX containers
-                type: string
-              https_proxy:
-                description: HTTPS proxy URL to configure on AWX containers
-                type: string
-              no_proxy:
-                description: Comma-separated list of hosts that bypass the proxy on AWX containers
-                type: string
               projects_persistence:
                 description: Whether or not the /var/lib/projects directory will be persistent
                 default: false

--- a/config/manifests/bases/awx-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/awx-operator.clusterserviceversion.yaml
@@ -1074,24 +1074,6 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:io.kubernetes:Secret
-      - description: HTTP proxy URL to configure on AWX containers
-        displayName: HTTP Proxy
-        path: http_proxy
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:advanced
-        - urn:alm:descriptor:com.tectonic.ui:text
-      - description: HTTPS proxy URL to configure on AWX containers
-        displayName: HTTPS Proxy
-        path: https_proxy
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:advanced
-        - urn:alm:descriptor:com.tectonic.ui:text
-      - description: Comma-separated list of hosts that bypass the proxy on AWX containers
-        displayName: No Proxy
-        path: no_proxy
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:advanced
-        - urn:alm:descriptor:com.tectonic.ui:text
       - displayName: Nodeport Port
         path: nodeport_port
         x-descriptors:

--- a/config/samples/awx_v1beta1_awx.yaml
+++ b/config/samples/awx_v1beta1_awx.yaml
@@ -16,7 +16,3 @@ spec:
     requests:
       cpu: 50m
       memory: 64M
-  # HTTP proxy settings (optional)
-  # http_proxy: "http://proxy.example.com:3128"
-  # https_proxy: "http://proxy.example.com:3128"
-  # no_proxy: "localhost,127.0.0.1,.cluster.local"

--- a/roles/installer/defaults/main.yml
+++ b/roles/installer/defaults/main.yml
@@ -460,9 +460,7 @@ ldap_password_secret: ''
 bundle_cacert_secret: ''
 
 # Proxy environment variables for AWX containers.
-# Defaults inherit from the operator pod environment (e.g. set by the OCP cluster
-# proxy object). Set these fields in the CR spec to override the inherited values
-# per instance.
+# Values are inherited from the operator pod environment.
 http_proxy: "{{ lookup('env', 'http_proxy') or lookup('env', 'HTTP_PROXY') or '' }}"
 https_proxy: "{{ lookup('env', 'https_proxy') or lookup('env', 'HTTPS_PROXY') or '' }}"
 no_proxy: "{{ lookup('env', 'no_proxy') or lookup('env', 'NO_PROXY') or '' }}"


### PR DESCRIPTION
##### SUMMARY

Removes `http_proxy`, `https_proxy`, and `no_proxy` from the CRD spec and CSV
specDescriptors. Proxy configuration is injected into the operator pod environment
and propagated to containers via the existing ConfigMap mechanism.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION

<!-- N/A -->