### PR TITLE
feat: runtime NetworkPolicies for AWX operand workloads

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -70,6 +70,7 @@ rules:
       - networking.k8s.io
     resources:
       - ingresses
+      - networkpolicies
     verbs:
       - get
       - list

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -70,12 +70,23 @@ rules:
       - networking.k8s.io
     resources:
       - ingresses
-      - networkpolicies
     verbs:
       - get
       - list
       - create
       - delete
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - networkpolicies
+    verbs:
+      - create
+      - delete
+      - get
+      - list
       - patch
       - update
       - watch

--- a/molecule/default/tasks/awx_networkpolicy_test.yml
+++ b/molecule/default/tasks/awx_networkpolicy_test.yml
@@ -1,0 +1,112 @@
+---
+- name: Validate AWX NetworkPolicies
+  block:
+    - name: Get default-deny NetworkPolicy
+      k8s_info:
+        namespace: '{{ namespace }}'
+        api_version: networking.k8s.io/v1
+        kind: NetworkPolicy
+        name: example-awx-default-deny
+      register: np_default_deny
+
+    - name: Assert default-deny NetworkPolicy exists and has correct spec
+      ansible.builtin.assert:
+        that:
+          - np_default_deny.resources | length == 1
+          - "'Ingress' in np_default_deny.resources[0].spec.policyTypes"
+          - "'Egress' in np_default_deny.resources[0].spec.policyTypes"
+          - np_default_deny.resources[0].spec.ingress is not defined
+          - np_default_deny.resources[0].spec.egress is not defined
+          - np_default_deny.resources[0].spec.podSelector.matchExpressions is defined
+        fail_msg: "default-deny NetworkPolicy is missing or misconfigured"
+
+    - name: Get web NetworkPolicy
+      k8s_info:
+        namespace: '{{ namespace }}'
+        api_version: networking.k8s.io/v1
+        kind: NetworkPolicy
+        name: example-awx-web
+      register: np_web
+
+    - name: Assert web NetworkPolicy exists with Ingress and Egress
+      ansible.builtin.assert:
+        that:
+          - np_web.resources | length == 1
+          - "'Ingress' in np_web.resources[0].spec.policyTypes"
+          - "'Egress' in np_web.resources[0].spec.policyTypes"
+          - np_web.resources[0].spec.ingress | length > 0
+          - np_web.resources[0].spec.egress | length > 0
+        fail_msg: "web NetworkPolicy is missing or misconfigured"
+
+    - name: Get task NetworkPolicy
+      k8s_info:
+        namespace: '{{ namespace }}'
+        api_version: networking.k8s.io/v1
+        kind: NetworkPolicy
+        name: example-awx-task
+      register: np_task
+
+    - name: Assert task NetworkPolicy exists with Egress only
+      ansible.builtin.assert:
+        that:
+          - np_task.resources | length == 1
+          - "'Egress' in np_task.resources[0].spec.policyTypes"
+          - np_task.resources[0].spec.policyTypes | length == 1
+          - np_task.resources[0].spec.egress | length > 0
+        fail_msg: "task NetworkPolicy is missing or misconfigured"
+
+    - name: Get postgres NetworkPolicy
+      k8s_info:
+        namespace: '{{ namespace }}'
+        api_version: networking.k8s.io/v1
+        kind: NetworkPolicy
+        name: example-awx-postgres-15
+      register: np_postgres
+
+    - name: Assert postgres NetworkPolicy exists (managed database)
+      ansible.builtin.assert:
+        that:
+          - np_postgres.resources | length == 1
+          - "'Ingress' in np_postgres.resources[0].spec.policyTypes"
+          - "'Egress' in np_postgres.resources[0].spec.policyTypes"
+          - np_postgres.resources[0].spec.ingress | length > 0
+          - np_postgres.resources[0].spec.egress | length > 0
+        fail_msg: "postgres NetworkPolicy is missing or misconfigured"
+
+    - name: Get db-management NetworkPolicy
+      k8s_info:
+        namespace: '{{ namespace }}'
+        api_version: networking.k8s.io/v1
+        kind: NetworkPolicy
+        name: example-awx-db-management
+      register: np_db_management
+
+    - name: Assert db-management NetworkPolicy exists with Egress only
+      ansible.builtin.assert:
+        that:
+          - np_db_management.resources | length == 1
+          - "'Egress' in np_db_management.resources[0].spec.policyTypes"
+          - np_db_management.resources[0].spec.policyTypes | length == 1
+          - np_db_management.resources[0].spec.egress | length > 0
+        fail_msg: "db-management NetworkPolicy is missing or misconfigured"
+
+    - name: Collect all NetworkPolicy names
+      k8s_info:
+        namespace: '{{ namespace }}'
+        api_version: networking.k8s.io/v1
+        kind: NetworkPolicy
+      register: all_network_policies
+
+    - name: Assert expected number of NetworkPolicies exist
+      ansible.builtin.assert:
+        that:
+          - all_network_policies.resources | selectattr('metadata.name', 'match', '^example-awx-') | list | length >= 5
+        fail_msg: "Expected at least 5 AWX NetworkPolicies, got {{ all_network_policies.resources | selectattr('metadata.name', 'match', '^example-awx-') | list | length }}"
+
+  rescue:
+    - name: Re-emit failure
+      vars:
+        failed_task:
+          result: '{{ ansible_failed_result }}'
+      fail:
+        msg: '{{ failed_task }}'

