### PR TITLE
web: Fix supervisord liveness config filename

### DIFF
--- a/roles/installer/templates/deployments/web.yaml.j2
+++ b/roles/installer/templates/deployments/web.yaml.j2
@@ -185,7 +185,7 @@ spec:
                 - sh
                 - -c
                 - |
-                  (exit $(/usr/bin/supervisorctl -c /etc/supervisord_task.conf status | grep -vc RUNNING))
+                  (exit $(/usr/bin/supervisorctl -c /etc/supervisord_web.conf status | grep -vc RUNNING))
             initialDelaySeconds: {{ web_liveness_initial_delay }}
             periodSeconds: {{ web_liveness_period }}
             failureThreshold: {{ web_liveness_failure_threshold }}


### PR DESCRIPTION
##### SUMMARY
The liveness probe setup is using the task supervisord configuration filename rather then the web one.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change
