### PR TITLE
docs: Fix documentation and configuration paths for project persistence

### DIFF
--- a/config/crd/bases/awx.ansible.com_awxs.yaml
+++ b/config/crd/bases/awx.ansible.com_awxs.yaml
@@ -1902,7 +1902,7 @@ spec:
                 description: Secret where can be found the trusted Certificate Authority Bundle
                 type: string
               projects_persistence:
-                description: Whether or not the /var/lib/projects directory will be persistent
+                description: Whether or not the /var/lib/awx/projects directory will be persistent
                 default: false
                 type: boolean
               projects_use_existing_claim:
@@ -1912,17 +1912,17 @@ spec:
                 - _Yes_
                 - _No_
               projects_existing_claim:
-                description: PersistentVolumeClaim to mount /var/lib/projects directory
+                description: PersistentVolumeClaim to mount /var/lib/awx/projects directory
                 type: string
               projects_storage_class:
-                description: Storage class for the /var/lib/projects PersistentVolumeClaim
+                description: Storage class for the /var/lib/awx/projects PersistentVolumeClaim
                 type: string
               projects_storage_size:
-                description: Size for the /var/lib/projects PersistentVolumeClaim
+                description: Size for the /var/lib/awx/projects PersistentVolumeClaim
                 default: 8Gi
                 type: string
               projects_storage_access_mode:
-                description: AccessMode for the /var/lib/projects PersistentVolumeClaim
+                description: AccessMode for the /var/lib/awx/projects PersistentVolumeClaim
                 default: ReadWriteMany
                 type: string
               csrf_cookie_secure:

--- a/config/manifests/bases/awx-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/awx-operator.clusterserviceversion.yaml
@@ -770,7 +770,7 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:hidden
-      - displayName: Enable persistence for /var/lib/projects directory?
+      - displayName: Enable persistence for /var/lib/awx/projects directory?
         path: projects_persistence
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced

--- a/docs/user-guide/advanced-configuration/persisting-projects-directory.md
+++ b/docs/user-guide/advanced-configuration/persisting-projects-directory.md
@@ -1,10 +1,10 @@
 # Persisting Projects Directory
 
-In cases which you want to persist the `/var/lib/projects` directory, there are few variables that are customizable for the `awx-operator`.
+In cases which you want to persist the `/var/lib/awx/projects` directory, there are few variables that are customizable for the `awx-operator`.
 
 | Name                         | Description                                                                                    | Default       |
 | ---------------------------- | ---------------------------------------------------------------------------------------------- | ------------- |
-| projects_persistence         | Whether or not the /var/lib/projects directory will be persistent                              | false         |
+| projects_persistence         | Whether or not the /var/lib/awx/projects directory will be persistent                              | false         |
 | projects_storage_class       | Define the PersistentVolume storage class                                                      | ''            |
 | projects_storage_size        | Define the PersistentVolume size                                                               | 8Gi           |
 | projects_storage_access_mode | Define the PersistentVolume access mode                                                        | ReadWriteMany |

--- a/roles/installer/defaults/main.yml
+++ b/roles/installer/defaults/main.yml
@@ -427,7 +427,7 @@ postgres_resource_requirements:
 postgres_priority_class: ''
 
 # Persistence to the AWX project data folder
-# Whether or not the /var/lib/projects directory will be persistent
+# Whether or not the /var/lib/awx/projects directory will be persistent
 projects_persistence: false
 #
 # Define an existing PersistentVolumeClaim to use


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Corrected the mount path for `projects_persistence` in the documentation. 

The docs currently mention `/var/lib/projects`, but the actual directory mounted in the AWX pods is `/var/lib/awx/projects`.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
-->
When deploying AWX with `projects_persistence: true` via the AWX Custom Resource like below:

```yaml
apiVersion: awx.ansible.com/v1beta1
kind: AWX
metadata:
  name: awx
spec:
  projects_persistence: true
  projects_storage_class: local-path
  projects_storage_access_mode: ReadWriteOnce
  projects_storage_size: 5Gi
```

The resulting volume mount in the actual AWX web/task pod is created at /var/lib/awx/projects, contrary to the documentation:

```bash
# web pod
k --kubeconfig kubeconfig.yaml get pod -n awx awx-web-b54cb7879-pxk5g -o jsonpath='{.spec.containers[*].volumeMounts[?(@.name=="awx-projects")]}'
{"mountPath":"/var/lib/awx/projects","name":"awx-projects"}

# task pod
k --kubeconfig kubeconfig.yaml get pod -n awx awx-task-68bc8979dc-fmfxw -o jsonpath='{.spec.containers[*].volumeMounts[?(@.name=="awx-projects")]}'
{"mountPath":"/var/lib/awx/projects","name":"awx-projects"} {"mountPath":"/var/lib/awx/projects","name":"awx-projects"}

```