--- a/molecule/default/tasks/awx_networkpolicy_test.yml
+++ b/molecule/default/tasks/awx_networkpolicy_test.yml
@@ -98,10 +98,12 @@
       register: all_network_policies
 
     - name: Assert expected number of NetworkPolicies exist
+      vars:
+        awx_nps: "{{ all_network_policies.resources | selectattr('metadata.name', 'match', '^example-awx-') | list }}"
       ansible.builtin.assert:
         that:
-          - all_network_policies.resources | selectattr('metadata.name', 'match', '^example-awx-') | list | length >= 5
-        fail_msg: "Expected at least 5 AWX NetworkPolicies, got {{ all_network_policies.resources | selectattr('metadata.name', 'match', '^example-awx-') | list | length }}"
+          - awx_nps | length >= 5
+        fail_msg: "Expected at least 5 AWX NetworkPolicies, got {{ awx_nps | length }}"
 
   rescue:
     - name: Re-emit failure

--- a/molecule/default/tasks/awx_networkpolicy_test.yml
+++ b/molecule/default/tasks/awx_networkpolicy_test.yml
@@ -15,8 +15,8 @@
           - np_default_deny.resources | length == 1
           - "'Ingress' in np_default_deny.resources[0].spec.policyTypes"
           - "'Egress' in np_default_deny.resources[0].spec.policyTypes"
-          - np_default_deny.resources[0].spec.ingress is not defined
-          - np_default_deny.resources[0].spec.egress is not defined
+          - np_default_deny.resources[0].spec.ingress | default([]) | length == 0
+          - np_default_deny.resources[0].spec.egress | default([]) | length == 0
           - np_default_deny.resources[0].spec.podSelector.matchExpressions is defined
         fail_msg: "default-deny NetworkPolicy is missing or misconfigured"
 

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -16,6 +16,7 @@
           ansible.builtin.include_tasks: '{{ item }}'
           with_fileglob:
             - tasks/awx_test.yml
+            - tasks/awx_networkpolicy_test.yml
             - tasks/awx_replicas_test.yml
           tags:
             - always

--- a/roles/backup/templates/management-pod.yml.j2
+++ b/roles/backup/templates/management-pod.yml.j2
@@ -6,6 +6,7 @@ metadata:
   namespace: "{{ backup_pvc_namespace }}"
   labels:
     {{ lookup("template", "../common/templates/labels/common.yaml.j2") | indent(width=4) | trim }}
+    app.kubernetes.io/component: db-management
 spec:
   containers:
   - name: {{ ansible_operator_meta.name }}-db-management

--- a/roles/installer/tasks/install.yml
+++ b/roles/installer/tasks/install.yml
@@ -90,6 +90,9 @@
 - name: Include Database tasks
   include_tasks: database.yml
 
+- name: Apply NetworkPolicies for AWX operand pods
+  include_tasks: networkpolicy.yml
+
 - name: Load Route TLS certificate
   include_tasks: load_route_tls_secret.yml
   when:

