### PR TITLE
fix: add Ansible defaults for CRD-only variables to prevent undefined errors

### DIFF
--- a/roles/installer/defaults/main.yml
+++ b/roles/installer/defaults/main.yml
@@ -306,11 +306,25 @@ create_preload_data: true
 replicas: 1
 web_replicas: ''
 task_replicas: ''
+web_manage_replicas: true
+task_manage_replicas: true
 
 web_liveness_period: 0
+web_liveness_initial_delay: 5
+web_liveness_failure_threshold: 3
+web_liveness_timeout: 1
 web_readiness_period: 0
+web_readiness_initial_delay: 20
+web_readiness_failure_threshold: 3
+web_readiness_timeout: 1
 task_liveness_period: 0
+task_liveness_initial_delay: 5
+task_liveness_failure_threshold: 3
+task_liveness_timeout: 1
 task_readiness_period: 0
+task_readiness_initial_delay: 20
+task_readiness_failure_threshold: 3
+task_readiness_timeout: 1
 
 task_args:
   - /usr/bin/launch_awx_task.sh


### PR DESCRIPTION
## Summary

- Adds Ansible-level defaults for 14 variables that previously only had defaults on the CRD
- Prevents `'variable_name' is undefined` fatal errors when the CR loses CRD-level defaults

## ISSUE TYPE
Bug, Docs Fix or other nominal change

## Root Cause

The following variables are used in deployment templates without `| default()` fallbacks and have no entry in `roles/installer/defaults/main.yml`. They rely entirely on CRD-level `default:` values, which can be lost through CR manipulation, deletion/recreation, or OCP upgrade race conditions:

**Tier 1 — Always fatal (evaluated every reconciliation):**
- `web_manage_replicas` (default: `true`)
- `task_manage_replicas` (default: `true`)

**Tier 2 — Conditionally fatal (inside probe blocks, triggered when probe periods > 0):**
- `web_liveness_initial_delay` (default: `5`)
- `web_liveness_failure_threshold` (default: `3`)
- `web_liveness_timeout` (default: `1`)
- `web_readiness_initial_delay` (default: `20`)
- `web_readiness_failure_threshold` (default: `3`)
- `web_readiness_timeout` (default: `1`)
- `task_liveness_initial_delay` (default: `5`)
- `task_liveness_failure_threshold` (default: `3`)
- `task_liveness_timeout` (default: `1`)
- `task_readiness_initial_delay` (default: `20`)
- `task_readiness_failure_threshold` (default: `3`)
- `task_readiness_timeout` (default: `1`)

All default values match the existing CRD defaults.

## Test Plan

- [ ] Deploy AWX with default configuration — verify reconciliation succeeds
- [ ] Delete and recreate the AWX CR — verify no undefined variable errors
- [ ] Enable custom probe periods (set `web_liveness_period: 10`) — verify probes render correctly
- [ ] Verify molecule tests pass

Fixes: AAP-41488
Ref: AAP-77490