### PR TITLE
deprecate: mark postgres_keep_pvc_after_upgrade as (Deprecated) in CRD

### DIFF
--- a/config/crd/bases/awx.ansible.com_awxs.yaml
+++ b/config/crd/bases/awx.ansible.com_awxs.yaml
@@ -1795,7 +1795,7 @@ spec:
                 description: nodeSelector for the Postgres pods
                 type: string
               postgres_keep_pvc_after_upgrade:
-                description: Specify whether or not to keep the old PVC after PostgreSQL upgrades
+                description: "(Deprecated) Specify whether or not to keep the old PVC after PostgreSQL upgrades"
                 type: boolean
               postgres_tolerations:
                 description: node tolerations for the Postgres pods

--- a/config/manifests/bases/awx-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/awx-operator.clusterserviceversion.yaml
@@ -688,11 +688,6 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:hidden
-      - displayName: Should PostgreSQL data for managed databases be kept after upgrades?
-        path: postgres_keep_pvc_after_upgrade
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
-        - urn:alm:descriptor:com.tectonic.ui:hidden
       - displayName: Postgres Tolerations
         path: postgres_tolerations
         x-descriptors:

--- a/docs/upgrade/upgrading.md
+++ b/docs/upgrade/upgrading.md
@@ -20,16 +20,6 @@ In the event you need to recover the backup see the [restore role documentation]
 
 **Note**: Do not delete the namespace/project, as that will delete the backup and the backup's PVC as well.
 
-## PostgreSQL Upgrade Considerations
-
-If there is a PostgreSQL major version upgrade, after the data directory on the PVC is migrated to the new version, the old PVC is kept by default.
-This provides the ability to roll back if needed, but can take up extra storage space in your cluster unnecessarily. You can configure it to be deleted automatically after a successful upgrade by setting the following variable on the AWX spec.
-
-```yaml
-spec:
-  postgres_keep_pvc_after_upgrade: False
-```
-
 ## Caveats for upgrading to v0.14.0
 
 ### Cluster-scope to Namespace-scope considerations

--- a/roles/installer/defaults/main.yml
+++ b/roles/installer/defaults/main.yml
@@ -407,9 +407,6 @@ postgres_extra_volume_mounts: ''
 #   kubernetes.io/os: linux
 postgres_selector: ''
 
-# Specify whether or not to keep the old PVC after PostgreSQL upgrades
-postgres_keep_pvc_after_upgrade: True
-
 # Add node tolerations for the Postgres pods.
 # Specify as literal block. E.g.:
 # postgres_tolerations: |


### PR DESCRIPTION
## Summary

Formally deprecates `postgres_keep_pvc_after_upgrade` in the AWX operator CRD.
The underlying Ansible task was removed in a8acae4a but the CRD field was never
updated to reflect this.

- Mark field as `(Deprecated)` in CRD description
- Remove CSV specDescriptor entry
- Remove role default (`roles/installer/defaults/main.yml`)
- Remove upgrading.md usage example

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change