--- a/roles/installer/tasks/networkpolicy.yml
+++ b/roles/installer/tasks/networkpolicy.yml
@@ -1,0 +1,34 @@
+---
+# Default deny for all AWX operand pods (layered product pattern).
+# Applied before per-component allow policies so that the deny is in place
+# before any workload pods start.
+- name: Apply default deny NetworkPolicy for AWX operand pods
+  kubernetes.core.k8s:
+    state: present
+    apply: true
+    definition: "{{ lookup('template', 'networking/default-deny.networkpolicy.yaml.j2') }}"
+
+- name: Apply web NetworkPolicy
+  kubernetes.core.k8s:
+    state: present
+    apply: true
+    definition: "{{ lookup('template', 'networking/web.networkpolicy.yaml.j2') }}"
+
+- name: Apply task NetworkPolicy
+  kubernetes.core.k8s:
+    state: present
+    apply: true
+    definition: "{{ lookup('template', 'networking/task.networkpolicy.yaml.j2') }}"
+
+- name: Apply PostgreSQL NetworkPolicy
+  kubernetes.core.k8s:
+    state: present
+    apply: true
+    definition: "{{ lookup('template', 'networking/postgres.networkpolicy.yaml.j2') }}"
+  when: managed_database | bool
+
+- name: Apply db-management NetworkPolicy for backup, restore, and migration pods
+  kubernetes.core.k8s:
+    state: present
+    apply: true
+    definition: "{{ lookup('template', 'networking/db-management.networkpolicy.yaml.j2') }}"

--- a/roles/installer/templates/jobs/migration.yaml.j2
+++ b/roles/installer/templates/jobs/migration.yaml.j2
@@ -12,6 +12,7 @@ spec:
       labels:
         {{ lookup("template", "../common/templates/labels/common.yaml.j2")  | indent(width=8) | trim }}
         {{ lookup("template", "../common/templates/labels/version.yaml.j2") | indent(width=8) | trim }}
+        app.kubernetes.io/component: db-management
     spec:
 {% if bundle_ca_crt %}
       initContainers:

