### PR TITLE
bump operator-sdk version to v1.42.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM quay.io/operator-framework/ansible-operator:v1.40.0
+FROM quay.io/operator-framework/ansible-operator:v1.42.2
 
 USER root
-RUN dnf update --security --bugfix -y --disableplugin=subscription-manager && \
-    dnf install -y --disableplugin=subscription-manager openssl
+RUN microdnf update -y && \
+    microdnf install -y openssl
 
 USER 1001
 

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ endif
 
 # Set the Operator SDK version to use. By default, what is installed on the system is used.
 # This is useful for CI or a project to utilize a specific version of the operator-sdk toolkit.
-OPERATOR_SDK_VERSION ?= v1.40.0
+OPERATOR_SDK_VERSION ?= v1.42.2
 CONTAINER_TOOL ?= podman
 
 # Image URL to use all building/pushing image targets


### PR DESCRIPTION
##### SUMMARY
Bump operator-sdk from v1.40.0 to v1.42.2. Updates `OPERATOR_SDK_VERSION` in Makefile and the base image in Dockerfile. Also updates Dockerfile to use `microdnf` in place of `dnf`, as the v1.42.2 base image does not include `dnf`.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION