### PR TITLE
ci: bump Python from 3.8 to 3.11

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,7 +23,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.8"
+          python-version: "3.11"
 
       - name: Install Dependencies
         run: |


### PR DESCRIPTION
## Summary

- Bump CI Python version from 3.8 to 3.11 in `.github/workflows/ci.yaml`
- Python 3.8 reached EOL in October 2024
- The latest `community.general` collection ships a `from_toml` filter plugin that imports `tomllib` (Python 3.11+) at module load time, breaking Ansible template initialization on Python 3.8

Fixes #2123

## ISSUE TYPE
* Bug, Docs Fix or other nominal change

## Test plan

- [ ] CI molecule tests pass with Python 3.11
- [ ] Verify no regressions in `--skip-tags=replicas` and `-t replicas` matrix jobs