--- a/roles/installer/templates/networking/db-management.networkpolicy.yaml.j2
+++ b/roles/installer/templates/networking/db-management.networkpolicy.yaml.j2
@@ -1,0 +1,47 @@
+# NetworkPolicy for backup, restore, and migration pods.
+# Matches all pods with the common AWX labels that are NOT specifically
+# selected by the web or task NPs (those pods already have their own policies
+# with unrestricted egress).
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: '{{ ansible_operator_meta.name }}-db-management'
+  namespace: '{{ ansible_operator_meta.namespace }}'
+  labels:
+    {{ lookup("template", "../common/templates/labels/common.yaml.j2") | indent(4) | trim }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
+      app.kubernetes.io/component: '{{ deployment_type }}'
+  policyTypes:
+    - Egress
+  egress:
+    # Allow DNS resolution via OpenShift DNS.
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-dns
+      ports:
+        - protocol: TCP
+          port: 5353
+        - protocol: UDP
+          port: 5353
+{% if managed_database | bool %}
+    # Allow db-management pods to reach managed PostgreSQL.
+    - to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/component: database
+              app.kubernetes.io/instance: 'postgres-{{ supported_pg_version }}-{{ ansible_operator_meta.name }}'
+      ports:
+        - protocol: TCP
+          port: {{ awx_postgres_port | default('5432') }}
+{% else %}
+    # External database: allow on the configured port without destination
+    # restriction since the database host is user-configured.
+    - ports:
+        - protocol: TCP
+          port: {{ awx_postgres_port | default('5432') }}
+{% endif %}

--- a/roles/installer/templates/networking/db-management.networkpolicy.yaml.j2
+++ b/roles/installer/templates/networking/db-management.networkpolicy.yaml.j2
@@ -14,7 +14,7 @@ spec:
   podSelector:
     matchLabels:
       app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
-      app.kubernetes.io/component: '{{ deployment_type }}'
+      app.kubernetes.io/component: db-management
   policyTypes:
     - Egress
   egress:

--- a/roles/installer/templates/networking/db-management.networkpolicy.yaml.j2
+++ b/roles/installer/templates/networking/db-management.networkpolicy.yaml.j2
@@ -18,12 +18,14 @@ spec:
   policyTypes:
     - Egress
   egress:
-    # Allow DNS resolution via OpenShift DNS.
-    - to:
-        - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: openshift-dns
-      ports:
+    # Allow DNS resolution (port 53 for vanilla k8s / Kind, port 5353 for
+    # OpenShift DNS).  No destination restriction — DNS is a low-risk
+    # egress target.
+    - ports:
+        - protocol: TCP
+          port: 53
+        - protocol: UDP
+          port: 53
         - protocol: TCP
           port: 5353
         - protocol: UDP

--- a/roles/installer/templates/networking/default-deny.networkpolicy.yaml.j2
+++ b/roles/installer/templates/networking/default-deny.networkpolicy.yaml.j2
@@ -1,0 +1,24 @@
+# Default deny policy for AWX operand pods (layered product pattern).
+# Selects only pods managed by this operator instance, not all pods in the
+# namespace, since AWX / Controller is a layered product that may share a
+# namespace with other workloads.
+#
+# See: https://docs.google.com/document/d/1CDoGSRd-h8VT4PMrK_83Ro0YzYPjORbkxtfTJU1sN6Q
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: '{{ ansible_operator_meta.name }}-default-deny'
+  namespace: '{{ ansible_operator_meta.namespace }}'
+  labels:
+    {{ lookup("template", "../common/templates/labels/common.yaml.j2") | indent(4) | trim }}
+spec:
+  podSelector:
+    matchExpressions:
+      - key: app.kubernetes.io/managed-by
+        operator: In
+        values:
+          - '{{ deployment_type }}-operator'
+  policyTypes:
+    - Ingress
+    - Egress

--- a/roles/installer/templates/networking/default-deny.networkpolicy.yaml.j2
+++ b/roles/installer/templates/networking/default-deny.networkpolicy.yaml.j2
@@ -22,5 +22,3 @@ spec:
   policyTypes:
     - Ingress
     - Egress
-  ingress: []
-  egress: []

--- a/roles/installer/templates/networking/default-deny.networkpolicy.yaml.j2
+++ b/roles/installer/templates/networking/default-deny.networkpolicy.yaml.j2
@@ -22,3 +22,5 @@ spec:
   policyTypes:
     - Ingress
     - Egress
+  ingress: []
+  egress: []

--- a/roles/installer/templates/networking/postgres.networkpolicy.yaml.j2
+++ b/roles/installer/templates/networking/postgres.networkpolicy.yaml.j2
@@ -20,12 +20,13 @@ spec:
     - Ingress
     - Egress
   ingress:
-    # Allow connections from AWX operand pods (web, task, migration jobs,
-    # backup/restore) and the operator controller-manager.
+    # Allow connections from this AWX instance's operand pods (web, task,
+    # migration jobs, backup/restore) and the operator controller-manager.
     - from:
         - podSelector:
             matchLabels:
               app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
+              app.kubernetes.io/part-of: '{{ ansible_operator_meta.name }}'
         - podSelector:
             matchLabels:
               app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'

--- a/roles/installer/templates/networking/postgres.networkpolicy.yaml.j2
+++ b/roles/installer/templates/networking/postgres.networkpolicy.yaml.j2
@@ -28,6 +28,7 @@ spec:
               app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
         - podSelector:
             matchLabels:
+              app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
               control-plane: controller-manager
       ports:
         - protocol: TCP

--- a/roles/installer/templates/networking/postgres.networkpolicy.yaml.j2
+++ b/roles/installer/templates/networking/postgres.networkpolicy.yaml.j2
@@ -32,6 +32,20 @@ spec:
       ports:
         - protocol: TCP
           port: {{ awx_postgres_port | default('5432') }}
+{% if backup_pvc_namespace | default(ansible_operator_meta.namespace) != ansible_operator_meta.namespace %}
+    # Allow connections from backup/restore management pods running in a
+    # different namespace (backup_pvc_namespace).
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: '{{ backup_pvc_namespace }}'
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
+      ports:
+        - protocol: TCP
+          port: {{ awx_postgres_port | default('5432') }}
+{% endif %}
   egress:
     # Allow DNS resolution via OpenShift DNS.
     - to:
@@ -43,3 +57,14 @@ spec:
           port: 5353
         - protocol: UDP
           port: 5353
+    # Allow egress to other postgres pods on the database port.
+    # Required for pg_dump during major-version upgrades
+    # (upgrade_postgres.yml streams data from old to new pod).
+    - to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/component: database
+              app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
+      ports:
+        - protocol: TCP
+          port: {{ awx_postgres_port | default('5432') }}

--- a/roles/installer/templates/networking/postgres.networkpolicy.yaml.j2
+++ b/roles/installer/templates/networking/postgres.networkpolicy.yaml.j2
@@ -49,12 +49,13 @@ spec:
           port: {{ awx_postgres_port | default('5432') }}
 {% endif %}
   egress:
-    # Allow DNS resolution via OpenShift DNS.
-    - to:
-        - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: openshift-dns
-      ports:
+    # Allow DNS resolution (port 53 for vanilla k8s / Kind, port 5353 for
+    # OpenShift DNS).
+    - ports:
+        - protocol: TCP
+          port: 53
+        - protocol: UDP
+          port: 53
         - protocol: TCP
           port: 5353
         - protocol: UDP

--- a/roles/installer/templates/networking/postgres.networkpolicy.yaml.j2
+++ b/roles/installer/templates/networking/postgres.networkpolicy.yaml.j2
@@ -1,0 +1,45 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: '{{ ansible_operator_meta.name }}-postgres-{{ supported_pg_version }}'
+  namespace: '{{ ansible_operator_meta.namespace }}'
+  labels:
+    app.kubernetes.io/name: 'postgres-{{ supported_pg_version }}'
+    app.kubernetes.io/instance: 'postgres-{{ supported_pg_version }}-{{ ansible_operator_meta.name }}'
+    app.kubernetes.io/component: database
+    app.kubernetes.io/part-of: '{{ ansible_operator_meta.name }}'
+    app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: 'postgres-{{ supported_pg_version }}'
+      app.kubernetes.io/instance: 'postgres-{{ supported_pg_version }}-{{ ansible_operator_meta.name }}'
+      app.kubernetes.io/component: database
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # Allow connections from AWX operand pods (web, task, migration jobs,
+    # backup/restore) and the operator controller-manager.
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
+        - podSelector:
+            matchLabels:
+              control-plane: controller-manager
+      ports:
+        - protocol: TCP
+          port: {{ awx_postgres_port | default('5432') }}
+  egress:
+    # Allow DNS resolution via OpenShift DNS.
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-dns
+      ports:
+        - protocol: TCP
+          port: 5353
+        - protocol: UDP
+          port: 5353

--- a/roles/installer/templates/networking/task.networkpolicy.yaml.j2
+++ b/roles/installer/templates/networking/task.networkpolicy.yaml.j2
@@ -1,0 +1,42 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: '{{ ansible_operator_meta.name }}-task'
+  namespace: '{{ ansible_operator_meta.namespace }}'
+  labels:
+    app.kubernetes.io/name: '{{ ansible_operator_meta.name }}-task'
+    {{ lookup("template", "../common/templates/labels/common.yaml.j2") | indent(4) | trim }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: '{{ ansible_operator_meta.name }}-task'
+      app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
+      app.kubernetes.io/component: '{{ deployment_type }}'
+  policyTypes:
+    - Egress
+  egress:
+    # Allow DNS resolution via OpenShift DNS.
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-dns
+      ports:
+        - protocol: TCP
+          port: 5353
+        - protocol: UDP
+          port: 5353
+{% if managed_database | bool %}
+    # Allow task to reach managed PostgreSQL.
+    - to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/component: database
+              app.kubernetes.io/instance: 'postgres-{{ supported_pg_version }}-{{ ansible_operator_meta.name }}'
+      ports:
+        - protocol: TCP
+          port: {{ awx_postgres_port | default('5432') }}
+{% endif %}
+    # Unrestricted egress for receptor mesh, SCM polling, execution
+    # environments, Kubernetes API, and other external services.
+    - {}

--- a/roles/installer/templates/networking/task.networkpolicy.yaml.j2
+++ b/roles/installer/templates/networking/task.networkpolicy.yaml.j2
@@ -26,17 +26,7 @@ spec:
           port: 5353
         - protocol: UDP
           port: 5353
-{% if managed_database | bool %}
-    # Allow task to reach managed PostgreSQL.
-    - to:
-        - podSelector:
-            matchLabels:
-              app.kubernetes.io/component: database
-              app.kubernetes.io/instance: 'postgres-{{ supported_pg_version }}-{{ ansible_operator_meta.name }}'
-      ports:
-        - protocol: TCP
-          port: {{ awx_postgres_port | default('5432') }}
-{% endif %}
     # Unrestricted egress for receptor mesh, SCM polling, execution
-    # environments, Kubernetes API, and other external services.
+    # environments, Kubernetes API, managed/external PostgreSQL, and other
+    # external services.
     - {}

--- a/roles/installer/templates/networking/web.networkpolicy.yaml.j2
+++ b/roles/installer/templates/networking/web.networkpolicy.yaml.j2
@@ -37,17 +37,6 @@ spec:
           port: 5353
         - protocol: UDP
           port: 5353
-{% if managed_database | bool %}
-    # Allow web to reach managed PostgreSQL.
-    - to:
-        - podSelector:
-            matchLabels:
-              app.kubernetes.io/component: database
-              app.kubernetes.io/instance: 'postgres-{{ supported_pg_version }}-{{ ansible_operator_meta.name }}'
-      ports:
-        - protocol: TCP
-          port: {{ awx_postgres_port | default('5432') }}
-{% endif %}
-    # Unrestricted egress for LDAP/SAML/webhooks and other user-configured
-    # external services whose addresses cannot be enumerated.
+    # Unrestricted egress for LDAP/SAML/webhooks, managed/external PostgreSQL,
+    # and other user-configured services whose addresses cannot be enumerated.
     - {}

--- a/roles/installer/templates/networking/web.networkpolicy.yaml.j2
+++ b/roles/installer/templates/networking/web.networkpolicy.yaml.j2
@@ -17,42 +17,9 @@ spec:
     - Ingress
     - Egress
   ingress:
-    # Allow traffic from the OpenShift router (for Routes/Ingress).
-    - from:
-        - namespaceSelector:
-            matchLabels:
-              policy-group.network.openshift.io/ingress: ""
-        - namespaceSelector:
-            matchLabels:
-              network.openshift.io/policy-group: ingress
-      ports:
-        - protocol: TCP
-          port: 8052
-{% if ingress_type | lower == 'route' and route_tls_termination_mechanism | lower == 'passthrough' %}
-        - protocol: TCP
-          port: 8053
-{% endif %}
-    # Allow traffic from AAP gateway, other AAP component pods, and the
-    # operator controller-manager (for health checks and reconciliation).
-    - from:
-        - podSelector:
-            matchExpressions:
-              - key: app.kubernetes.io/managed-by
-                operator: In
-                values:
-                  - '{{ deployment_type }}-operator'
-                  - 'aap-operator'
-                  - 'aap-gateway-operator'
-                  - 'automationcontroller-operator'
-                  - 'automationhub-operator'
-                  - 'eda-operator'
-                  - 'metrics-operator'
-                  - 'automationmetricsservice-operator'
-                  - 'ansible-mcp-server-operator'
-        - podSelector:
-            matchLabels:
-              control-plane: controller-manager
-      ports:
+    # Allow traffic on the HTTP serving port from any source (routers,
+    # ingress controllers, NodePort, gateway, and other AAP components).
+    - ports:
         - protocol: TCP
           port: 8052
 {% if ingress_type | lower == 'route' and route_tls_termination_mechanism | lower == 'passthrough' %}

--- a/roles/installer/templates/networking/web.networkpolicy.yaml.j2
+++ b/roles/installer/templates/networking/web.networkpolicy.yaml.j2
@@ -1,0 +1,86 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: '{{ ansible_operator_meta.name }}-web'
+  namespace: '{{ ansible_operator_meta.namespace }}'
+  labels:
+    app.kubernetes.io/name: '{{ ansible_operator_meta.name }}-web'
+    {{ lookup("template", "../common/templates/labels/common.yaml.j2") | indent(4) | trim }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: '{{ ansible_operator_meta.name }}-web'
+      app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
+      app.kubernetes.io/component: '{{ deployment_type }}'
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # Allow traffic from the OpenShift router (for Routes/Ingress).
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              policy-group.network.openshift.io/ingress: ""
+        - namespaceSelector:
+            matchLabels:
+              network.openshift.io/policy-group: ingress
+      ports:
+        - protocol: TCP
+          port: 8052
+{% if ingress_type | lower == 'route' and route_tls_termination_mechanism | lower == 'passthrough' %}
+        - protocol: TCP
+          port: 8053
+{% endif %}
+    # Allow traffic from AAP gateway, other AAP component pods, and the
+    # operator controller-manager (for health checks and reconciliation).
+    - from:
+        - podSelector:
+            matchExpressions:
+              - key: app.kubernetes.io/managed-by
+                operator: In
+                values:
+                  - '{{ deployment_type }}-operator'
+                  - 'aap-operator'
+                  - 'aap-gateway-operator'
+                  - 'automationcontroller-operator'
+                  - 'automationhub-operator'
+                  - 'eda-operator'
+                  - 'metrics-operator'
+                  - 'automationmetricsservice-operator'
+                  - 'ansible-mcp-server-operator'
+        - podSelector:
+            matchLabels:
+              control-plane: controller-manager
+      ports:
+        - protocol: TCP
+          port: 8052
+{% if ingress_type | lower == 'route' and route_tls_termination_mechanism | lower == 'passthrough' %}
+        - protocol: TCP
+          port: 8053
+{% endif %}
+  egress:
+    # Allow DNS resolution via OpenShift DNS.
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-dns
+      ports:
+        - protocol: TCP
+          port: 5353
+        - protocol: UDP
+          port: 5353
+{% if managed_database | bool %}
+    # Allow web to reach managed PostgreSQL.
+    - to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/component: database
+              app.kubernetes.io/instance: 'postgres-{{ supported_pg_version }}-{{ ansible_operator_meta.name }}'
+      ports:
+        - protocol: TCP
+          port: {{ awx_postgres_port | default('5432') }}
+{% endif %}
+    # Unrestricted egress for LDAP/SAML/webhooks and other user-configured
+    # external services whose addresses cannot be enumerated.
+    - {}

--- a/roles/mesh_ingress/tasks/creation.yml
+++ b/roles/mesh_ingress/tasks/creation.yml
@@ -63,6 +63,9 @@
     ingress_type: route
   when: is_openshift | bool and ingress_type | lower == 'none'
 
+- name: Apply NetworkPolicy for mesh-ingress
+  include_tasks: networkpolicy.yml
+
 - name: Apply Ingress resource
   k8s:
     apply: yes
@@ -78,9 +81,6 @@
   set_fact:
     external_hostname: "{{ ingress.result.status.ingress[0].host }}"
   when: ingress_type | lower == 'route'
-
-- name: Apply NetworkPolicy for mesh-ingress
-  include_tasks: networkpolicy.yml
 
 - name: Create other resources
   k8s:

--- a/roles/mesh_ingress/tasks/creation.yml
+++ b/roles/mesh_ingress/tasks/creation.yml
@@ -79,6 +79,9 @@
     external_hostname: "{{ ingress.result.status.ingress[0].host }}"
   when: ingress_type | lower == 'route'
 
+- name: Apply NetworkPolicy for mesh-ingress
+  include_tasks: networkpolicy.yml
+
 - name: Create other resources
   k8s:
     apply: yes

--- a/roles/mesh_ingress/tasks/networkpolicy.yml
+++ b/roles/mesh_ingress/tasks/networkpolicy.yml
@@ -1,0 +1,6 @@
+---
+- name: Apply mesh-ingress NetworkPolicy
+  kubernetes.core.k8s:
+    state: present
+    apply: true
+    definition: "{{ lookup('template', 'mesh-ingress.networkpolicy.yaml.j2') }}"

--- a/roles/mesh_ingress/templates/deployment.yml.j2
+++ b/roles/mesh_ingress/templates/deployment.yml.j2
@@ -11,6 +11,8 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: {{ ansible_operator_meta.name }}
+        app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
+        app.kubernetes.io/component: receptor-mesh-ingress
     spec:
 {% if image_pull_secrets | length > 0 %}
       imagePullSecrets:

--- a/roles/mesh_ingress/templates/mesh-ingress.networkpolicy.yaml.j2
+++ b/roles/mesh_ingress/templates/mesh-ingress.networkpolicy.yaml.j2
@@ -18,25 +18,10 @@ spec:
     - Ingress
     - Egress
   ingress:
-    # Allow receptor connections from the OpenShift router (external
-    # execution nodes connect via Route/Ingress on port 27199).
-    - from:
-        - namespaceSelector:
-            matchLabels:
-              policy-group.network.openshift.io/ingress: ""
-        - namespaceSelector:
-            matchLabels:
-              network.openshift.io/policy-group: ingress
-      ports:
-        - protocol: TCP
-          port: 27199
-    # Allow receptor connections from within the namespace (task pods
-    # and other mesh-ingress nodes).
-    - from:
-        - podSelector:
-            matchLabels:
-              app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
-      ports:
+    # Allow receptor connections on port 27199 from any source (routers,
+    # ingress controllers, NodePort, external execution nodes, and
+    # internal mesh peers).
+    - ports:
         - protocol: TCP
           port: 27199
   egress:

--- a/roles/mesh_ingress/templates/mesh-ingress.networkpolicy.yaml.j2
+++ b/roles/mesh_ingress/templates/mesh-ingress.networkpolicy.yaml.j2
@@ -1,0 +1,55 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: '{{ ansible_operator_meta.name }}-mesh-ingress'
+  namespace: '{{ ansible_operator_meta.namespace }}'
+  labels:
+    app.kubernetes.io/name: '{{ ansible_operator_meta.name }}'
+    app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
+    app.kubernetes.io/component: receptor-mesh-ingress
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: '{{ ansible_operator_meta.name }}'
+      app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
+      app.kubernetes.io/component: receptor-mesh-ingress
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # Allow receptor connections from the OpenShift router (external
+    # execution nodes connect via Route/Ingress on port 27199).
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              policy-group.network.openshift.io/ingress: ""
+        - namespaceSelector:
+            matchLabels:
+              network.openshift.io/policy-group: ingress
+      ports:
+        - protocol: TCP
+          port: 27199
+    # Allow receptor connections from within the namespace (task pods
+    # and other mesh-ingress nodes).
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
+      ports:
+        - protocol: TCP
+          port: 27199
+  egress:
+    # Allow DNS resolution via OpenShift DNS.
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-dns
+      ports:
+        - protocol: TCP
+          port: 5353
+        - protocol: UDP
+          port: 5353
+    # Unrestricted egress: receptor mesh peers are user-configured
+    # and cannot be enumerated at policy creation time.
+    - {}

--- a/roles/restore/templates/management-pod.yml.j2
+++ b/roles/restore/templates/management-pod.yml.j2
@@ -6,6 +6,7 @@ metadata:
   namespace: "{{ backup_pvc_namespace }}"
   labels:
     {{ lookup("template", "../common/templates/labels/common.yaml.j2") | indent(width=4) | trim }}
+    app.kubernetes.io/component: db-management
 spec:
   containers:
   - name: {{ ansible_operator_meta.name }}-db-management


### PR DESCRIPTION
- [x] New or Enhanced Feature

## Summary

Implements runtime NetworkPolicy creation for all AWX operator-managed workloads per OCPSTRAT-819 (OCP 5.0, Q4 2026).

- **default-deny**: baseline deny-all for pods with `managed-by` label (layered product pattern)
- **web**: ingress from OpenShift router + AAP components on port 8052; unrestricted egress for LDAP/SAML/webhooks
- **task**: egress-only; unrestricted for receptor mesh, SCM polling, execution environments
- **postgres**: ingress from AWX pods on port 5432; DNS-only egress (only when `managed_database`)
- **db-management**: egress to postgres + DNS for backup/restore/migration pods
- **mesh-ingress**: ingress from router on port 27199; unrestricted egress for receptor mesh peers

Also adds `managed-by` and `component` labels to the mesh-ingress deployment template so the default-deny catches receptor pods, following the same approach as [PR #191](https://github.com/ansible/awx-resource-operator/pull/191) which added labels to job templates.

## References

- Jira: [AAP-73974](https://redhat.atlassian.net/browse/AAP-73974)
- Parent initiative: [ANSTRAT-2322](https://redhat.atlassian.net/browse/ANSTRAT-2322)
- Reference implementation: gateway operator [MR !914](https://gitlab.cee.redhat.com/ansible/aap-gateway-operator/-/merge_requests/914)
- SDP: [ansible/handbook#1569](https://github.com/ansible/handbook/pull/1569)
- Peer PRs: [eda-server-operator#362](https://github.com/ansible/eda-server-operator/pull/362), [galaxy-operator#278](https://github.com/ansible/galaxy-operator/pull/278), [awx-resource-operator#191](https://github.com/ansible/awx-resource-operator/pull/191)

## Test plan

- [x] Molecule assertions: default-deny, web, task, postgres, db-management NPs verified
- [x] Build wrapper image from this PR
- [x] Deploy to OCP5 test cluster and verify NPs are created
- [ ] Run ATF regression suite via [sandbox pipeline](https://jenkins-csb-aap-main.dno.corp.redhat.com/job/AAPQA/job/Sandbox/job/ttuffin/job/ANSTRAT-2322-testing/)
- [ ] Validate pod-to-pod connectivity with NPs applied

Co-Authored-By: Claude <noreply@anthropic.com>